### PR TITLE
Uml 269 fix add an lpa with new api

### DIFF
--- a/service-api/app/src/App/src/Handler/ActorCodeConfirmHandler.php
+++ b/service-api/app/src/App/src/Handler/ActorCodeConfirmHandler.php
@@ -39,7 +39,7 @@ class ActorCodeConfirmHandler implements RequestHandlerInterface
 
         $user = $request->getAttribute('user-id');
 
-        if (!isset($data['actor-code']) || !isset($data['uid'])| !isset($data['dob'])) {
+        if (!isset($data['actor-code']) || !isset($data['uid']) || !isset($data['dob'])) {
             throw new BadRequestException("'actor-code', 'uid' and 'dob' are required fields");
         }
 

--- a/service-api/app/src/App/src/Handler/ActorCodeSummaryHandler.php
+++ b/service-api/app/src/App/src/Handler/ActorCodeSummaryHandler.php
@@ -37,7 +37,7 @@ class ActorCodeSummaryHandler implements RequestHandlerInterface
     {
         $data = $request->getParsedBody();
 
-        if (!isset($data['actor-code']) || !isset($data['uid'])| !isset($data['dob'])) {
+        if (!isset($data['actor-code']) || !isset($data['uid']) || !isset($data['dob'])) {
             throw new BadRequestException("'actor-code', 'uid' and 'dob' are required fields");
         }
 

--- a/service-front/app/src/Common/src/Service/Lpa/LpaService.php
+++ b/service-front/app/src/Common/src/Service/Lpa/LpaService.php
@@ -66,22 +66,24 @@ class LpaService
     }
 
     /**
-     * Search for an LPA using credentials
+     * Get an LPA using a users supplied one time passcode, LPA uid and the actors DoB
+     *
+     * Used when an actor adds an LPA to their UaLPA account
      *
      * @param string $passcode
      * @param string $referenceNumber
      * @param string $dob
      * @return ArrayObject|null
      */
-    public function search(string $passcode, string $referenceNumber, string $dob) : ?ArrayObject
+    public function getLpaByPasscode(string $passcode, string $referenceNumber, string $dob) : ?ArrayObject
     {
         $data = [
-            'code' => $passcode,
+            'actor-code' => $passcode,
             'uid'  => $referenceNumber,
             'dob'  => $dob,
         ];
 
-        $lpaData = $this->apiClient->httpGet('/v1/lpa-search', $data);
+        $lpaData = $this->apiClient->httpPost('/v1/actor-codes/summary', $data);
 
         if (is_array($lpaData)) {
             $lpaData = $this->parseLpaData($lpaData);

--- a/service-front/app/test/CommonTest/Service/Lpa/LpaServiceTest.php
+++ b/service-front/app/test/CommonTest/Service/Lpa/LpaServiceTest.php
@@ -104,7 +104,7 @@ class LpaServiceTest extends TestCase
 
         $service = new LpaService($this->apiClientProphecy->reveal());
 
-        $lpa = $service->search($passcode, $referenceNumber, $dob);
+        $lpa = $service->getLpaByPasscode($passcode, $referenceNumber, $dob);
 
         $this->assertInstanceOf(ArrayObject::class, $lpa);
         $this->assertEquals(123456789012, $lpa->id);


### PR DESCRIPTION
The new API layer broke the addition of LPAs to an account (well, the summary page at least, fully adding the LPAs has never worked)

This updates the controller and service layer to work with the new API return values and endpoints.