### PR TITLE
fix up python version to 3 and add apk upgrade

### DIFF
--- a/zap/Dockerfile
+++ b/zap/Dockerfile
@@ -4,12 +4,10 @@ WORKDIR /zap
 
 USER root
 
-RUN apk upgrade
-RUN  apk add python3 py3-pip
-RUN rm -rf /var/cache/apk/*
-RUN pip3 install --no-cache-dir --upgrade pip
-RUN pip3 install --no-cache-dir --upgrade setuptools
-RUN pip3 install --no-cache-dir --upgrade zapcli
+RUN apk upgrade \
+ && apk add python3 py3-pip \
+ && rm -rf /var/cache/apk/* \
+ && pip3 install --no-cache-dir --upgrade pip zapcli
 
 COPY ./scripts/ /scripts
 

--- a/zap/Dockerfile
+++ b/zap/Dockerfile
@@ -4,8 +4,12 @@ WORKDIR /zap
 
 USER root
 
-RUN apk add python3 py-pip && rm -rf /var/cache/apk/* \
-    && pip install --upgrade zapcli
+RUN apk upgrade
+RUN  apk add python3 py3-pip
+RUN rm -rf /var/cache/apk/*
+RUN pip3 install --no-cache-dir --upgrade pip
+RUN pip3 install --no-cache-dir --upgrade setuptools
+RUN pip3 install --no-cache-dir --upgrade zapcli
 
 COPY ./scripts/ /scripts
 

--- a/zap/Dockerfile
+++ b/zap/Dockerfile
@@ -7,7 +7,7 @@ USER root
 RUN apk upgrade \
  && apk add python3 py3-pip \
  && rm -rf /var/cache/apk/* \
- && pip3 install --no-cache-dir --upgrade pip zapcli
+ && pip3 install --no-cache-dir --upgrade zapcli
 
 COPY ./scripts/ /scripts
 


### PR DESCRIPTION
## Purpose
_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

To fix an issue with Zap DockerFile that was causing issues locally when spinning up in docker-compose. This does not commission the docker file to run the zap scripts it has yet.

## Approach
- Upgrade PIP to PIP3 and add some prerequisites and no-cache to prevent warnings.
- add an Apk upgrade to prevent vuln creep.
- Made the docker file clearer in terms of steps taken by running each step separately.

## Learning

- general research around docker and python:
https://stackoverflow.com/questions/7446187/no-module-named-pkg-resources 
https://wiki.alpinelinux.org/wiki/Alpine_Linux_package_management#Upgrade_a_Running_System
 - also, what is zap? 
https://www.zaproxy.org/

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

