### PR TITLE
add commit messages and colour to UAL slack messages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -826,7 +826,9 @@ jobs:
             echo 'export USE_DOMAIN="$(jq -r .actor_fqdn /tmp/cluster_config.json)"' >> $BASH_ENV
       - slack/notify:
           title: "Use a Lasting Power of Attorney Development Environment Ready"
+          color: "#9933ff"
           message: "User: $CIRCLE_USERNAME \nview url: https://$VIEW_DOMAIN \nuse url: https://$USE_DOMAIN"
+          footer: "$CIRCLE_BRANCH - Commit Message: $COMMIT_MESSAGE"
   slack_notify_production_release:
     docker:
       - image: circleci/python
@@ -841,5 +843,7 @@ jobs:
             echo 'export USE_DOMAIN="$(jq -r .actor_fqdn /tmp/cluster_config.json)"' >> $BASH_ENV
       - slack/notify:
           title: "Use a Lasting Power of Attorney Production Release Successful"
+          color: "#9933ff"
           message: "User: $CIRCLE_USERNAME \nview url: https://$VIEW_DOMAIN \nuse url: https://$USE_DOMAIN"
           webhook: ${PROD_RELEASE_SLACK_WEBHOOK}
+          footer: "$CIRCLE_BRANCH - Commit Message: $COMMIT_MESSAGE"


### PR DESCRIPTION
## Purpose
Provide useful information about what has changed when posting slack messages

## Approach

Adds `$COMMIT_MESSAGE` and colours the posts to make them stand out in slack from the other products.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

