### PR TITLE
add listener rule to redirect port 80 to port 443

### DIFF
--- a/features/modules.py
+++ b/features/modules.py
@@ -2,7 +2,7 @@ import os
 from collections import defaultdict
 
 
-def get_frontend_url(frontend, path=''):
+def get_frontend_url(frontend, path='', protocol="https"):
     # Return a URL for a Use an LPA frontend on a specific environment.
     # The environment is based on the Terraform Workspace environment variable.
     workspace = os.getenv('TF_WORKSPACE', 'localhost')
@@ -15,7 +15,7 @@ def get_frontend_url(frontend, path=''):
     if workspace == 'localhost':
         url = 'http://viewer-web'
     else:
-        url = 'https://{0}{1}.lastingpowerofattorney.opg.service.justice.gov.uk'.format(
-            dns_env_namespace, frontend)
+        url = '{0}://{1}{2}.lastingpowerofattorney.opg.service.justice.gov.uk'.format(
+            protocol, dns_env_namespace, frontend)
 
     return url + path

--- a/features/steps/viewer.py
+++ b/features/steps/viewer.py
@@ -5,6 +5,11 @@ from modules import get_frontend_url
 
 
 # GIVENS
+@given('I go to the viewer service homepage without using https')
+def step_impl(context):
+    context.browser.get(get_frontend_url('view', protocol='http'))
+
+
 @given('I go to the viewer service homepage')
 def step_impl(context):
     context.browser.get(get_frontend_url('view'))

--- a/features/view-an-lpa.feature
+++ b/features/view-an-lpa.feature
@@ -4,6 +4,10 @@ Feature: View a lasting power of attorney
   I want to enter a code for a lasting power of attorney that has been shared with me,
   So I can view information about a lasting power of attorney to make decisions about how I should serve a customer.
 
+  Scenario: Redirected to service securely
+    Given I go to the viewer service homepage without using https
+    Then the "View a lasting power of attorney" page is displayed
+
   Scenario: Go to the service homepage
     Given I go to the viewer service homepage
     Then the "View a lasting power of attorney" page is displayed

--- a/terraform/environment/actor_load_balancer.tf
+++ b/terraform/environment/actor_load_balancer.tf
@@ -65,6 +65,15 @@ resource "aws_security_group" "actor_loadbalancer" {
   tags        = local.default_tags
 }
 
+resource "aws_security_group_rule" "actor_loadbalancer_ingress_http" {
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.actor_loadbalancer.id
+}
+
 resource "aws_security_group_rule" "actor_loadbalancer_ingress" {
   type              = "ingress"
   from_port         = 443

--- a/terraform/environment/actor_load_balancer.tf
+++ b/terraform/environment/actor_load_balancer.tf
@@ -27,6 +27,22 @@ resource "aws_lb" "actor" {
   }
 }
 
+resource "aws_lb_listener" "actor_loadbalancer_http_redirect" {
+  load_balancer_arn = aws_lb.actor.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = 443
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
 resource "aws_lb_listener" "actor_loadbalancer" {
   load_balancer_arn = aws_lb.actor.arn
   port              = "443"
@@ -40,6 +56,7 @@ resource "aws_lb_listener" "actor_loadbalancer" {
     type             = "forward"
   }
 }
+
 
 resource "aws_security_group" "actor_loadbalancer" {
   name        = "${local.environment}-actor-loadbalancer"
@@ -75,4 +92,3 @@ resource "aws_security_group_rule" "actor_loadbalancer_egress" {
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.actor_loadbalancer.id
 }
-

--- a/terraform/environment/viewer_load_balancer.tf
+++ b/terraform/environment/viewer_load_balancer.tf
@@ -64,6 +64,15 @@ resource "aws_security_group" "viewer_loadbalancer" {
   tags        = local.default_tags
 }
 
+resource "aws_security_group_rule" "viewer_loadbalancer_ingress_http" {
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.viewer_loadbalancer.id
+}
+
 resource "aws_security_group_rule" "viewer_loadbalancer_ingress" {
   type              = "ingress"
   from_port         = 443

--- a/terraform/environment/viewer_load_balancer.tf
+++ b/terraform/environment/viewer_load_balancer.tf
@@ -27,6 +27,22 @@ resource "aws_lb" "viewer" {
   }
 }
 
+resource "aws_lb_listener" "viewer_loadbalancer_http_redirect" {
+  load_balancer_arn = aws_lb.viewer.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = 443
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
 resource "aws_lb_listener" "viewer_loadbalancer" {
   load_balancer_arn = aws_lb.viewer.arn
   port              = "443"
@@ -75,4 +91,3 @@ resource "aws_security_group_rule" "viewer_loadbalancer_egress" {
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.viewer_loadbalancer.id
 }
-


### PR DESCRIPTION
## Purpose
Users have reported that the service is not working when they don't use `https://` in the service URLs. The service is only listening for `https://` requests.



Fixes UML-531

## Approach

This PR adds a listener rule to each load balancer to redirect the user to `https://` if they omit it.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes

