### PR TITLE
removed govuk link on viewer home page

### DIFF
--- a/service-front/app/src/Viewer/templates/viewer/home-page.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/home-page.html.twig
@@ -14,7 +14,7 @@
                 <p class="govuk-body-l">Use this service to:</p>
 
                 <ul class="govuk-list govuk-list--bullet">
-                    <li>view a summary of a <a href="https://www.gov.uk/power-of-attorney/make-lasting-power" class="govuk-link">lasting power of attorney</a> (LPA)</li>
+                    <li>view a summary of a lasting power of attorney (LPA)</li>
                     <li>check whether an LPA is currently valid</li>
                     <li>see who the attorneys are on an LPA</li>
                     <li>check when an LPA can be used</li>


### PR DESCRIPTION
## Purpose
To remove the link to the lpa service on the viewer home page as from research some users are unnecessarily following the link which takes them away from the service and interrupts their journey

Fixes UML-484

## Approach

Removed the link so that 'lasting power of attorney' is just text

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

