### PR TITLE
Uml 325 css fonts pdf

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       context: .
       dockerfile: service-front/web/Dockerfile
     entrypoint: >
-      sh -c "npm i && npm run watch"
+      sh -c "npm i && npm run build:pdf && npm run watch"
     volumes:
       - ./service-front/web:/web
       - webpack_dist:/dist

--- a/service-front/docker/web/Dockerfile
+++ b/service-front/docker/web/Dockerfile
@@ -6,6 +6,7 @@ RUN npm install
 RUN npm rebuild node-sass
 
 RUN npm run build
+RUN npm run build:pdf_production
 
 FROM nginx:stable-alpine
 

--- a/service-front/web/babel.config.js
+++ b/service-front/web/babel.config.js
@@ -1,12 +1,12 @@
 module.exports = {
   presets: [
     [
-      "@babel/preset-env",
+      '@babel/preset-env',
       {
         targets: {
-          node: "current"
-        }
-      }
-    ]
-  ]
+          node: 'current',
+        },
+      },
+    ],
+  ],
 };

--- a/service-front/web/package-lock.json
+++ b/service-front/web/package-lock.json
@@ -1752,6 +1752,39 @@
         }
       }
     },
+    "base64-inline-loader": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/base64-inline-loader/-/base64-inline-loader-1.1.1.tgz",
+      "integrity": "sha512-v/bHvXQ8sW28t9ZwBsFGgyqZw2bpT49/dtPTtlmixoSM/s9wnOngOKFVQLRH8BfMTy6jTl5m5CdvqpZt8y5d6g==",
+      "dev": true,
+      "requires": {
+        "file-loader": "1.1.11",
+        "loader-utils": "1.2.3",
+        "mime-types": "2.1.24"
+      },
+      "dependencies": {
+        "file-loader": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
+          "integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
+          "dev": true,
+          "requires": {
+            "loader-utils": "1.2.3",
+            "schema-utils": "0.4.7"
+          }
+        },
+        "schema-utils": {
+          "version": "0.4.7",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+          "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "6.10.2",
+            "ajv-keywords": "3.4.1"
+          }
+        }
+      }
+    },
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
@@ -4285,12 +4318,6 @@
           "dev": true
         }
       }
-    },
-    "is-directory": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
-      "dev": true
     },
     "is-extendable": {
       "version": "0.1.1",

--- a/service-front/web/package-lock.json
+++ b/service-front/web/package-lock.json
@@ -1758,9 +1758,9 @@
       "integrity": "sha512-v/bHvXQ8sW28t9ZwBsFGgyqZw2bpT49/dtPTtlmixoSM/s9wnOngOKFVQLRH8BfMTy6jTl5m5CdvqpZt8y5d6g==",
       "dev": true,
       "requires": {
-        "file-loader": "1.1.11",
-        "loader-utils": "1.2.3",
-        "mime-types": "2.1.24"
+        "file-loader": "^1.1.11",
+        "loader-utils": "^1.1.0",
+        "mime-types": "^2.1.18"
       },
       "dependencies": {
         "file-loader": {
@@ -1769,8 +1769,8 @@
           "integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
           "dev": true,
           "requires": {
-            "loader-utils": "1.2.3",
-            "schema-utils": "0.4.7"
+            "loader-utils": "^1.0.2",
+            "schema-utils": "^0.4.5"
           }
         },
         "schema-utils": {
@@ -1779,8 +1779,8 @@
           "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
           "dev": true,
           "requires": {
-            "ajv": "6.10.2",
-            "ajv-keywords": "3.4.1"
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0"
           }
         }
       }
@@ -9430,7 +9430,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
               }
             },
@@ -9476,7 +9476,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "ms": "2.1.1"
+                "ms": "^2.1.1"
               }
             },
             "deep-extend": {
@@ -9563,7 +9563,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3"
               }
             },
             "ignore-walk": {
@@ -9573,7 +9573,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "minimatch": "3.0.4"
+                "minimatch": "^3.0.4"
               }
             },
             "inflight": {
@@ -9608,7 +9608,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "isarray": {
@@ -9625,7 +9625,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
@@ -9680,9 +9680,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "debug": "4.1.1",
-                "iconv-lite": "0.4.24",
-                "sax": "1.2.4"
+                "debug": "^4.1.0",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
               }
             },
             "node-pre-gyp": {
@@ -9711,8 +9711,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "abbrev": "1.1.1",
-                "osenv": "0.1.5"
+                "abbrev": "1",
+                "osenv": "^0.1.4"
               }
             },
             "npm-bundled": {
@@ -9729,8 +9729,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "ignore-walk": "3.0.1",
-                "npm-bundled": "1.0.6"
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
               }
             },
             "npmlog": {
@@ -9791,8 +9791,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
               }
             },
             "path-is-absolute": {
@@ -9905,9 +9905,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             },
             "string_decoder": {
@@ -9917,7 +9917,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
               }
             },
             "strip-ansi": {
@@ -9926,7 +9926,7 @@
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               }
             },
             "strip-json-comments": {

--- a/service-front/web/package.json
+++ b/service-front/web/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "CI=true jest --coverage",
     "test:watch": "jest --watch",
-    "build:pdf": "webpack -p --progress --config webpack.pdf.js",
+    "build:pdf": "webpack -p --progress --config webpack.pdf.development.js",
+    "build:pdf_production": "webpack -p --progress --config webpack.pdf.production.js",
     "build": "webpack -p --progress --config webpack.production.js",
     "watch": "webpack -p --progress --watch --config webpack.development.js"
   },

--- a/service-front/web/package.json
+++ b/service-front/web/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "CI=true jest --coverage",
     "test:watch": "jest --watch",
