### PR TITLE
Uml 199 move to id for users

### DIFF
--- a/service-api/app/src/App/src/DataAccess/DynamoDb/ActorUsers.php
+++ b/service-api/app/src/App/src/DataAccess/DynamoDb/ActorUsers.php
@@ -212,7 +212,7 @@ class ActorUsers implements ActorUsersInterface
         $this->client->updateItem([
             'TableName' => $this->actorUsersTable,
             'Key' => [
-                'Email' => [
+                'Id' => [
                     'S' => $id,
                 ],
             ],

--- a/service-api/app/src/App/src/DataAccess/Repository/ActorUsersInterface.php
+++ b/service-api/app/src/App/src/DataAccess/Repository/ActorUsersInterface.php
@@ -19,14 +19,23 @@ interface ActorUsersInterface
     /**
      * Add an actor user
      *
+     * @param string $id
      * @param string $email
      * @param string $password
      * @param string $activationToken
      * @param int $activationTtl
      * @return array
-     * @throws CreationException
      */
-    public function add(string $email, string $password, string $activationToken, int $activationTtl) : array;
+    public function add(string $id, string $email, string $password, string $activationToken, int $activationTtl) : array;
+
+    /**
+     * Get an actor user from the database
+     *
+     * @param string $id
+     * @return array
+     * @throws NotFoundException
+     */
+    public function get(string $id) : array;
 
     /**
      * Get an actor user from the database
@@ -35,7 +44,7 @@ interface ActorUsersInterface
      * @return array
      * @throws NotFoundException
      */
-    public function get(string $email) : array;
+    public function getByEmail(string $email) : array;
 
     /**
      * Activate the user account in the database using the token value

--- a/service-api/app/src/App/src/DataAccess/Repository/ActorUsersInterface.php
+++ b/service-api/app/src/App/src/DataAccess/Repository/ActorUsersInterface.php
@@ -38,7 +38,7 @@ interface ActorUsersInterface
     public function get(string $id) : array;
 
     /**
-     * Get an actor user from the database
+     * Get an actor user from the database using their email
      *
      * @param string $email
      * @return array
@@ -75,10 +75,10 @@ interface ActorUsersInterface
     /**
      * Records a successful login against the actor user
      *
-     * @param string $email
+     * @param string $id
      * @param string $loginTime An ATOM format datetime string
      */
-    public function recordSuccessfulLogin(string $email, string $loginTime) : void;
+    public function recordSuccessfulLogin(string $id, string $loginTime) : void;
 
     /**
      * Records a reset token against an actor user account

--- a/service-api/app/src/App/src/Handler/UserHandler.php
+++ b/service-api/app/src/App/src/Handler/UserHandler.php
@@ -58,7 +58,7 @@ class UserHandler implements RequestHandlerInterface
             throw new BadRequestException('Email address must be provided');
         }
 
-        $data = $this->userService->get($params['email']);
+        $data = $this->userService->getByEmail($params['email']);
 
         return new JsonResponse($data);
     }

--- a/service-api/app/src/App/src/Service/User/UserService.php
+++ b/service-api/app/src/App/src/Service/User/UserService.php
@@ -104,7 +104,7 @@ class UserService
         }
 
         $this->usersRepository->recordSuccessfulLogin(
-            $email,
+            $user['Id'],
             (new DateTime('now'))->format(DateTimeInterface::ATOM)
         );
 

--- a/service-api/app/test/AppTest/Handler/UserHandlerTest.php
+++ b/service-api/app/test/AppTest/Handler/UserHandlerTest.php
@@ -27,7 +27,7 @@ class UserHandlerTest extends TestCase
         ];
 
         $userServiceProphecy = $this->prophesize(UserService::class);
-        $userServiceProphecy->get($email)
+        $userServiceProphecy->getByEmail($email)
             ->willReturn($expectedData);
 
         //  Set up the handler

--- a/service-api/app/test/AppTest/Service/User/UserServiceTest.php
+++ b/service-api/app/test/AppTest/Service/User/UserServiceTest.php
@@ -12,6 +12,7 @@ use App\Exception\UnauthorizedException;
 use App\Service\User\UserService;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Ramsey\Uuid\Uuid;
 
 /**
  * Class UserServiceTest
@@ -36,25 +37,35 @@ class UserServiceTest extends TestCase
     /** @test */
     public function can_add_a_new_user()
     {
-        $userData = [
-            'email' => 'a@b.com',
-            'password' => self::PASS,
-            'activation_token' => '4O09oMEd57ZzF-xgEv7XMiGRLD7D8I0G9VawMykYVZU=',
-            'ttl' => time() + 60
-        ];
+        $id = '12345678-1234-1234-1234-123456789012';
+        $email = 'a@b.com';
+        $password = 'password1';
 
         $repoProphecy = $this->prophesize(ActorUsersInterface::class);
 
-        $repoProphecy->exists($userData['email'])
-            ->willReturn(false);
-        $repoProphecy->add($userData['email'], $userData['password'], Argument::type('string'), Argument::type('int'))
-            ->willReturn(['Email' => $userData['email'], 'Password' => self::PASS_HASH]);
+        $repoProphecy->exists($email)->willReturn(false);
+        $repoProphecy
+            ->add(
+                Argument::that(function(string $data) {
+                    return Uuid::isValid($data);
+                }),
+                Argument::exact($email),
+                Argument::exact($password),
+                Argument::type('string'),
+                Argument::type('int')
+            )
+            ->willReturn(
+                [
+                    'Id' => $id,
+                    'Email' => $email
+                ]
+            );
 
         $us = new UserService($repoProphecy->reveal());
 
-        $return = $us->add($userData);
+        $return = $us->add(['email' => $email, 'password' => $password]);
 
-        $this->assertEquals(['Email' => $userData['email'], 'Password' => self::PASS_HASH], $return);
+        $this->assertEquals(['Id' => $id, 'Email' => $email], $return);
     }
 
     /** @test */
@@ -78,12 +89,12 @@ class UserServiceTest extends TestCase
     {
         $repoProphecy = $this->prophesize(ActorUsersInterface::class);
 
-        $repoProphecy->get('a@b.com')
+        $repoProphecy->getByEmail('a@b.com')
             ->willReturn(['Email' => 'a@b.com', 'Password' => self::PASS_HASH]);
 
         $us = new UserService($repoProphecy->reveal());
 
-        $return = $us->get('a@b.com');
+        $return = $us->getByEmail('a@b.com');
 
         $this->assertEquals(['Email' => 'a@b.com', 'Password' => self::PASS_HASH], $return);
     }
@@ -93,13 +104,13 @@ class UserServiceTest extends TestCase
     {
         $repoProphecy = $this->prophesize(ActorUsersInterface::class);
 
-        $repoProphecy->get('a@b.com')
+        $repoProphecy->getByEmail('a@b.com')
             ->willThrow(new NotFoundException());
 
         $us = new UserService($repoProphecy->reveal());
 
         $this->expectException(NotFoundException::class);
-        $return = $us->get('a@b.com');
+        $return = $us->getByEmail('a@b.com');
     }
 
     /** @test */
@@ -107,7 +118,7 @@ class UserServiceTest extends TestCase
     {
         $repoProphecy = $this->prophesize(ActorUsersInterface::class);
 
-        $repoProphecy->get('a@b.com')
+        $repoProphecy->getByEmail('a@b.com')
             ->willReturn(['Email' => 'a@b.com', 'Password' => self::PASS_HASH]);
         $repoProphecy->recordSuccessfulLogin('a@b.com', Argument::that(function($dateTime) {
             $this->assertIsString($dateTime);
@@ -130,7 +141,7 @@ class UserServiceTest extends TestCase
     {
         $repoProphecy = $this->prophesize(ActorUsersInterface::class);
 
-        $repoProphecy->get('a@b.com')
+        $repoProphecy->getByEmail('a@b.com')
             ->willReturn(['Email' => 'a@b.com', 'Password' => self::PASS_HASH]);
 
         $us = new UserService($repoProphecy->reveal());
@@ -144,7 +155,7 @@ class UserServiceTest extends TestCase
     {
         $repoProphecy = $this->prophesize(ActorUsersInterface::class);
 
-        $repoProphecy->get('baduser@b.com')
+        $repoProphecy->getByEmail('baduser@b.com')
             ->willThrow(new NotFoundException());
 
         $us = new UserService($repoProphecy->reveal());
@@ -158,7 +169,7 @@ class UserServiceTest extends TestCase
     {
         $repoProphecy = $this->prophesize(ActorUsersInterface::class);
 
-        $repoProphecy->get('a@b.com')
+        $repoProphecy->getByEmail('a@b.com')
             ->willReturn(['Email' => 'a@b.com', 'Password' => self::PASS_HASH, 'ActivationToken' => 'aToken']);
 
         $us = new UserService($repoProphecy->reveal());

--- a/service-api/app/test/AppTest/Service/User/UserServiceTest.php
+++ b/service-api/app/test/AppTest/Service/User/UserServiceTest.php
@@ -119,8 +119,8 @@ class UserServiceTest extends TestCase
         $repoProphecy = $this->prophesize(ActorUsersInterface::class);
 
         $repoProphecy->getByEmail('a@b.com')
-            ->willReturn(['Email' => 'a@b.com', 'Password' => self::PASS_HASH]);
-        $repoProphecy->recordSuccessfulLogin('a@b.com', Argument::that(function($dateTime) {
+            ->willReturn(['Id' => '1234-1234-1234', 'Email' => 'a@b.com', 'Password' => self::PASS_HASH]);
+        $repoProphecy->recordSuccessfulLogin('1234-1234-1234', Argument::that(function($dateTime) {
             $this->assertIsString($dateTime);
 
             $date = new \DateTime($dateTime);
@@ -133,7 +133,7 @@ class UserServiceTest extends TestCase
 
         $return = $us->authenticate('a@b.com', self::PASS);
 
-        $this->assertEquals(['Email' => 'a@b.com', 'Password' => self::PASS_HASH], $return);
+        $this->assertEquals(['Id' => '1234-1234-1234', 'Email' => 'a@b.com', 'Password' => self::PASS_HASH], $return);
     }
 
     /** @test */

--- a/service-api/docker/seeding/start.sh
+++ b/service-api/docker/seeding/start.sh
@@ -29,13 +29,15 @@ if ! [[ -z "${AWS_ENDPOINT_DYNAMODB}" ]]; then
     --endpoint $DYNAMODN_ENDPOINT
 
     aws dynamodb create-table \
-    --attribute-definitions AttributeName=Email,AttributeType=S AttributeName=ActivationToken,AttributeType=S \
+    --attribute-definitions AttributeName=Id,AttributeType=S AttributeName=Email,AttributeType=S AttributeName=ActivationToken,AttributeType=S \
     --table-name ActorUsers \
-    --key-schema AttributeName=Email,KeyType=HASH \
+    --key-schema AttributeName=Id,KeyType=HASH \
     --provisioned-throughput ReadCapacityUnits=10,WriteCapacityUnits=10 \
     --region eu-west-1 \
     --endpoint $DYNAMODN_ENDPOINT \
-    --global-secondary-indexes IndexName=ActivationTokenIndex,KeySchema=["{AttributeName=ActivationToken,KeyType=HASH}"],Projection="{ProjectionType=KEYS_ONLY}",ProvisionedThroughput="{ReadCapacityUnits=10,WriteCapacityUnits=10}"
+    --global-secondary-indexes \
+      IndexName=EmailIndex,KeySchema=["{AttributeName=Email,KeyType=HASH}"],Projection="{ProjectionType=ALL}",ProvisionedThroughput="{ReadCapacityUnits=10,WriteCapacityUnits=10}" \
+      IndexName=ActivationTokenIndex,KeySchema=["{AttributeName=ActivationToken,KeyType=HASH}"],Projection="{ProjectionType=KEYS_ONLY}",ProvisionedThroughput="{ReadCapacityUnits=10,WriteCapacityUnits=10}"
 
     aws dynamodb update-time-to-live \
     --table-name ActorUsers \

--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -40,7 +40,7 @@ resource "aws_dynamodb_table" "actor_users_table" {
   global_secondary_index {
     name            = "EmailIndex"
     hash_key        = "Email"
-    projection_type = "KEYS_ONLY"
+    projection_type = "ALL"
   }
   global_secondary_index {
     name            = "ActivationTokenIndex"

--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -22,7 +22,7 @@ resource "aws_dynamodb_table" "actor_codes_table" {
 resource "aws_dynamodb_table" "actor_users_table" {
   name         = "${local.environment}-ActorUsers"
   billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "Email"
+  hash_key     = "Id"
 
   attribute {
     name = "Id"

--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -25,6 +25,10 @@ resource "aws_dynamodb_table" "actor_users_table" {
   hash_key     = "Email"
 
   attribute {
+    name = "Id"
+    type= "S"
+  }
+  attribute {
     name = "Email"
     type = "S"
   }
@@ -33,6 +37,11 @@ resource "aws_dynamodb_table" "actor_users_table" {
     type = "S"
   }
 
+  global_secondary_index {
+    hash_key = "EmailIndex"
+    name = "Email"
+    projection_type = "KEYS_ONLY"
+  }
   global_secondary_index {
     name            = "ActivationTokenIndex"
     hash_key        = "ActivationToken"

--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -38,8 +38,8 @@ resource "aws_dynamodb_table" "actor_users_table" {
   }
 
   global_secondary_index {
-    hash_key = "EmailIndex"
-    name = "Email"
+    name            = "EmailIndex"
+    hash_key        = "Email"
     projection_type = "KEYS_ONLY"
   }
   global_secondary_index {


### PR DESCRIPTION
In order to get dashboards working we need to attach individual lpas to actor accounts. It is not possible to do this with email so this PR ensures unique id's for users instead. We'll be able to use them for assigning LPA's to accounts.

