### PR TITLE
Uml 565 dashboard on login feature test

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -9,7 +9,7 @@ options.headless = True
 def before_tag(context, tag):
     if tag == 'web':
         context.browser = webdriver.Firefox(options=options)
-        context.browser.implicitly_wait(10)
+        context.browser.implicitly_wait(12)
 
 
 def after_tag(context, tag):

--- a/service-front/app/features/actor-login.feature
+++ b/service-front/app/features/actor-login.feature
@@ -39,9 +39,9 @@ Feature: A user of the system is able to login
     When I attempt to sign in again
     Then I am directed to my dashboard
 
-#  @ui @integration
-#  Scenario: A user is taken to the dashboard page when the login having logged in previously
-#    Given I am a user of the lpa application
-#    And I have logged in previously
-#    When I sign in
-#    Then I am on the dashboard page
+  @ui @integration
+  Scenario: A user is taken to the dashboard page when the login having logged in previously
+    Given I am a user of the lpa application
+    And I have logged in previously
+    When I sign in
+    Then I am taken to the dashboard page

--- a/service-front/app/features/actor-login.feature
+++ b/service-front/app/features/actor-login.feature
@@ -40,7 +40,7 @@ Feature: A user of the system is able to login
     Then I am directed to my dashboard
 
   @ui @integration
-  Scenario: A user is taken to the dashboard page when the login having logged in previously
+  Scenario: A user is taken to the dashboard page when they login, having logged in previously
     Given I am a user of the lpa application
     And I have logged in previously
     When I sign in

--- a/service-front/app/features/actor-login.feature
+++ b/service-front/app/features/actor-login.feature
@@ -6,6 +6,7 @@ Feature: A user of the system is able to login
 
   Background:
     Given I am a user of the lpa application
+    And I have been given access to use an LPA via credentials
 
   @ui
   Scenario: A user can login
@@ -37,3 +38,10 @@ Feature: A user of the system is able to login
     Given I am currently signed in
     When I attempt to sign in again
     Then I am directed to my dashboard
+
+#  @ui @integration
+#  Scenario: A user is taken to the dashboard page when the login having logged in previously
+#    Given I am a user of the lpa application
+#    And I have logged in previously
+#    When I sign in
+#    Then I am on the dashboard page

--- a/service-front/app/features/context/Integration/AccountContext.php
+++ b/service-front/app/features/context/Integration/AccountContext.php
@@ -131,7 +131,11 @@ class AccountContext extends BaseIntegrationContext
                 new Response(
                     StatusCodeInterface::STATUS_OK,
                     [],
-                    json_encode([ 'PasswordResetToken' => $this->userPasswordResetToken ])
+                    json_encode(
+                        [
+                            'Id'                 => '123',
+                            'PasswordResetToken' => $this->userPasswordResetToken
+                        ])
                 )
             );
 
@@ -306,14 +310,17 @@ class AccountContext extends BaseIntegrationContext
         $this->activationToken = 'activate1234567890';
         $this->password = 'n3wPassWord';
 
-
         // API call for password reset request
         $this->apiFixtures->post('/v1/user')
             ->respondWith(
                 new Response(
                     StatusCodeInterface::STATUS_OK,
                     [],
-                    json_encode([ 'activationToken' => $this->activationToken])
+                    json_encode(
+                        [
+                            'Id'              => '123',
+                            'activationToken' => $this->activationToken
+                        ])
                 )
             );
 
