### PR TITLE
add SESSION_EXPIRES env var for view and use tasks

### DIFF
--- a/terraform/environment/actor_ecs.tf
+++ b/terraform/environment/actor_ecs.tf
@@ -143,7 +143,7 @@ locals {
       "value": "${var.container_version}"
     }]
   }
-  
+
 EOF
 
 
@@ -191,9 +191,13 @@ EOF
     {
       "name": "API_SERVICE_URL",
       "value": "http://${local.api_service_fqdn}"
+    },
+    {
+      "name": "SESSION_EXPIRES",
+      "value": "${local.account.session_expires_use}"
     }]
   }
-  
+
 EOF
 
 }
@@ -205,4 +209,3 @@ output "front_web_deployed_version" {
 output "front_app_deployed_version" {
   value = "${data.aws_ecr_repository.use_an_lpa_front_app.repository_url}:${var.container_version}"
 }
-

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -14,6 +14,8 @@ variable "accounts" {
       is_production        = bool
       sirius_account_id    = string
       api_gateway_endpoint = string
+      session_expires_view = number
+      session_expires_use  = number
     })
   )
 }

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -9,19 +9,25 @@
       "account_id": "367815980639",
       "is_production": false,
       "sirius_account_id": "288342028542",
-      "api_gateway_endpoint": "https://api.dev.sirius.opg.digital"
+      "api_gateway_endpoint": "https://api.dev.sirius.opg.digital",
+      "session_expires_view": 1000,
+      "session_expires_use": 1000
     },
     "preproduction": {
       "account_id": "888228022356",
       "is_production": false,
       "sirius_account_id": "288342028542",
-      "api_gateway_endpoint": "https://api.dev.sirius.opg.digital"
+      "api_gateway_endpoint": "https://api.dev.sirius.opg.digital",
+      "session_expires_view": 1000,
+      "session_expires_use": 1000
     },
     "production": {
       "account_id": "690083044361",
       "is_production": true,
       "sirius_account_id": "649098267436",
-      "api_gateway_endpoint": "https://api.sirius.opg.digital"
+      "api_gateway_endpoint": "https://api.sirius.opg.digital",
+      "session_expires_view": 1000,
+      "session_expires_use": 1000
     }
   }
 }

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -10,24 +10,24 @@
       "is_production": false,
       "sirius_account_id": "288342028542",
       "api_gateway_endpoint": "https://api.dev.sirius.opg.digital",
-      "session_expires_view": 1000,
-      "session_expires_use": 1000
+      "session_expires_view": 10,
+      "session_expires_use": 5
     },
     "preproduction": {
       "account_id": "888228022356",
       "is_production": false,
       "sirius_account_id": "288342028542",
       "api_gateway_endpoint": "https://api.dev.sirius.opg.digital",
-      "session_expires_view": 1000,
-      "session_expires_use": 1000
+      "session_expires_view": 30,
+      "session_expires_use": 20
     },
     "production": {
       "account_id": "690083044361",
       "is_production": true,
       "sirius_account_id": "649098267436",
       "api_gateway_endpoint": "https://api.sirius.opg.digital",
-      "session_expires_view": 1000,
-      "session_expires_use": 1000
+      "session_expires_view": 30,
+      "session_expires_use": 20
     }
   }
 }

--- a/terraform/environment/viewer_ecs.tf
+++ b/terraform/environment/viewer_ecs.tf
@@ -143,7 +143,7 @@ locals {
       "value": "${var.container_version}"
     }]
   }
-  
+
 EOF
 
 
@@ -190,10 +190,12 @@ EOF
     {
       "name": "PDF_SERVICE_URL",
       "value": "http://${local.pdf_service_fqdn}"
+    },
+    {
+      "name": "SESSION_EXPIRES",
+      "value": "${local.account.session_expires_view}"
     }]
   }
-  
+
 EOF
-
 }
-


### PR DESCRIPTION
## Purpose
Each front end wants to have independant session expiry values, and developers would like the ability to have shorter expiry times on dev environments to make it easier to test.

Fixes UML-536

## Approach

Use the account level variables to set a session expiry value, and pass that value into each front end's ECS containner definition.

This PR does not affect the current session expiry, onnly provides a new place to retrieve a value from.

## Learning


## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