+    "build:pdf": "webpack -p --progress --config webpack.pdf.js",
     "build": "webpack -p --progress --config webpack.production.js",
     "watch": "webpack -p --progress --watch --config webpack.development.js"
   },
@@ -20,6 +21,7 @@
     "@babel/preset-env": "^7.7.1",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",
+    "base64-inline-loader": "^1.1.1",
     "copy-webpack-plugin": "^5.0.4",
     "css-loader": "^3.2.0",
     "eslint": "^6.5.1",
@@ -28,11 +30,9 @@
     "jest": "^24.9.0",
     "mini-css-extract-plugin": "^0.8.0",
     "node-sass": "^4.12.0",
-    "postcss-loader": "^3.0.0",
     "prettier": "^1.18.2",
     "sass": "^1.23.0",
     "sass-loader": "^8.0.0",
-    "style-loader": "^1.0.0",
     "webpack": "^4.41.0",
     "webpack-cli": "^3.3.9",
     "webpack-merge": "^4.2.2"

--- a/service-front/web/src/index.js
+++ b/service-front/web/src/index.js
@@ -1,7 +1,6 @@
 /* istanbul ignore file */
 
-import './main.scss';
-import './scss/lpa.scss';
+import './scss.js';
 import { initAll } from 'govuk-frontend';
 import jsEnabled from './javascript/jsEnabled';
 

--- a/service-front/web/src/pdf-scss.js
+++ b/service-front/web/src/pdf-scss.js
@@ -1,0 +1,6 @@
+/* istanbul ignore file */
+import './pdf.scss';
+
+const pdfscssLoader = () => {};
+
+export default pdfscssLoader;

--- a/service-front/web/src/pdf.js
+++ b/service-front/web/src/pdf.js
@@ -1,0 +1,3 @@
+/* istanbul ignore file */
+import './scss.js';
+import './pdf-scss.js';

--- a/service-front/web/src/pdf.scss
+++ b/service-front/web/src/pdf.scss
@@ -1,0 +1,20 @@
+@font-face {
+  font-family: 'GDS Transport';
+  src: url('../node_modules/govuk-frontend/govuk/assets/fonts/light-94a07e06a1-v2.woff2')
+      format('woff2'),
+    url('../node_modules/govuk-frontend/govuk/assets/fonts/light-f591b13f7d-v2.woff')
+      format('woff');
+  font-weight: normal;
+  font-style: normal;
+  font-display: fallback;
+}
+@font-face {
+  font-family: 'GDS Transport';
+  src: url('../node_modules/govuk-frontend/govuk/assets/fonts/bold-b542beb274-v2.woff2')
+      format('woff2'),
+    url('../node_modules/govuk-frontend/govuk/assets/fonts/bold-affa96571d-v2.woff')
+      format('woff');
+  font-weight: bold;
+  font-style: normal;
+  font-display: fallback;
+}

--- a/service-front/web/src/scss.js
+++ b/service-front/web/src/scss.js
@@ -1,0 +1,7 @@
+/* istanbul ignore file */
+import './main.scss';
+import './scss/lpa.scss';
+
+const scssLoader = () => {};
+
+export default scssLoader;

--- a/service-front/web/webpack.pdf.common.js
+++ b/service-front/web/webpack.pdf.common.js
@@ -2,13 +2,6 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 module.exports = {
   entry: './src/pdf.js',
-  resolve: {
-    modules: [__dirname, 'node_modules'],
-  },
-  output: {
-    path: '/dist',
-    filename: 'build.js',
-  },
   module: {
     rules: [
       {

--- a/service-front/web/webpack.pdf.development.js
+++ b/service-front/web/webpack.pdf.development.js
@@ -1,0 +1,13 @@
+const merge = require('webpack-merge');
+const common = require('./webpack.pdf.common.js');
+
+module.exports = merge(common, {
+  output: {
+    path: '/dist',
+    filename: 'javascript/pdf.bundle.js',
+    sourceMapFilename: 'pdf.[name].js.map',
+  },
+  resolve: {
+    modules: [__dirname, 'node_modules'],
+  },
+});

--- a/service-front/web/webpack.pdf.js
+++ b/service-front/web/webpack.pdf.js
@@ -1,0 +1,40 @@
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+
+module.exports = {
+  entry: './src/pdf.js',
+  resolve: {
+    modules: [__dirname, 'node_modules'],
+  },
+  output: {
+    path: __dirname + '/dist',
+    filename: 'build.js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.s[ac]ss$/i,
+        use: [
+          MiniCssExtractPlugin.loader,
+          {
+            loader: 'css-loader',
+            options: {
+              url: true,
+            },
+          },
+          {
+            loader: 'sass-loader',
+          },
+        ],
+      },
+      {
+        test: /\.(woff|woff2|ttf|eot|svg)/,
+        use: 'base64-inline-loader',
+      },
+    ],
+  },
+  plugins: [
+    new MiniCssExtractPlugin({
+      filename: 'stylesheets/pdf/[name].css',
+    }),
+  ],
+};

--- a/service-front/web/webpack.pdf.production.js
+++ b/service-front/web/webpack.pdf.production.js
@@ -1,0 +1,11 @@
+const merge = require('webpack-merge');
+const common = require('./webpack.pdf.common.js');
+const path = require('path');
+
+module.exports = merge(common, {
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'javascript/pdf.bundle.js',
+    sourceMapFilename: 'pdf.[name].js.map',
+  },
+});


### PR DESCRIPTION
This branch uses webpack to build out a seperate CSS file for use in the PDF Service. It takes the latest styles and fonts then base64 encodes the fonts into the CSS for faster processing of the PDF document.