### PR TITLE
Set a CLI specific trace-id into the container

### DIFF
--- a/service-api/app/src/App/src/Command/ActorCodeCreationCommandFactory.php
+++ b/service-api/app/src/App/src/Command/ActorCodeCreationCommandFactory.php
@@ -6,6 +6,7 @@ namespace App\Command;
 
 use App\DataAccess\ApiGateway\Lpas;
 use Aws\DynamoDb\DynamoDbClient;
+use DI\Container;
 use Psr\Container\ContainerInterface;
 
 class ActorCodeCreationCommandFactory
@@ -16,6 +17,14 @@ class ActorCodeCreationCommandFactory
 
         if (!isset($config['repositories']['dynamodb']['actor-codes-table'])) {
             throw new \Exception('Actor Codes table configuration not present');
+        }
+
+        // This factory will only be hit when building the ActorCodeCreationCommand so
+        // the trace-id will not be available to services requesting it. Lpas::class is one
+        // of those so here we add a dummy value. Runtime modification of the container outside
+        // of testing contexts should noe generally be done.
+        if ($container instanceof Container) {
+            $container->set('trace-id', 'CLI_TRACE_ID');
         }
 
         return new ActorCodeCreationCommand(

--- a/service-api/app/src/App/src/Command/ActorCodeCreationCommandFactory.php
+++ b/service-api/app/src/App/src/Command/ActorCodeCreationCommandFactory.php
@@ -19,10 +19,9 @@ class ActorCodeCreationCommandFactory
             throw new \Exception('Actor Codes table configuration not present');
         }
 
-        // This factory will only be hit when building the ActorCodeCreationCommand so
-        // the trace-id will not be available to services requesting it. Lpas::class is one
+        // The trace-id is not available to services requesting it under CLI running. Lpas::class is one
         // of those so here we add a dummy value. Runtime modification of the container outside
-        // of testing contexts should noe generally be done.
+        // of testing contexts should not generally be done.
         if ($container instanceof Container) {
             $container->set('trace-id', 'CLI_TRACE_ID');
         }


### PR DESCRIPTION
So calls to $container->get('trace-id') do not fail.

## Purpose
The actorcode generation was failing due to logging code changes, this fixes that case.

Fixes UML-574

## Approach

Attaches a CLI specific trace-id into the container when building the code creation Symfony command.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

