### PR TITLE
Added local DynamoDB table for Viewer Codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The API service will be available via http://localhost:9002/
 To run the unit tests
 ```bash
 docker-compose run viewer-app /app/vendor/bin/phpunit
+
+docker-compose run api-app /app/vendor/bin/phpunit
 ```
 
 ### Updating composer dependencies

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,6 @@ services:
       # Always required
       CONTEXT: 'viewer'
       KMS_SESSION_CMK_ALIAS: 'alias/viewer-sessions-cmk-alias'
-      DYNAMODB_TABLE_VIEWER_CODES: 'ViewerCodes'
 
       # Local only
       AWS_ENDPOINT_KMS: http://kms:8080
@@ -81,6 +80,8 @@ services:
     volumes:
       - ./service-api/app:/app
     environment:
+      DYNAMODB_TABLE_VIEWER_CODES: 'ViewerCodes'
+
       # Local only
       AWS_ACCESS_KEY_ID: '-'
       AWS_SECRET_ACCESS_KEY: '-'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       # Always required
       CONTEXT: 'viewer'
       KMS_SESSION_CMK_ALIAS: 'alias/viewer-sessions-cmk-alias'
+      DYNAMODB_TABLE_VIEWER_CODES: 'ViewerCodes'
 
       # Local only
       AWS_ENDPOINT_KMS: http://kms:8080

--- a/local-config/config.sh
+++ b/local-config/config.sh
@@ -9,5 +9,14 @@ if [ $? -ne 0 ]; then
     echo "DynamoDB failed to start"
 else
     echo "DynamoDB ready"
+
     # Setup tables
+
+    aws dynamodb create-table \
+    --attribute-definitions AttributeName=ViewerCode,AttributeType=S \
+    --table-name ViewerCodes \
+    --key-schema AttributeName=ViewerCode,KeyType=HASH \
+    --provisioned-throughput ReadCapacityUnits=10,WriteCapacityUnits=10 \
+    --region eu-west-1 \
+    --endpoint http://localstack:4569
 fi

--- a/terraform_environment/viewer_ecs.tf
+++ b/terraform_environment/viewer_ecs.tf
@@ -175,6 +175,10 @@ locals {
       "value": "${data.aws_kms_alias.sessions_viewer.name}"
     },
     {
+      "name": "DYNAMODB_TABLE_VIEWER_CODES",
+      "value": "${aws_dynamodb_table.viewer_codes_table.name}"
+    },
+    {
       "name": "CONTAINER_VERSION",
       "value": "${var.container_version}"
     }]

--- a/terraform_environment/viewer_ecs.tf
+++ b/terraform_environment/viewer_ecs.tf
@@ -175,10 +175,6 @@ locals {
       "value": "${data.aws_kms_alias.sessions_viewer.name}"
     },
     {
-      "name": "DYNAMODB_TABLE_VIEWER_CODES",
-      "value": "${aws_dynamodb_table.viewer_codes_table.name}"
-    },
-    {
       "name": "CONTAINER_VERSION",
       "value": "${var.container_version}"
     }]


### PR DESCRIPTION
Also added the relevant local variable, `DYNAMODB_TABLE_VIEWER_CODES`, for accessing it, both locally and in AWS.

Added missing API unit test line into the README