### PR TITLE
Uml 582 viewer terms of use

### DIFF
--- a/service-front/app/config/routes.php
+++ b/service-front/app/config/routes.php
@@ -42,6 +42,7 @@ $viewerRoutes = function (Application $app, MiddlewareFactory $factory, Containe
     $app->get('/check-code', Viewer\Handler\CheckCodeHandler::class, 'check-code');
     $app->get('/view-lpa', Viewer\Handler\ViewLpaHandler::class, 'view-lpa');
     $app->get('/download-lpa', Viewer\Handler\DownloadLpaHandler::class, 'download-lpa');
+    $app->get('/terms-of-use', Viewer\Handler\ViewerTermsOfUseHandler::class, 'viewer-terms-of-use');
 };
 
 $actorRoutes = function (Application $app, MiddlewareFactory $factory, ContainerInterface $container) : void

--- a/service-front/app/features/context/UI/ViewerContext.php
+++ b/service-front/app/features/context/UI/ViewerContext.php
@@ -329,4 +329,47 @@ class ViewerContext implements Context
         $this->ui->assertPageContainsText("I want to check another LPA");
         $this->ui->clickLink("I want to check another LPA");
     }
+
+    /**
+     * @When /^I request to see the viewer terms of use$/
+     */
+    public function iRequestToSeeTheViewerTermsOfUse()
+    {
+        $this->ui->clickLink("terms of use");
+    }
+
+    /**
+     * @Then /^I can see the viewer terms of use$/
+     */
+    public function iCanSeeTheViewerTermsOfUse()
+    {
+        $this->ui->assertPageAddress('/terms-of-use');
+        $this->ui->assertPageContainsText('Terms of use');
+    }
+
+    /**
+     * @Given /^I am on the terms of use page$/
+     */
+    public function iAmOnTheTermsOfUsePage()
+    {
+        $this->ui->visit('/terms-of-use');
+        $this->ui->assertPageAddress('/terms-of-use');
+    }
+
+    /**
+     * @When /^I request to go back to the enter code page$/
+     */
+    public function iRequestToGoBackToTheEnterCodePage()
+    {
+        $this->ui->clickLink('Back');
+    }
+
+    /**
+     * @Then /^I am taken back to the enter code page$/
+     */
+    public function iAmTakenBackToTheEnterCodePage()
+    {
+        $this->ui->assertPageAddress('/enter-code');
+        $this->ui->assertPageContainsText('Enter the LPA access code');
+    }
 }

--- a/service-front/app/features/viewer-terms-of-use.feature
+++ b/service-front/app/features/viewer-terms-of-use.feature
@@ -1,13 +1,17 @@
-@viewer @termsOfUSe
-Feature: View an LPA via sharecode
-  As an organisation who has been given a share code
-  I can enter that code and see the details of an LPA
-  So that I can carry out business functions
+@viewer @termsOfUse
+Feature: View terms of use from enter code page
+  As an organisation using the service
+  I want to check the terms of use
+  So that I can be be sure of my rights and responsibilities for using the service
 
-  @integration @ui
-  Scenario: The user can enter a valid sharecode and see the details of an LPA
-    Given I have been given access to an LPA via share code
-    And I access the viewer service
-    And I give a valid LPA share code
-    When I confirm the LPA is correct
-    Then I can see the full details of the valid LPA
+  @ui
+  Scenario: The user can access the terms of use from the enter code page
+    Given I am on the enter code page
+    When I request to see the viewer terms of use
+    Then I can see the viewer terms of use
+
+  @ui
+  Scenario: The user can go back to the enter code page from the terms of use page
+    Given I am on the terms of use page
+    When I request to go back to the enter code page
+    Then I am taken back to the enter code page

--- a/service-front/app/features/viewer-terms-of-use.feature
+++ b/service-front/app/features/viewer-terms-of-use.feature
@@ -1,0 +1,13 @@
+@viewer @termsOfUSe
+Feature: View an LPA via sharecode
+  As an organisation who has been given a share code
+  I can enter that code and see the details of an LPA
+  So that I can carry out business functions
+
+  @integration @ui
+  Scenario: The user can enter a valid sharecode and see the details of an LPA
+    Given I have been given access to an LPA via share code
+    And I access the viewer service
+    And I give a valid LPA share code
+    When I confirm the LPA is correct
+    Then I can see the full details of the valid LPA

--- a/service-front/app/src/Viewer/src/Handler/ViewerTermsOfUseHandler.php
+++ b/service-front/app/src/Viewer/src/Handler/ViewerTermsOfUseHandler.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Viewer\Handler;
+
+use Common\Handler\AbstractHandler;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\Response\HtmlResponse;
+
+/**
+ * Class ViewerTermsOfUseHandler
+ * @package Viewer\Handler
+ */
+class ViewerTermsOfUseHandler extends AbstractHandler
+{
+    /**
+     * @param ServerRequestInterface $request
+     * @return ResponseInterface
+     */
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        return new HtmlResponse($this->renderer->render('viewer::viewer-terms-of-use'));
+    }
+}

--- a/service-front/app/src/Viewer/templates/viewer/enter-code.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/enter-code.html.twig
@@ -42,6 +42,8 @@
                             An LPA access code is a unique code given to you by the donor or an attorney named on a lasting power of attorney.
                         </div>
 
+                        <p class="govuk-body">By continuing you agree to our <a href = "{{ path('viewer-terms-of-use') }}" class="govuk-link">terms of use</a>.</p>
+
                         <button type="submit" class="govuk-button">Continue</button>
 
                     </fieldset>

--- a/service-front/app/src/Viewer/templates/viewer/viewer-terms-of-use.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/viewer-terms-of-use.html.twig
@@ -1,0 +1,88 @@
+{% extends '@viewer/layout.html.twig' %}
+
+{% block html_title %}Terms of use - {{ parent() }} {% endblock %}
+
+{% block content %}
+<div class="govuk-width-container">
+    {{ include('@partials/new-service.html.twig') }}
+
+    <a href="{{ path('enter-code') }}" class="govuk-back-link">Back</a>
+
+    <main class="govuk-main-wrapper">
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+
+                <h1 class="govuk-heading-xl">Terms of use</h1>
+
+                <p class="govuk-body">The Use a lasting power of attorney (LPA) service lets donors and attorneys share a summary of an LPA with professionals or organisations by creating a unique ‘access code’.
+                    View a lasting power of attorney is the part of this service that lets you see a summary of an LPA, using the access code given to you by the donor or an attorney.
+                    This part of the service is for professionals or organisations providing a service to the donor. For example, financial institutions, medical professionals, and care organisations.
+                    You can use this service instead of asking to see the original paper LPA.</p>
+
+                <p class="govuk-body">By using this service you:</p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>agree to these terms of use and the <a href="https://www.gov.uk/help/terms-conditions">GOV.UK terms and conditions</a></li>
+                    <li>confirm that a donor or attorney wants you to view the LPA and has given you an access code</li>
+                </ul>
+
+                <p class="govuk-body govuk-!-font-weight-bold">! It can be a criminal offence to use someone’s personal information without their permission.</p>
+
+                <h2 class="govuk-heading-m">Information security</h2>
+
+                <p class="govuk-body">You and your organisation are responsible for your use of View a lasting power of attorney.</p>
+                <p class="govuk-body">If you download a copy of an LPA summary, or record details of the summary, <b>your organisation becomes the ‘data controller’ of that information.</b> This means your organisation will be responsible for keeping the information safe and secure, in line with Data Protection Act 2018.</p>
+
+                <h3 class="govuk-heading-s">Accessing the service securely</h3>
+
+                <p class="govuk-body">You’re responsible for accessing the service securely. You should not access it using a computer or network that may leave personal information accessible to others or you think may be insecure. For example, you should not:</p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>leave a computer unprotected while you’re using the service</li>
+                    <li>access the service using a shared or public computer</li>
+                </ul>
+
+                <p class="govuk-body">We recommend that you close the tab on your web browser when you’ve finished using the service. We’ll automatically return you to the service start page if you have not used the service for 60 minutes.</p>
+
+                <h2 class="govuk-heading-m">Keeping information up to date</h2>
+
+                <p class="govuk-body">LPAs can change. For example, attorneys may change, people’s names or addresses may change, or the donor may cancel their LPA.</p>
+
+                <p class="govuk-body">We use OPG’s records about registered LPAs to keep this service up to date. However:</p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>we rely on donors and attorneys to tell us about any changes</li>
+                    <li>once we’re told about a change, it may take several days before we update the LPA summary on the service</li>
+                </ul>
+
+                <h2 class="govuk-heading-m">The online summary</h2>
+
+                <p class="govuk-body">Any screenshots, downloads or printouts of the LPA summary are not proof of an LPA and may not show the latest status of an LPA.</p>
+
+                <h2 class="govuk-heading-m">Tracking use of the service</h2>
+
+                <p class="govuk-body">We keep a record of when an access code has been used to view an LPA. This information is available to the donor and attorneys.</p>
+                <p class="govuk-body">The information will be stored securely and used in line with our <a href="https://www.lastingpowerofattorney.service.gov.uk/privacy-notice">privacy notice</a> and cookie policy.</p>
+
+                <h2 class="govuk-heading-m">If you suspect fraud or abuse</h2>
+
+                <p class="govuk-body"><a href="https://www.gov.uk/report-concern-about-attorney-deputy">Contact the Office of the Public Guardian</a> if you have concerns about the actions of an attorney. For example, if you’re concerned they’re misusing a donor’s money or are making decisions that are not in the donor’s best interests.</p>
+                <p class="govuk-body">If you suspect abuse, a criminal offence, or think someone is in immediate danger, <a href="https://www.gov.uk/contact-police">contact the police</a> first.</p>
+
+                <h2 class="govuk-heading-m">Governing law</h2>
+
+                <p class="govuk-body">These terms of use are governed by the laws of England and Wales, including:</p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>Computer Misuse Act 1990</li>
+                    <li>General Data Protection Regulation 2018</li>
+                    <li>Data Protection Bill 2018</li>
+                    <li>Mental Capacity Act 2005</li>
+                </ul>
+
+                <p class="govuk-body">Any dispute you have about these terms of use, or your use of OPG services (whether it be contractual or non-contractual), will be subject to the exclusive jurisdiction of the courts of England and Wales.</p>
+
+                <h2 class="govuk-heading-m">About these terms of use</h2>
+                <p class="govuk-body">These terms of use affect your rights and responsibilities under the law. They govern your use of the View a lasting power of attorney service. They do not apply to any other department or online service. Please check these terms of use regularly. We may update them without notice. This might happen if there’s a change in the law or to the way the service works. You’ll agree to any changes if you continue to use the service after the terms of use have been updated.</p>
+
+            </div>
+        </div>
+    </main>
+</div>
+{% endblock %}

--- a/service-front/web/package-lock.json
+++ b/service-front/web/package-lock.json
@@ -10993,7 +10993,8 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -11004,7 +11005,8 @@
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -11121,7 +11123,8 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -11133,6 +11136,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -11147,6 +11151,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -11267,7 +11272,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -11279,6 +11285,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -11400,6 +11407,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
## Purpose
Added the terms of use page on the viewer side of the service. The link to the terms of use is on the enter code page

Fixes UML-582

## Approach

Created the new page, with a handler and added a route in the routes file. Then added the new text and link to the enter code page. Finally I created 2 feature tests, the first checks that the user is taken to the terms of use page from the enter code page by clicking the link. The second test checks that the user is taken back to the enter code page when they click the "back" button on the terms of use page

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes

