### PR TITLE
Updated session timeout message from 60min to 20min

### DIFF
--- a/service-front/app/src/Common/src/Form/AbstractForm.php
+++ b/service-front/app/src/Common/src/Form/AbstractForm.php
@@ -35,7 +35,7 @@ abstract class AbstractForm extends Form
                     'csrf_options' => [
                         'guard' => $csrfGuard,
                         'messageTemplates' => [
-                            CsrfGuardValidator::NOT_SAME => "As you have not used this service for over 60 minutes, the page has timed out. We've now refreshed the page - please try to sign in again."
+                            CsrfGuardValidator::NOT_SAME => "As you have not used this service for over 20 minutes, the page has timed out. We've now refreshed the page - please try to sign in again."
                         ],
                     ],
                 ]


### PR DESCRIPTION
## Purpose
Updating warning message on session time out from 60 to 20

Fixes UML-####

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Refunds service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