@@ -480,7 +487,13 @@ class AccountContext extends BaseIntegrationContext
     public function iFollowTheInstructionsOnHowToActivateMyAccount()
     {
         $this->apiFixtures->patch('/v1/user-activation')
-            ->respondWith(new Response(StatusCodeInterface::STATUS_OK, [], json_encode([ 'activation_token' => $this->activationToken])))
+            ->respondWith(
+                new Response(
+                    StatusCodeInterface::STATUS_OK,
+                    [], json_encode(
+                        [
+                            'activation_token' => $this->activationToken
+                        ])))
             ->inspectRequest(function (RequestInterface $request, array $options) {
                 $query = $request->getUri()->getQuery();
                 assertContains($this->activationToken, $query);

--- a/service-front/app/features/context/Integration/AccountContext.php
+++ b/service-front/app/features/context/Integration/AccountContext.php
@@ -692,8 +692,8 @@ class AccountContext extends BaseIntegrationContext
         $lpas = $this->lpaService->getLpas($this->userIdentity);
 
         assertEmpty($lpas);
-                  
-               
+    }
+
     /**
      * @When /^I attempt  to add the same LPA again$/
      */

--- a/service-front/app/features/context/Integration/AccountContext.php
+++ b/service-front/app/features/context/Integration/AccountContext.php
@@ -600,4 +600,49 @@ class AccountContext extends BaseIntegrationContext
 
         assertEquals($lpa, $lpaObject);
     }
+
+    /**
+     * @Given /^I have logged in previously$/
+     */
+    public function iHaveLoggedInPreviously()
+    {
+        $this->iAmCurrentlySignedIn();
+    }
+
+    /**
+     * @When /^I sign in$/
+     */
+    public function iSignIn()
+    {
+        $this->apiFixtures->patch('/v1/auth')
+            ->respondWith(new Response(StatusCodeInterface::STATUS_OK, [], json_encode([
+                'Id'        => $this->userIdentity,
+                'Email'     => $this->userEmail,
+                'LastLogin' => '2020-01-21T15:58:47+00:00'
+            ])));
+
+        $user = $this->userService->authenticate($this->userEmail, $this->password);
+
+        assertEquals($user->getIdentity(), $this->userIdentity);
+    }
+
+    /**
+     * @Then /^I am taken to the dashboard page$/
+     */
+    public function iAmTakenToTheDashboardPage()
+    {
+        // API call for finding all the users added LPAs on dashboard
+        $this->apiFixtures->get('/v1/lpas')
+            ->respondWith(
+                new Response(
+                    StatusCodeInterface::STATUS_OK,
+                    [],
+                    json_encode([])
+                )
+            );
+
+        $lpas = $this->lpaService->getLpas($this->userIdentity);
+
+        assertEmpty($lpas);
+    }
 }

--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -254,7 +254,14 @@ class AccountContext implements Context
 
         // API call for password reset request
         $this->apiFixtures->patch('/v1/request-password-reset')
-            ->respondWith(new Response(StatusCodeInterface::STATUS_OK, [], json_encode([ 'PasswordResetToken' => '123456' ])));
+            ->respondWith(
+                new Response(
+                    StatusCodeInterface::STATUS_OK,
+                    [], json_encode(
+                        [
+                            'Id'                 => $this->userId,
+                            'PasswordResetToken' => '123456'
+                        ])));
 
         // API call for Notify
         $this->apiFixtures->post(Client::PATH_NOTIFICATION_SEND_EMAIL)
@@ -314,7 +321,14 @@ class AccountContext implements Context
     {
         // API fixture for reset token check
         $this->apiFixtures->get('/v1/can-password-reset')
-            ->respondWith(new Response(StatusCodeInterface::STATUS_OK, [], json_encode([ 'Id' => '123456' ])));
+            ->respondWith(
+                new Response(
+                    StatusCodeInterface::STATUS_OK,
+                    [],
+                    json_encode(
+                        [
+                            'Id' => '123456'
+                        ])));
     }
 
     /**
@@ -757,6 +771,7 @@ class AccountContext implements Context
         // API call for password reset request
         $this->apiFixtures->post('/v1/user')
             ->respondWith(new Response(StatusCodeInterface::STATUS_OK, [], json_encode([
+                'Id'              => '123',
                 'Email'           => $this->email,
                 'ActivationToken' => $this->activationToken,
             ])));
@@ -802,7 +817,15 @@ class AccountContext implements Context
     {
         // API fixture for reset token check
         $this->apiFixtures->patch('/v1/user-activation')
-            ->respondWith(new Response(StatusCodeInterface::STATUS_OK, [], json_encode([ 'activation_token' => $this->activationToken])));
+            ->respondWith(
+                new Response(
+                    StatusCodeInterface::STATUS_OK,
+                    [],
+                    json_encode(
+                        [
+                            'Id'               => '123',
+                            'activation_token' => $this->activationToken,
+                        ])));
 
         $this->ui->visit('/activate-account/' . $this->activationToken);
     }

--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -982,4 +982,42 @@ class AccountContext implements Context
         $this->ui->assertPageAddress('/lpa/view-lpa');
         $this->ui->assertPageContainsText($message);
     }
+
+//    /**
+//     * @Given /^I have logged in previously$/
+//     */
+//    public function iHaveLoggedInPreviously()
+//    {
+//        // do all the steps to sign in
+//        $this->iAccessTheLoginForm();
+//
+//        $this->ui->fillField('email', $this->userEmail);
+//        $this->ui->fillField('password', $this->userPassword);
+//
+//        if ($this->userActive) {
+//            // API call for authentication
+//            $this->apiFixtures->patch('/v1/auth')
+//                ->respondWith(new Response(StatusCodeInterface::STATUS_OK, [], json_encode(
+//                    [
+//                        'Id'        => $this->userId,
+//                        'Email'     => $this->userEmail,
+//                        'LastLogin' => null,
+//                    ]
+//                )));
+//
+////            // Dashboard page checks for all LPA's for a user
+////            $this->apiFixtures->get('/v1/lpas')
+////                ->respondWith(new Response(StatusCodeInterface::STATUS_OK, [], json_encode([])));
+//        } else {
+//            // API call for authentication
+//            $this->apiFixtures->patch('/v1/auth')
+//                ->respondWith(new Response(StatusCodeInterface::STATUS_UNAUTHORIZED, [], json_encode([])));
+//        }
+//
+//        $this->ui->pressButton('Continue');
+//
+//        $this->iAmSignedIn();
+//
+//        $this->iLogoutOfTheApplication();
+//    }
 }

--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -983,41 +983,45 @@ class AccountContext implements Context
         $this->ui->assertPageContainsText($message);
     }
 
-//    /**
-//     * @Given /^I have logged in previously$/
-//     */
-//    public function iHaveLoggedInPreviously()
-//    {
-//        // do all the steps to sign in
-//        $this->iAccessTheLoginForm();
-//
-//        $this->ui->fillField('email', $this->userEmail);
-//        $this->ui->fillField('password', $this->userPassword);
-//
-//        if ($this->userActive) {
-//            // API call for authentication
-//            $this->apiFixtures->patch('/v1/auth')
-//                ->respondWith(new Response(StatusCodeInterface::STATUS_OK, [], json_encode(
-//                    [
-//                        'Id'        => $this->userId,
-//                        'Email'     => $this->userEmail,
-//                        'LastLogin' => null,
-//                    ]
-//                )));
-//
-////            // Dashboard page checks for all LPA's for a user
-////            $this->apiFixtures->get('/v1/lpas')
-////                ->respondWith(new Response(StatusCodeInterface::STATUS_OK, [], json_encode([])));
-//        } else {
-//            // API call for authentication
-//            $this->apiFixtures->patch('/v1/auth')
-//                ->respondWith(new Response(StatusCodeInterface::STATUS_UNAUTHORIZED, [], json_encode([])));
-//        }
-//
-//        $this->ui->pressButton('Continue');
-//
-//        $this->iAmSignedIn();
-//
-//        $this->iLogoutOfTheApplication();
-//    }
+    /**
+     * @Given /^I have logged in previously$/
+     */
+    public function iHaveLoggedInPreviously()
+    {
+        // do all the steps to sign in
+        $this->iAccessTheLoginForm();
+
+        $this->ui->fillField('email', $this->userEmail);
+        $this->ui->fillField('password', $this->userPassword);
+
+        if ($this->userActive) {
+            // API call for authentication
+            $this->apiFixtures->patch('/v1/auth')
+                ->respondWith(new Response(StatusCodeInterface::STATUS_OK, [], json_encode(
+                    [
+                        'Id'        => $this->userId,
+                        'Email'     => $this->userEmail,
+                        'LastLogin' => null,
+                    ]
+                )));
+
+        } else {
+            // API call for authentication
+            $this->apiFixtures->patch('/v1/auth')
+                ->respondWith(new Response(StatusCodeInterface::STATUS_UNAUTHORIZED, [], json_encode([])));
+        }
+
+        $this->ui->pressButton('Continue');
+
+        $this->iAmSignedIn();
+        $this->iLogoutOfTheApplication();
+    }
+
+    /**
+     * @Then /^I am taken to the dashboard page$/
+     */
+    public function iAmTakenToTheDashboardPage()
+    {
+        $this->ui->assertPageAddress('/lpa/dashboard');
+    }
 }


### PR DESCRIPTION
## Purpose
To add feature tests to cover the scenario of a returning user logging in, having logged in previously, and being taken to the dashboard page (rather than the add an LPA page)

Fixes UML-565

## Approach

Written scenario steps for the front ui and integration. For the step 'I have logged in previously', I set the LastLogin value to null to represent their first ever login (even though their previous login doesn't necessarily mean their first ever login) and had this changed to a date time in the step 'When I sign in' to show the difference in response from the first login and how that should affect the redirect

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes

