### PR TITLE
Removed email confirmation box, updated unit and feature tests

### DIFF
--- a/service-front/app/features/actor-account-creation.feature
+++ b/service-front/app/features/actor-account-creation.feature
@@ -34,24 +34,15 @@ Feature: Account creation
   Scenario Outline: As a new user I want to be shown the mistakes I make while creating an account
     Given I am not a user of the lpa application
     And I want to create a new account
-    When I have not provided required information for account creation such as <email1> <email2> <password1> <password2> <terms>
+    When I have not provided required information for account creation such as <email1> <password1> <password2> <terms>
     Then I should be told my account could not be created due to <reasons>
     Examples:
-      | email1          | email2          | password1 | password2 | terms | reasons                          |
-      |                 |                 | Password1 | Password1 |   1   | Enter your email address         |
-      |test@example.com |                 | Password1 | Password1 |   1   | Confirm your email address       |
-      |test@example.com |test@example.com | Password1 |           |   1   | Confirm your password            |
-      |test@example.com |test@example.com | Password1 | Password1 |       | You must accept the terms of use |
+      | email1          | password1 | password2 | terms | reasons                          |
+      |                 | Password1 | Password1 |   1   | Enter your email address         |
+      |invalid_email    | Password1 | Password1 |   1   | Enter a valid email address      |
+      |test@example.com | Password1 |           |   1   | Confirm your password            |
+      |test@example.com | Password1 | Password1 |       | You must accept the terms of use |
 
-  @ui @integration
-  Scenario Outline: As a new user I want to be shown the mistakes I make while creating an account
-    Given I am not a user of the lpa application
-    And I want to create a new account
-    When Creating account I provide mismatching <email> <confirm_email>
-    Then I should be told my account could not be created due to <reasons>
-    Examples:
-      | email           | confirm_email  |reasons                     |
-      | test@example.com|test@exampl.com |The emails did not match    |
 
   @ui @integration
   Scenario Outline: As a new user I want to be shown the mistakes I make while creating an account

--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -722,7 +722,6 @@ class AccountContext extends BaseUIContext
             ->respondWith(new Response(StatusCodeInterface::STATUS_OK, [], json_encode([])));
 
         $this->ui->fillField('email', $this->email);
-        $this->ui->fillField('email_confirm', $this->email);
         $this->ui->fillField('password', $this->password);
         $this->ui->fillField('password_confirm', $this->password);
         $this->ui->fillField('terms', 1);
@@ -818,7 +817,6 @@ class AccountContext extends BaseUIContext
             ->respondWith(new Response(StatusCodeInterface::STATUS_OK, [], json_encode([])));
 
         $this->ui->fillField('email', $this->email);
-        $this->ui->fillField('email_confirm', $this->email);
         $this->ui->fillField('password', $this->password);
         $this->ui->fillField('password_confirm', $this->password);
         $this->ui->fillField('terms', 1);
@@ -841,7 +839,6 @@ class AccountContext extends BaseUIContext
             ->respondWith(new Response(StatusCodeInterface::STATUS_OK, [], json_encode([])));
 
         $this->ui->fillField('email', $email1);
-        $this->ui->fillField('email_confirm', $email2);
         $this->ui->fillField('password', $password1);
         $this->ui->fillField('password_confirm', $password2);
 
@@ -874,7 +871,6 @@ class AccountContext extends BaseUIContext
             ->respondWith(new Response(StatusCodeInterface::STATUS_OK, [], json_encode([])));
 
         $this->ui->fillField('email', $value1);
-        $this->ui->fillField('email_confirm', $value2);
         $this->ui->fillField('password',  $value1);
         $this->ui->fillField('password_confirm', $value2);
 

--- a/service-front/app/src/Actor/src/Form/CreateAccount.php
+++ b/service-front/app/src/Actor/src/Form/CreateAccount.php
@@ -36,11 +36,6 @@ class CreateAccount extends AbstractForm implements InputFilterProviderInterface
         ]);
 
         $this->add([
-            'name' => 'email_confirm',
-            'type' => 'Text',
-        ]);
-
-        $this->add([
             'name' => 'password',
             'type' => 'Password',
         ]);
@@ -81,35 +76,6 @@ class CreateAccount extends AbstractForm implements InputFilterProviderInterface
                         'name'                   => EmailAddressValidator::class,
                         'break_chain_on_failure' => true,
                     ]
-                ],
-            ],
-            'email_confirm'    => [
-                'required' => true,
-                'filters'  => [
-                    [
-                        'name' => StringToLower::class,
-                    ],
-                ],
-                'validators' => [
-                    [
-                        'name'                   => NotEmpty::class,
-                        'break_chain_on_failure' => true,
-                        'options'                => [
-                            'messages'           => [
-                                NotEmpty::IS_EMPTY => 'Confirm your email address',
-                            ],
-                        ],
-                    ],
-                    [
-                        'name'                   => Identical::class,
-                        'break_chain_on_failure' => true,
-                        'options'                => [
-                            'token'    => 'email',
-                            'messages' => [
-                                Identical::NOT_SAME => 'The emails did not match',
-                            ],
-                        ],
-                    ],
                 ],
             ],
             'password'         => [

--- a/service-front/app/src/Actor/templates/actor/create-account.html.twig
+++ b/service-front/app/src/Actor/templates/actor/create-account.html.twig
@@ -38,8 +38,6 @@
 
                                 {{ govuk_form_element(form.get('email'), { 'label': 'Enter your email address' }) }}
 
-                                {{ govuk_form_element(form.get('email_confirm'), { 'label': 'Confirm your email address' }) }}
-
                                 <p class="govuk-body govuk-!-font-weight-bold">Password</p>
 
                                 <p class="govuk-body">Your password needs to have:</p>

--- a/service-front/app/test/ActorTest/Form/CreateAccountTest.php
+++ b/service-front/app/test/ActorTest/Form/CreateAccountTest.php
@@ -34,7 +34,6 @@ class CreateAccountTest extends TestCase implements TestsZendForm
         return [
             '__csrf'           => Csrf::class,
             'email'            => Text::class,
-            'email_confirm'    => Text::class,
             'password'         => Password::class,
             'password_confirm' => Password::class,
             'terms'            => Checkbox::class,

--- a/service-front/app/test/ActorTest/Handler/CreateAccountHandlerTest.php
+++ b/service-front/app/test/ActorTest/Handler/CreateAccountHandlerTest.php
@@ -131,7 +131,6 @@ class CreateAccountHandlerTest extends TestCase
             ->willReturn([
                 '__csrf'           => self::CSRF_CODE,
                 'email'            => 'a@b.com',
-                'email_confirm'    => 'a@b.com',
                 'password'         => 'P@55word',
                 'password_confirm' => 'P@55word',
                 'terms'            => '1',
@@ -175,7 +174,6 @@ class CreateAccountHandlerTest extends TestCase
             ->willReturn([
                 '__csrf'           => self::CSRF_CODE,
                 'email'            => 'a@b.com',
-                'email_confirm'    => 'a@b.com',
                 'password'         => 'P@55word',
                 'password_confirm' => 'P@55word',
                 'terms'            => '1',
@@ -205,7 +203,6 @@ class CreateAccountHandlerTest extends TestCase
             ->willReturn([
                 '__csrf'           => self::CSRF_CODE,
                 'email'            => 'a@b.com',
-                'email_confirm'    => 'a@b.com',
                 'password'         => 'P@55word',
                 'password_confirm' => 'P@55word',
                 'terms'            => '1',


### PR DESCRIPTION
## Purpose
Remove email confirmation box on account creation page to meet GDS guidelines

Fixes UML-311

## Approach

Removed the email confirmation box and related validation on the account creation form. Updated unit tests and feature tests accordingly 

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a LPA service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes

