### PR TITLE
Add tests for disable button on click function

### DIFF
--- a/service-front/web/src/javascript/disableButtonOnClick.js
+++ b/service-front/web/src/javascript/disableButtonOnClick.js
@@ -1,14 +1,11 @@
 const disableButtonOnClick = (form) => {
-
   for (let i = 0; i < form.length; i++) {
-
-      form[i].addEventListener('click', function disableButton(e) {
-
-          if (e.target.nodeName == 'BUTTON' && e.target.getAttribute('data-prevent-double-click')) {
-              e.target.disabled = true;
-              document.forms[form[i].name].submit();
-          }
-      });
+    form[i].addEventListener('click', function disableButton(e) {
+      if (e.target.nodeName == 'BUTTON' && e.target.getAttribute('data-prevent-double-click')) {
+        e.target.disabled = true;
+        document.forms[form[i].name].submit();
+      }
+    });
   }
 };
 

--- a/service-front/web/src/javascript/disableButtonOnClick.test.js
+++ b/service-front/web/src/javascript/disableButtonOnClick.test.js
@@ -1,0 +1,42 @@
+import disableButtonOnClick from './disableButtonOnClick';
+
+describe('disableButtonOnClick', () => {
+  // jsdom doesn't implement form submission so this will keep it from showing errors in the console
+  window.HTMLFormElement.prototype.submit = () => {};
+
+  describe('without the attribute', () => {
+    test('clicking button will not disable it', () => {
+      document.body.innerHTML = `
+      <form name="test" onsubmit="return false">
+        <button type="submit">Click</button>
+      </form>
+    `;
+
+      disableButtonOnClick(document.getElementsByTagName('form'));
+
+      const button = document.querySelector('button');
+      expect(button.disabled).toBe(false);
+
+      button.click();
+      expect(button.disabled).toBe(false);
+    });
+  });
+
+  describe('with the attribute', () => {
+    test('clicking button will disable it', () => {
+      document.body.innerHTML = `
+      <form name="test" onsubmit="return false">
+        <button type="submit" data-prevent-double-click="true">Click</button>
+      </form>
+    `;
+
+      disableButtonOnClick(document.getElementsByTagName('form'));
+
+      const button = document.querySelector('button');
+      expect(button.disabled).toBe(false);
+
+      button.click();
+      expect(button.disabled).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
With the introduction of UML-446 we now need a way to test javascript related functionalities. ~Behat can do this but setup and configuration needs to happen so it can work in our environment.~

Fixes UML-549

## Approach

I've added a Jest test for the function that was added in UML-446. I know this ticket talked about setting up Behat to run the tests but I don't think that is workable without a lot of changes. Since the JavaScript lives in the `web` side and we have Behat set up on the `app` side, we'd probably want to run Behat at a different "level" for these tests (like the `features` folder?). 

I did get Selenium setup, running Behat tests, with the app spun up as you would for locally playing around. Using the `@javascript` tag to only run the single test I added worked. But I don't think it is worth it if all we are going to have is this one test, and it would still need working out how to do this in the CI pipeline. 


## Learning

- https://github.com/SeleniumHQ/docker-selenium
- https://mink.behat.org/en/latest/drivers/selenium2.html

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

