### PR TITLE
Ensure actor codes are used as uppercase

### DIFF
--- a/service-front/app/features/actor-add-an-lpa.feature
+++ b/service-front/app/features/actor-add-an-lpa.feature
@@ -10,11 +10,17 @@ Feature: Add an LPA
     And I have been given access to use an LPA via credentials
 
   @integration @ui
-  Scenario: The user can add an LPA to their account
+  Scenario Outline: The user can add an LPA to their account
     Given I am on the add an LPA page
-    When I request to add an LPA with valid details
+    When I request to add an LPA with valid details using <passcode>
     Then The correct LPA is found and I can confirm to add it
     And The LPA is successfully added
+
+    Examples:
+      | passcode       |
+      | xyuphwqrechv   |
+      | XYUPHWQRECHV   |
+      | XYUP-hwqr-EcHv |
 
   @integration @ui
   Scenario: The user cannot add an LPA to their account as it does not exist

--- a/service-front/app/features/context/Integration/AccountContext.php
+++ b/service-front/app/features/context/Integration/AccountContext.php
@@ -378,9 +378,9 @@ class AccountContext extends BaseIntegrationContext
     }
 
     /**
-     * @When /^I request to add an LPA with valid details$/
+     * @When /^I request to add an LPA with valid details using (.*)$/
      */
-    public function iRequestToAddAnLPAWithValidDetails()
+    public function iRequestToAddAnLPAWithValidDetailsUsing(string $code)
     {
         // API call for checking LPA
         $this->apiFixtures->post('/v1/actor-codes/summary')
@@ -392,7 +392,7 @@ class AccountContext extends BaseIntegrationContext
                 )
             );
 
-        $lpa = $this->lpaService->getLpaByPasscode($this->userIdentity, $this->passcode, $this->referenceNo, $this->userDob);
+        $lpa = $this->lpaService->getLpaByPasscode($this->userIdentity, $code, $this->referenceNo, $this->userDob);
 
         assertEquals($lpa->getUId(), $this->lpa['uId']);
     }
@@ -618,7 +618,7 @@ class AccountContext extends BaseIntegrationContext
     {
         $this->iHaveBeenGivenAccessToUseAnLPAViaCredentials();
         $this->iAmOnTheAddAnLPAPage();
-        $this->iRequestToAddAnLPAWithValidDetails();
+        $this->iRequestToAddAnLPAWithValidDetailsUsing($this->passcode);
         $this->theCorrectLPAIsFoundAndICanConfirmToAddIt();
         $this->theLPAIsSuccessfullyAdded();
     }

--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -531,9 +531,9 @@ class AccountContext implements Context
     }
 
     /**
-     * @When /^I request to add an LPA with valid details$/
+     * @When /^I request to add an LPA with valid details using (.*)$/
      */
-    public function iRequestToAddAnLPAWithValidDetails()
+    public function iRequestToAddAnLPAWithValidDetailsUsing(string $code)
     {
         $this->ui->assertPageAddress('/lpa/add-details');
 
@@ -545,9 +545,14 @@ class AccountContext implements Context
                     [],
                     json_encode(['lpa' => $this->lpa])
                 )
-            );
+            )
+            ->inspectRequest(function (RequestInterface $request, array $options) {
+                $params = json_decode($request->getBody()->getContents(), true);
 
-        $this->ui->fillField('passcode', 'XYUPHWQRECHV');
+                assertEquals('XYUPHWQRECHV', $params['actor-code']);
+            });
+
+        $this->ui->fillField('passcode', $code);
         $this->ui->fillField('reference_number', '700000000054');
         $this->ui->fillField('dob[day]', '05');
         $this->ui->fillField('dob[month]', '10');

--- a/service-front/app/src/Actor/src/Form/LpaAdd.php
+++ b/service-front/app/src/Actor/src/Form/LpaAdd.php
@@ -8,6 +8,7 @@ use Common\Form\AbstractForm;
 use Common\Form\Fieldset\Date;
 use Common\Form\Fieldset\DatePrefixFilter;
 use Common\Validator\DobValidator;
+use Laminas\Filter\StringToUpper;
 use Mezzio\Csrf\CsrfGuardInterface;
 use Laminas\Filter\StringTrim;
 use Laminas\InputFilter\InputFilterProviderInterface;
@@ -53,6 +54,7 @@ class LpaAdd extends AbstractForm implements InputFilterProviderInterface
             'passcode' => [
                 'filters'  => [
                     ['name' => StringTrim::class],
+                    ['name' => StringToUpper::class],
                 ],
                 'validators' => [
                     [


### PR DESCRIPTION
## Purpose
We are not treating codes as case-insensitive when looking them up to add LPAs.

(Partially) fixes [UML-621](https://opgtransform.atlassian.net/secure/RapidBoard.jspa?rapidView=149&projectKey=LPA&modal=detail&selectedIssue=UML-621)

## Approach

It changes the data access layer to uppercase codes before calling DynamoDB.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Refunds service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

