### PR TITLE
LPA not found message still says 'passcode'

### DIFF
--- a/service-front/app/src/Actor/templates/actor/lpa-not-found.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-not-found.html.twig
@@ -15,7 +15,7 @@
 
                     <h1 class="govuk-heading-l">We could not find that lasting power of attorney</h1>
 
-                    <p class="govuk-body">We could not find a lasting power of attorney with the passcode, reference number and date of birth you entered.</p>
+                    <p class="govuk-body">We could not find a lasting power of attorney with the activation key, reference number and date of birth you entered.</p>
 
                     <p class="govuk-body">If you're sure you entered the right information, please contact us.</p>
 


### PR DESCRIPTION
## Purpose
I've replaced 'passcode' with 'activation key'

