### PR TITLE
UML-563 Added tests to cover the single scenario when access code not created

### DIFF
--- a/service-api/app/features/actor-create-access-code.feature
+++ b/service-api/app/features/actor-create-access-code.feature
@@ -9,6 +9,14 @@ Feature: The user is able to create access codes for organisations
     And I am currently signed in
     And I have added an LPA to my account
 
+  @acceptance @integration
+  Scenario: As a user I want to be told if I have not created any access codes yet
+    Given I have added an LPA to my account
+    And I am on the dashboard page
+    When I check my access codes
+    Then I should be told that I have not created any access codes yet
+    And I should be able to click a link to go and create the access codes
+
   @integration @acceptance
   Scenario: As a user I can generate an access code for an organisation
     Given I am on the dashboard page

--- a/service-api/app/features/context/Integration/AccountContext.php
+++ b/service-api/app/features/context/Integration/AccountContext.php
@@ -1212,4 +1212,76 @@ class AccountContext extends BaseIntegrationContext
     {
         // Not needed for this context
     }
+
+    /**
+     * @When /^I check my access codes$/
+     */
+    public function iCheckMyAccessCodes()
+    {
+        //Get the LPA
+
+        // UserLpaActorMap::get
+        $this->awsFixtures->append(new Result([
+            'Item' => $this->marshalAwsResultData([
+                'SiriusUid'        => $this->lpaUid,
+                'Added'            => (new DateTime('2020-01-01'))->format('Y-m-d\TH:i:s.u\Z'),
+                'Id'               => $this->userLpaActorToken,
+                'ActorId'          => $this->actorLpaId,
+                'UserId'           => $this->userId
+            ])
+        ]));
+
+        // LpaRepository::get
+        $this->apiFixtures->get('/v1/use-an-lpa/lpas/' . $this->lpaUid)
+            ->respondWith(
+                new Response(
+                    StatusCodeInterface::STATUS_OK,
+                    [],
+                    json_encode($this->lpa)));
+
+        $lpaService = $this->container->get(LpaService::class);
+
+        $lpaData = $lpaService->getByUserLpaActorToken($this->userLpaActorToken, (string) $this->userId);
+
+        assertEquals($this->userLpaActorToken, $lpaData['user-lpa-actor-token']);
+        assertEquals($this->lpa->uId, $lpaData['lpa']['uId']);
+        assertEquals($this->lpaUid, $lpaData['actor']['details']['uId']);
+
+        // Get the share codes
+
+        // UserLpaActorMap::get
+        $this->awsFixtures->append(new Result([
+            'Item' => $this->marshalAwsResultData([
+                'SiriusUid'        => $this->lpaUid,
+                'Added'            => (new DateTime('2020-01-01'))->format('Y-m-d\TH:i:s.u\Z'),
+                'Id'               => $this->userLpaActorToken,
+                'ActorId'          => $this->actorLpaId,
+                'UserId'           => $this->userId
+            ])
+        ]));
+
+        // ViewerCodes::getCodesByUserLpaActorId
+        $this->awsFixtures->append(new Result([]));
+
+        $viewerCodeService = $this->container->get(\App\Service\ViewerCodes\ViewerCodeService::class);
+        $accessCodes = $viewerCodeService->getCodes($this->userLpaActorToken, $this->userId);
+
+        assertEmpty($accessCodes);
+    }
+
+    /**
+     * @Then /^I should be told that I have not created any access codes yet$/
+     */
+    public function iShouldBeToldThatIHaveNotCreatedAnyAccessCodesYet()
+    {
+        // Not needed for this context
+    }
+
+    /**
+     * @Then /^I should be able to click a link to go and create the access codes$/
+     */
+    public function iShouldBeAbleToClickALinkToGoAndCreateTheAccessCodes()
+    {
+        $this->iRequestToGiveAnOrganisationAccessToOneOfMyLPAs();
+    }
 }

--- a/service-front/app/features/actor-create-access-code.feature
+++ b/service-front/app/features/actor-create-access-code.feature
@@ -9,6 +9,15 @@ Feature: The user is able to create access codes for organisations
     And I am currently signed in
     And I have added an LPA to my account
 
+  @ui @integration
+  Scenario: As a user I want to be told if I have not created any access codes yet
+    Given I have added an LPA to my account
+    And I am on the dashboard page
+    When I check my access codes
+    Then I should be told that I have not created any access codes yet
+    And I should be able to click a link to go and create the access codes
+
+
   @ui
   Scenario Outline: As a user I to be shown the mistakes I make while creating an access code for an organisation
     Given I am on the dashboard page

--- a/service-front/app/features/context/Integration/AccountContext.php
+++ b/service-front/app/features/context/Integration/AccountContext.php
@@ -1189,4 +1189,53 @@ class AccountContext extends BaseIntegrationContext
     {
         // Not needed for this context
     }
+
+    /**
+     * @When /^I check my access codes$/
+     */
+    public function iCheckMyAccessCodes()
+    {
+        // API call for get LpaById
+        $this->apiFixtures->get('/v1/lpas/' . $this->actorLpaToken)
+            ->respondWith(
+                new Response(
+                    StatusCodeInterface::STATUS_OK,
+                    [],
+                    json_encode([
+                        'user-lpa-actor-token' => $this->actorLpaToken,
+                        'date' => 'date',
+                        'lpa' => $this->lpa,
+                        'actor' => [],
+                    ])));
+
+        // API call to make code
+        $this->apiFixtures->get('/v1/lpas/' . $this->actorLpaToken . '/codes')
+            ->respondWith(
+                new Response(
+                    StatusCodeInterface::STATUS_OK,
+                    [],
+                    json_encode([])
+                ));
+
+        $shareCodes = $this->viewerCodeService->getShareCodes($this->userIdentity, $this->actorLpaToken, false);
+
+        assertEmpty($shareCodes);
+    }
+
+    /**
+     * @Then /^I should be told that I have not created any access codes yet$/
+     */
+    public function iShouldBeToldThatIHaveNotCreatedAnyAccessCodesYet()
+    {
+        // Not needed for this context
+    }
+
+    /**
+     * @Then /^I should be able to click a link to go and create the access codes$/
+     */
+    public function iShouldBeAbleToClickALinkToGoAndCreateTheAccessCodes()
+    {
+        $this->iRequestToGiveAnOrganisationAccessToOneOfMyLPAs();
+    }
+
 }

--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -1489,31 +1489,6 @@ class AccountContext implements Context
         $this->ui->pressButton('Continue');
     }
 
-//    /**
-//     * @When /^I cancel the organisation access code/
-//     */
-//    public function iCancelTheOrganisationAccessCode()
-//    {
-//        $this->ui->assertPageAddress('/lpa/access-codes?lpa=' .$this->userLpaActorToken);
-//
-//        // API call for get LpaById
-//        $this->apiFixtures->get('/v1/lpas/' . $this->userLpaActorToken)
-//            ->respondWith(
-//                new Response(
-//                    StatusCodeInterface::STATUS_OK,
-//                    [],
-//                    json_encode([
-//                        'user-lpa-actor-token' => $this->userLpaActorToken,
-//                        'date'                 => 'date',
-//                        'lpa'                  => $this->lpa,
-//                        'actor'                => [],
-//                    ])));
-//
-//        $this->ui->pressButton("Cancel organisation's access");
-//
-//        $this->iWantToBeAskedForConfirmationPriorToCancellation();
-//    }
-
     /**
      * @Then /^I should be shown the details of the cancelled viewer code with cancelled status/
      */
@@ -1590,4 +1565,66 @@ class AccountContext implements Context
         $this->ui->assertPageContainsText('We could not find that lasting power of attorney');
     }
 
+    /**
+     * @When /^I check my access codes/
+     */
+    public function iCheckMyAccessCodes()
+    {
+        // API call for get LpaById
+        $this->apiFixtures->get('/v1/lpas/' . $this->userLpaActorToken)
+            ->respondWith(
+                new Response(
+                    StatusCodeInterface::STATUS_OK,
+                    [],
+                    json_encode([
+                        'user-lpa-actor-token' => $this->userLpaActorToken,
+                        'date'                 => 'date',
+                        'lpa'                  => $this->lpa,
+                        'actor'                => [],
+                    ])));
+
+        // API call to get access codes
+        $this->apiFixtures->get('/v1/lpas/' . $this->userLpaActorToken . '/codes')
+            ->respondWith(
+                new Response(
+                    StatusCodeInterface::STATUS_OK,
+                    [],
+                    json_encode([])));
+
+        $this->ui->clickLink('Check access codes');
+    }
+
+    /**
+     * @Then /^I should be told that I have not created any access codes yet$/
+     */
+    public function iShouldBeToldThatIHaveNotCreatedAnyAccessCodesYet()
+    {
+        $this->ui->assertPageContainsText('Check access codes');
+        $this->ui->assertPageContainsText('There are no access codes for this LPA');
+        $this->ui->assertPageContainsText('Give an organisation access');
+    }
+
+    /**
+     * @Then /^I should be able to click a link to go and create the access codes$/
+     */
+    public function iShouldBeAbleToClickALinkToGoAndCreateTheAccessCodes()
+    {
+        // API call for get LpaById (when give organisation access is clicked)
+        $this->apiFixtures->get('/v1/lpas/' . $this->userLpaActorToken)
+            ->respondWith(
+                new Response(
+                    StatusCodeInterface::STATUS_OK,
+                    [],
+                    json_encode([
+                        'user-lpa-actor-token' => $this->userLpaActorToken,
+                        'date'                 => 'date',
+                        'lpa'                  => $this->lpa,
+                        'actor'                => [],
+                    ])));
+
+        $this->ui->clickLink('Give an organisation access');
+        $this->ui->assertPageAddress('lpa/code-make?lpa=' .$this->userLpaActorToken);
+        $this->ui->assertPageContainsText('Which organisation do you want to give access to');
+
+    }
 }

--- a/service-front/app/src/Actor/src/Handler/CheckAccessCodesHandler.php
+++ b/service-front/app/src/Actor/src/Handler/CheckAccessCodesHandler.php
@@ -96,6 +96,14 @@ class CheckAccessCodesHandler extends AbstractHandler implements UserAware, Csrf
             }
         }
 
+//        var_dump("--------1");
+//        var_dump($actorLpaToken);
+//        var_dump("--------2");
+//        var_dump($user);
+//        var_dump("--------3");
+//        var_dump($shareCodes);
+//        die;
+
         return new HtmlResponse($this->renderer->render('actor::check-access-codes', [
             'actorToken' => $actorLpaToken,
             'user' => $user,

--- a/service-front/app/src/Actor/src/Handler/CheckAccessCodesHandler.php
+++ b/service-front/app/src/Actor/src/Handler/CheckAccessCodesHandler.php
@@ -96,14 +96,6 @@ class CheckAccessCodesHandler extends AbstractHandler implements UserAware, Csrf
             }
         }
 
-//        var_dump("--------1");
-//        var_dump($actorLpaToken);
-//        var_dump("--------2");
-//        var_dump($user);
-//        var_dump("--------3");
-//        var_dump($shareCodes);
-//        die;
-
         return new HtmlResponse($this->renderer->render('actor::check-access-codes', [
             'actorToken' => $actorLpaToken,
             'user' => $user,


### PR DESCRIPTION
## Purpose
_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

Fixes UML-563

## Approach

Added feature tests to cover the scenario : When user has not created an access code , it should display to the user relevant message and show them an option to create one if needed.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Refunds service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes

