### PR TITLE
Uml 214 send appropriate user id to api

### DIFF
--- a/service-api/app/config/pipeline.php
+++ b/service-api/app/config/pipeline.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Middleware;
+use App\Middleware\UserIdentificationMiddleware;
 use Psr\Container\ContainerInterface;
 use Zend\Expressive\Application;
 use Zend\Expressive\Handler\NotFoundHandler;
@@ -62,8 +63,6 @@ return function (Application $app, MiddlewareFactory $factory, ContainerInterfac
     //  Handle any API problem exception types
     $app->pipe(Middleware\ProblemDetailsMiddleware::class);
 
-    $app->pipe(Middleware\UserIdentificationMiddleware::class);
-
     // Seed the UrlHelper with the routing results:
     $app->pipe(UrlHelperMiddleware::class);
 
@@ -73,6 +72,8 @@ return function (Application $app, MiddlewareFactory $factory, ContainerInterfac
     // - route-based authentication
     // - route-based validation
     // - etc.
+    $app->pipe('/v1/actor-codes', UserIdentificationMiddleware::class);
+    $app->pipe('/v1/lpas', UserIdentificationMiddleware::class);
 
     // Register the dispatch middleware in the middleware pipeline
     $app->pipe(DispatchMiddleware::class);

--- a/service-api/app/config/routes.php
+++ b/service-api/app/config/routes.php
@@ -37,11 +37,9 @@ return function (Application $app, MiddlewareFactory $factory, ContainerInterfac
     $app->get('/v1/lpa-search', App\Handler\LpaSearchHandler::class, 'lpa.search');
     $app->get('/v1/lpa-by-code/{shareCode}', App\Handler\LpaHandler::class, 'lpa.by.share-code');
 
-
     $app->get('/v1/lpas', App\Handler\LpasCollectionHandler::class, 'lpa.collection');
     $app->get('/v1/lpas/{user-lpa-actor-token:[0-9a-f\-]+}', App\Handler\LpasResourceHandler::class, 'lpa.resource');
     $app->post('/v1/lpas/{user-lpa-actor-token:[0-9a-f\-]+}/codes', App\Handler\LpasResourceCodesCollectionHandler::class, 'lpa.resource.code');
-
 
     $app->post('/v1/actor-codes/summary', App\Handler\ActorCodeSummaryHandler::class, 'lpa.actor-code.summary');
     $app->post('/v1/actor-codes/confirm', App\Handler\ActorCodeConfirmHandler::class, 'lpa.actor-code.confirm');

--- a/service-api/app/src/App/src/Handler/ActorCodeConfirmHandler.php
+++ b/service-api/app/src/App/src/Handler/ActorCodeConfirmHandler.php
@@ -37,13 +37,13 @@ class ActorCodeConfirmHandler implements RequestHandlerInterface
     {
         $data = $request->getParsedBody();
 
-        $user = $request->getAttribute('user-id');
+        $actorId = $request->getAttribute('actor-id');
 
         if (!isset($data['actor-code']) || !isset($data['uid']) || !isset($data['dob'])) {
             throw new BadRequestException("'actor-code', 'uid' and 'dob' are required fields");
         }
 
-        $response = $this->actorCodeService->confirmDetails($data['actor-code'], $data['uid'], $data['dob'], $user);
+        $response = $this->actorCodeService->confirmDetails($data['actor-code'], $data['uid'], $data['dob'], $actorId);
 
         // We deliberately don't return details of why the (validated) code was not found.
         if (!is_string($response)){

--- a/service-api/app/src/App/src/Middleware/UserIdentificationMiddleware.php
+++ b/service-api/app/src/App/src/Middleware/UserIdentificationMiddleware.php
@@ -1,20 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Middleware;
 
-use App\Exception\AbstractApiException;
+use App\Exception\UnauthorizedException;
 use Psr\Http\Server\RequestHandlerInterface as DelegateInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Zend\Diactoros\Response\JsonResponse;
-
 
 class UserIdentificationMiddleware implements MiddlewareInterface
 {
-
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate) : ResponseInterface
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate): ResponseInterface
     {
-        return $delegate->handle($request->withAttribute('user-id', 'user-1'));
+        $userId = $request->getHeader('User-Token');
+
+        if (isset($userId[0])) {
+            return $delegate->handle($request->withAttribute('actor-id', $userId[0]));
+        }
+
+        throw new UnauthorizedException('User-Token not specified or invalid');
     }
 }

--- a/service-api/app/src/App/src/Service/ActorCodes/ActorCodeService.php
+++ b/service-api/app/src/App/src/Service/ActorCodes/ActorCodeService.php
@@ -114,11 +114,11 @@ class ActorCodeService
      * @param string $code
      * @param string $uid
      * @param string $dob
-     * @param string $userId
+     * @param string $actorId
      * @return array|null
      * @throws \Exception
      */
-    public function confirmDetails(string $code, string $uid, string $dob, string $userId) : ?string {
+    public function confirmDetails(string $code, string $uid, string $dob, string $actorId) : ?string {
 
         $details = $this->validateDetails($code, $uid, $dob);
 
@@ -139,7 +139,7 @@ class ActorCodeService
             try {
                 $this->userLpaActorMapRepository->create(
                     $id,
-                    $userId,
+                    $actorId,
                     $details['lpa']['uId'],
                     $details['actor']['details']['id']
                 );

--- a/service-front/app/src/Actor/src/Handler/CheckLpaHandler.php
+++ b/service-front/app/src/Actor/src/Handler/CheckLpaHandler.php
@@ -68,18 +68,21 @@ class CheckLpaHandler extends AbstractHandler implements CsrfGuardAware, UserAwa
 
         $form = new LpaConfirm($this->getCsrfGuard($request));
 
+        $user = $this->getUser($request);
+        $identity = (!is_null($user)) ? $user->getIdentity() : null;
+
         $passcode = $session->get('passcode');
         $referenceNumber = $session->get('reference_number');
         $dob = $session->get('dob');
 
-        if (isset($passcode) && isset($referenceNumber) && isset($dob)) {
+        if (isset($identity) && isset($passcode) && isset($referenceNumber) && isset($dob)) {
             try {
                 if ($request->getMethod() === 'POST') {
                     $form->setData($request->getParsedBody());
 
                     if ($form->isValid()) {
                         $actorCode = $this->lpaService->confirmLpaAddition(
-                            $this->getUser($request)->getIdentity(),
+                            $identity,
                             $passcode,
                             $referenceNumber,
                             $dob
@@ -94,7 +97,7 @@ class CheckLpaHandler extends AbstractHandler implements CsrfGuardAware, UserAwa
 
                 // is a GET or failed POST
                 $lpa = $this->lpaService->getLpaByPasscode(
-                    $this->getUser($request)->getIdentity(),
+                    $identity,
                     $passcode,
                     $referenceNumber,
                     $dob

--- a/service-front/app/src/Actor/src/Handler/CheckLpaHandler.php
+++ b/service-front/app/src/Actor/src/Handler/CheckLpaHandler.php
@@ -78,7 +78,12 @@ class CheckLpaHandler extends AbstractHandler implements CsrfGuardAware, UserAwa
                     $form->setData($request->getParsedBody());
 
                     if ($form->isValid()) {
-                        $actorCode = $this->lpaService->confirmLpaAddition($passcode, $referenceNumber, $dob);
+                        $actorCode = $this->lpaService->confirmLpaAddition(
+                            $this->getUser($request)->getIdentity(),
+                            $passcode,
+                            $referenceNumber,
+                            $dob
+                        );
 
                         if (!is_null($actorCode)) {
                             // TODO UML-209 this will need to go to the dashboard
@@ -88,7 +93,12 @@ class CheckLpaHandler extends AbstractHandler implements CsrfGuardAware, UserAwa
                 }
 
                 // is a GET or failed POST
-                $lpa = $this->lpaService->getLpaByPasscode($passcode, $referenceNumber, $dob);
+                $lpa = $this->lpaService->getLpaByPasscode(
+                    $this->getUser($request)->getIdentity(),
+                    $passcode,
+                    $referenceNumber,
+                    $dob
+                );
 
                 if (!is_null($lpa)) {
                     list($user, $userRole) = $this->resolveLpaData($lpa, $dob);

--- a/service-front/app/src/Common/src/Entity/User.php
+++ b/service-front/app/src/Common/src/Entity/User.php
@@ -21,6 +21,9 @@ class User implements UserInterface
     /** @var string */
     protected $identity;
 
+    /** @var string */
+    protected $email;
+
     /** @var DateTime */
     protected $lastLogin;
 
@@ -28,6 +31,8 @@ class User implements UserInterface
     {
         $this->identity = $identity;
         $this->lastLogin = null;
+
+        $this->email = $details['Email'] ?? null;
 
         if (array_key_exists('LastLogin', $details)) {
             $this->setLastLogin($details['LastLogin']);
@@ -77,6 +82,7 @@ class User implements UserInterface
     public function getDetails(): array
     {
         return [
+            'Email'     => $this->email,
             'LastLogin' => $this->lastLogin
         ];
     }

--- a/service-front/app/src/Common/src/Service/ApiClient/Client.php
+++ b/service-front/app/src/Common/src/Service/ApiClient/Client.php
@@ -40,10 +40,20 @@ class Client
      * @param string $apiBaseUri
      * @param string|null $token
      */
-    public function __construct(ClientInterface $httpClient, string $apiBaseUri, ?string $token)
+    public function __construct(ClientInterface $httpClient, string $apiBaseUri)
     {
         $this->httpClient = $httpClient;
         $this->apiBaseUri = $apiBaseUri;
+    }
+
+    /**
+     * Sets up the client object to attach authentication headers
+     * to outgoing requests.
+     *
+     * @param string $token
+     */
+    public function setUserTokenHeader(string $token) : void
+    {
         $this->token = $token;
     }
 
@@ -217,7 +227,7 @@ class Client
 
         //  If the logged in user has an auth token already then set that in the header
         if (isset($this->token)) {
-            $headerLines['token'] = $this->token;
+            $headerLines['User-Token'] = $this->token;
         }
 
         return $headerLines;

--- a/service-front/app/src/Common/src/Service/ApiClient/ClientFactory.php
+++ b/service-front/app/src/Common/src/Service/ApiClient/ClientFactory.php
@@ -30,7 +30,6 @@ class ClientFactory
         return new Client(
             $container->get(ClientInterface::class),
             $config['api']['uri'],
-            null
         );
     }
 }

--- a/service-front/app/src/Common/src/Service/Lpa/LpaService.php
+++ b/service-front/app/src/Common/src/Service/Lpa/LpaService.php
@@ -84,7 +84,7 @@ class LpaService
      * @param string $dob
      * @return Lpa|null
      */
-    public function getLpaByPasscode(string $passcode, string $referenceNumber, string $dob) : ?Lpa
+    public function getLpaByPasscode(string $userToken, string $passcode, string $referenceNumber, string $dob) : ?Lpa
     {
         $data = [
             'actor-code' => $passcode,
@@ -92,6 +92,9 @@ class LpaService
             'dob'        => $dob,
         ];
 
+        $this->apiClient->setUserTokenHeader($userToken);
+
+        // TODO $lpaData also contains an CaseActor 'actor' that we should probably return
         $lpaData = $this->apiClient->httpPost('/v1/actor-codes/summary', $data);
 
         return isset($lpaData['lpa']) ? $this->lpaFactory->createLpaFromData($lpaData['lpa']) : null;
@@ -105,13 +108,15 @@ class LpaService
      * @param string $dob
      * @return string|null The unique actor token that links an actor record and lpa together
      */
-    public function confirmLpaAddition(string $passcode, string $referenceNumber, string $dob) : ?string
+    public function confirmLpaAddition(string $userToken, string $passcode, string $referenceNumber, string $dob) : ?string
     {
         $data = [
             'actor-code' => $passcode,
             'uid'        => $referenceNumber,
             'dob'        => $dob,
         ];
+
+        $this->apiClient->setUserTokenHeader($userToken);
 
         $lpaData = $this->apiClient->httpPost('/v1/actor-codes/confirm', $data);
 

--- a/service-front/app/src/Common/src/Service/User/UserService.php
+++ b/service-front/app/src/Common/src/Service/User/UserService.php
@@ -87,9 +87,10 @@ class UserService implements UserRepositoryInterface
 
             if (!is_null($userData)) {
                 return ($this->userModelFactory)(
-                    $userData['Email'],
+                    $userData['Id'],
                     [],
                     [
+                        'Email'     => $userData['Email'],
                         'LastLogin' => $userData['LastLogin']
                     ]
                 );

--- a/service-front/app/test/CommonTest/Entity/UserTest.php
+++ b/service-front/app/test/CommonTest/Entity/UserTest.php
@@ -23,10 +23,13 @@ class UserTest extends TestCase
     public function it_returns_valid_user_details()
     {
         $date = new DateTime();
-        $user = new User('test', [], ['LastLogin' => $date->format(DateTimeInterface::ATOM)]);
+        $user = new User('test', [], [
+            'Email'     => 'a@b.com',
+            'LastLogin' => $date->format(DateTimeInterface::ATOM)
+        ]);
 
         $this->assertIsArray($user->getDetails());
-        $this->assertCount(1, $user->getDetails());
+        $this->assertCount(2, $user->getDetails());
         $this->assertArrayHasKey('LastLogin', $user->getDetails());
     }
 

--- a/service-front/app/test/CommonTest/Service/ApiClient/ClientTest.php
+++ b/service-front/app/test/CommonTest/Service/ApiClient/ClientTest.php
@@ -336,13 +336,14 @@ class ClientTest extends TestCase
             $this->assertInstanceOf(RequestInterface::class, $request);
 
             $headers = $request->getHeaders();
-            $this->assertArrayHasKey('token', $headers);
-            $this->assertEquals('test_token', $headers['token'][0]);
+            $this->assertArrayHasKey('User-Token', $headers);
+            $this->assertEquals('test_token', $headers['User-Token'][0]);
             return true;
         }))
             ->willReturn($this->setupResponse('[]', StatusCodeInterface::STATUS_OK)->reveal());
 
-        $client = new Client($this->apiClient->reveal(), 'https://localhost', 'test_token');
+        $client = new Client($this->apiClient->reveal(), 'https://localhost');
+        $client->setUserTokenHeader('test_token');
 
         $data = $client->httpGet('/simple_get');
         $this->assertIsArray($data);

--- a/service-front/app/test/CommonTest/Service/Lpa/LpaServiceTest.php
+++ b/service-front/app/test/CommonTest/Service/Lpa/LpaServiceTest.php
@@ -91,6 +91,7 @@ class LpaServiceTest extends TestCase
     /** @test */
     public function it_finds_an_lpa_by_passcode()
     {
+        $token = '01234567-01234-01234-01234-012345678901';
         $passcode = '123456789012';
         $referenceNumber = '123456789012';
         $dob = '1980-01-01';
@@ -119,12 +120,13 @@ class LpaServiceTest extends TestCase
             ->willReturn([
                 'lpa' => $lpaData
             ]);
+        $this->apiClientProphecy->setUserTokenHeader($token)->shouldBeCalled();
 
         $this->lpaFactoryProphecy->createLpaFromData($lpaData)->willReturn($lpa);
 
         $service = new LpaService($this->apiClientProphecy->reveal(), $this->lpaFactoryProphecy->reveal());
 
-        $lpa = $service->getLpaByPasscode($passcode, $referenceNumber, $dob);
+        $lpa = $service->getLpaByPasscode($token, $passcode, $referenceNumber, $dob);
 
         $this->assertInstanceOf(Lpa::class, $lpa);
         $this->assertEquals(123456789012, $lpa->getUId());
@@ -135,6 +137,7 @@ class LpaServiceTest extends TestCase
     /** @test */
     public function an_invalid_find_by_passcode_response_returns_null()
     {
+        $token = '01234567-01234-01234-01234-012345678901';
         $passcode = '123456789012';
         $referenceNumber = '123456789012';
         $dob = '1980-01-01';
@@ -147,10 +150,11 @@ class LpaServiceTest extends TestCase
 
         $this->apiClientProphecy->httpPost('/v1/actor-codes/summary', $params)
             ->willReturn([ 'bad-response' => 'bad']);
+        $this->apiClientProphecy->setUserTokenHeader($token)->shouldBeCalled();
 
         $service = new LpaService($this->apiClientProphecy->reveal(), $this->lpaFactoryProphecy->reveal());
 
-        $lpa = $service->getLpaByPasscode($passcode, $referenceNumber, $dob);
+        $lpa = $service->getLpaByPasscode($token, $passcode, $referenceNumber, $dob);
 
         $this->assertNull($lpa);
     }
@@ -158,6 +162,7 @@ class LpaServiceTest extends TestCase
     /** @test */
     public function it_confirms_an_lpa_by_passcode()
     {
+        $token = '01234567-01234-01234-01234-012345678901';
         $passcode = '123456789012';
         $referenceNumber = '123456789012';
         $dob = '1980-01-01';
@@ -172,10 +177,11 @@ class LpaServiceTest extends TestCase
             ->willReturn([
                 'user-lpa-actor-token' => 'actor-lpa-code'
             ]);
+        $this->apiClientProphecy->setUserTokenHeader($token)->shouldBeCalled();
 
         $service = new LpaService($this->apiClientProphecy->reveal(), $this->lpaFactoryProphecy->reveal());
 
-        $lpaCode = $service->confirmLpaAddition($passcode, $referenceNumber, $dob);
+        $lpaCode = $service->confirmLpaAddition($token, $passcode, $referenceNumber, $dob);
 
         $this->assertEquals('actor-lpa-code', $lpaCode);
     }
@@ -183,6 +189,7 @@ class LpaServiceTest extends TestCase
     /** @test */
     public function an_invalid_confirmation_of_lpa_by_passcode_returns_null()
     {
+        $token = '01234567-01234-01234-01234-012345678901';
         $passcode = '123456789012';
         $referenceNumber = '123456789012';
         $dob = '1980-01-01';
@@ -197,10 +204,11 @@ class LpaServiceTest extends TestCase
             ->willReturn([
                 'bad_response' => 'bad'
             ]);
+        $this->apiClientProphecy->setUserTokenHeader($token)->shouldBeCalled();
 
         $service = new LpaService($this->apiClientProphecy->reveal(), $this->lpaFactoryProphecy->reveal());
 
-        $lpaCode = $service->confirmLpaAddition($passcode, $referenceNumber, $dob);
+        $lpaCode = $service->confirmLpaAddition($token, $passcode, $referenceNumber, $dob);
 
         $this->assertNull($lpaCode);
     }

--- a/service-front/app/test/CommonTest/Service/User/UserServiceTest.php
+++ b/service-front/app/test/CommonTest/Service/User/UserServiceTest.php
@@ -104,14 +104,16 @@ class UserServiceTest extends TestCase
                 'password' => 'test'
             ])
             ->willReturn([
-                'Email'        => 'test@example.com',
+                'Id'        => '01234567-0123-0123-0123-012345678901',
+                'Email'     => 'test@example.com',
                 'LastLogin' => '2019-07-10T09:00:00'
             ]);
 
         $userFactoryCallable = function($identity, $roles, $details) {
-            $this->assertEquals('test@example.com', $identity);
+            $this->assertEquals('01234567-0123-0123-0123-012345678901', $identity);
             $this->assertIsArray($roles);
             $this->assertIsArray($details);
+            $this->assertArrayHasKey('Email', $details);
             $this->assertArrayHasKey('LastLogin', $details);
 
             return new User($identity, $roles, $details);
@@ -122,9 +124,9 @@ class UserServiceTest extends TestCase
         $return = $service->authenticate('test@example.com', 'test');
 
         $this->assertInstanceOf(User::class, $return);
-        $this->assertEquals('test@example.com', $return->getIdentity());
+        $this->assertEquals('01234567-0123-0123-0123-012345678901', $return->getIdentity());
         $this->assertEquals(new DateTime('2019-07-10T09:00:00'), $return->getDetail('lastLogin'));
-
+        $this->assertEquals('test@example.com', $return->getDetail('email'));
     }
 
     /** @test */

--- a/service-front/app/test/CommonTest/Service/User/UserServiceTest.php
+++ b/service-front/app/test/CommonTest/Service/User/UserServiceTest.php
@@ -164,8 +164,9 @@ class UserServiceTest extends TestCase
                 'password' => 'test'
             ])
             ->willReturn([
-                'Email'        => 'test@example.com',
-                'LastLogin' => 'baddatetime'
+                'Id'        => '01234567-0123-0123-0123-012345678901',
+                'Email'     => 'test@example.com',
+                'LastLogin' => '2019-07-10T09:00:00'
             ]);
 
         $userFactoryCallable = function($identity, $roles, $details) {
@@ -175,7 +176,7 @@ class UserServiceTest extends TestCase
 
         $service = new UserService($apiClientProphecy->reveal(), $userFactoryCallable);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $return = $service->authenticate('test@example.com', 'test');
     }
 


### PR DESCRIPTION
Ensure that we're passing through appropriate user context when attempting some actions that require it. 