### PR TITLE
UML-673 - Create a cloudwatch alarm for viewer 5xx errors

### DIFF
--- a/terraform/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/cloudwatch_alarms.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_metric_alarm" "viewer_5xx_errors" {
-  actions_enabled = true
+  actions_enabled = false
   # alarm_actions       = [aws_sns_topic.cloudwatch_topic.arn]
   alarm_description   = "Number of 5XX Errors returned to viewer users for ${local.environment}"
   alarm_name          = "${local.environment}-viewer-5XX-errors"

--- a/terraform/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/cloudwatch_alarms.tf
@@ -19,3 +19,25 @@ resource "aws_cloudwatch_metric_alarm" "viewer_5xx_errors" {
   threshold          = 5
   treat_missing_data = "notBreaching"
 }
+
+resource "aws_cloudwatch_metric_alarm" "actor_5xx_errors" {
+  actions_enabled = false
+  # alarm_actions       = [aws_sns_topic.cloudwatch_topic.arn]
+  alarm_description   = "Number of 5XX Errors returned to actor users for ${local.environment}"
+  alarm_name          = "${local.environment}-actor-5XX-errors"
+  comparison_operator = "GreaterThanThreshold"
+  datapoints_to_alarm = 3
+  dimensions = {
+    "LoadBalancer" = trimprefix(split(":", aws_lb.actor.arn)[5], "loadbalancer/")
+  }
+  evaluation_periods        = 3
+  insufficient_data_actions = []
+  metric_name               = "HTTPCode_Target_5XX_Count"
+  namespace                 = "AWS/ApplicationELB"
+  # ok_actions                = [aws_sns_topic.cloudwatch_topic.arn]
+  period             = 60
+  statistic          = "Sum"
+  tags               = {}
+  threshold          = 5
+  treat_missing_data = "notBreaching"
+}

--- a/terraform/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/cloudwatch_alarms.tf
@@ -8,7 +8,7 @@ resource "aws_cloudwatch_metric_alarm" "viewer_5xx_errors" {
   dimensions = {
     "LoadBalancer" = trimprefix(split(":", aws_lb.viewer.arn)[5], "loadbalancer/")
   }
-  evaluation_periods        = 3
+  evaluation_periods        = 2
   insufficient_data_actions = []
   metric_name               = "HTTPCode_Target_5XX_Count"
   namespace                 = "AWS/ApplicationELB"
@@ -16,7 +16,7 @@ resource "aws_cloudwatch_metric_alarm" "viewer_5xx_errors" {
   period             = 60
   statistic          = "Sum"
   tags               = {}
-  threshold          = 5
+  threshold          = 3
   treat_missing_data = "notBreaching"
 }
 
@@ -30,7 +30,7 @@ resource "aws_cloudwatch_metric_alarm" "actor_5xx_errors" {
   dimensions = {
     "LoadBalancer" = trimprefix(split(":", aws_lb.actor.arn)[5], "loadbalancer/")
   }
-  evaluation_periods        = 3
+  evaluation_periods        = 2
   insufficient_data_actions = []
   metric_name               = "HTTPCode_Target_5XX_Count"
   namespace                 = "AWS/ApplicationELB"
@@ -38,6 +38,6 @@ resource "aws_cloudwatch_metric_alarm" "actor_5xx_errors" {
   period             = 60
   statistic          = "Sum"
   tags               = {}
-  threshold          = 5
+  threshold          = 3
   treat_missing_data = "notBreaching"
 }

--- a/terraform/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/cloudwatch_alarms.tf
@@ -1,0 +1,21 @@
+resource "aws_cloudwatch_metric_alarm" "viewer_5xx_errors" {
+  actions_enabled = true
+  # alarm_actions       = [aws_sns_topic.cloudwatch_topic.arn]
+  alarm_description   = "Number of 5XX Errors returned to viewer users for ${local.environment}"
+  alarm_name          = "${local.environment}-viewer-5XX-errors"
+  comparison_operator = "GreaterThanThreshold"
+  datapoints_to_alarm = 3
+  dimensions = {
+    "LoadBalancer" = trimprefix(split(":", aws_lb.viewer.arn)[5], "loadbalancer/")
+  }
+  evaluation_periods        = 3
+  insufficient_data_actions = []
+  metric_name               = "HTTPCode_Target_5XX_Count"
+  namespace                 = "AWS/ApplicationELB"
+  # ok_actions                = [aws_sns_topic.cloudwatch_topic.arn]
+  period             = 60
+  statistic          = "Sum"
+  tags               = {}
+  threshold          = 5
+  treat_missing_data = "notBreaching"
+}

--- a/terraform/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/cloudwatch_alarms.tf
@@ -4,7 +4,7 @@ resource "aws_cloudwatch_metric_alarm" "viewer_5xx_errors" {
   alarm_description   = "Number of 5XX Errors returned to viewer users for ${local.environment}"
   alarm_name          = "${local.environment}-viewer-5XX-errors"
   comparison_operator = "GreaterThanThreshold"
-  datapoints_to_alarm = 3
+  datapoints_to_alarm = 2
   dimensions = {
     "LoadBalancer" = trimprefix(split(":", aws_lb.viewer.arn)[5], "loadbalancer/")
   }
@@ -16,7 +16,7 @@ resource "aws_cloudwatch_metric_alarm" "viewer_5xx_errors" {
   period             = 60
   statistic          = "Sum"
   tags               = {}
-  threshold          = 3
+  threshold          = 2
   treat_missing_data = "notBreaching"
 }
 
@@ -26,7 +26,7 @@ resource "aws_cloudwatch_metric_alarm" "actor_5xx_errors" {
   alarm_description   = "Number of 5XX Errors returned to actor users for ${local.environment}"
   alarm_name          = "${local.environment}-actor-5XX-errors"
   comparison_operator = "GreaterThanThreshold"
-  datapoints_to_alarm = 3
+  datapoints_to_alarm = 2
   dimensions = {
     "LoadBalancer" = trimprefix(split(":", aws_lb.actor.arn)[5], "loadbalancer/")
   }
@@ -38,6 +38,6 @@ resource "aws_cloudwatch_metric_alarm" "actor_5xx_errors" {
   period             = 60
   statistic          = "Sum"
   tags               = {}
-  threshold          = 3
+  threshold          = 2
   treat_missing_data = "notBreaching"
 }


### PR DESCRIPTION
## Purpose
Monitor and alert team when there are 5xx errors being returned to users.

Fixes UML-673

## Approach

Use a cloudwatch metric alarm to monitor absolute values within a time window. This is preferable for this service over percentage of errors.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [x] The product team have tested these changes

