### PR TITLE
make sure scheduled jobs only runs on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ workflows:
           filters:
             branches:
               only:
-                - UML-517-redeploy-demo
+                - master
     jobs:
       - use-my-lpa/redeploy_latest:
           name: redeploy_demo


### PR DESCRIPTION
## Purpose
set scheduled jobs on CircleCI to run against master branch only

Fixes UML-517

## Approach

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

