### PR TITLE
Call API Gateway Script Update

### DIFF
--- a/scripts/call-api-gateway/.envrc
+++ b/scripts/call-api-gateway/.envrc
@@ -1,5 +1,0 @@
-export AWS_ACCOUNT_ID=367815980639
-# export AWS_ACCOUNT_ID=690083044361
-export AWS_IAM_ROLE=operator
-export API_GATEWAY_URL="https://api.dev.sirius.opg.digital/v1/use-an-lpa/lpas/"
-export BASE_URL='https://frontend-integration.sirius.opg.digital'

--- a/scripts/call-api-gateway/.envrc
+++ b/scripts/call-api-gateway/.envrc
@@ -1,4 +1,5 @@
-export AWS_ACCOUNT_ID=288342028542
-export AWS_IAM_ROLE=sirius-api-gateway-access-use-an-lpa
+export AWS_ACCOUNT_ID=367815980639
+# export AWS_ACCOUNT_ID=690083044361
+export AWS_IAM_ROLE=operator
 export API_GATEWAY_URL="https://api.dev.sirius.opg.digital/v1/use-an-lpa/lpas/"
 export BASE_URL='https://frontend-integration.sirius.opg.digital'

--- a/scripts/call-api-gateway/README.md
+++ b/scripts/call-api-gateway/README.md
@@ -1,24 +1,21 @@
-# call api gateway
+# Call the Sirius API gateway
 
 This script returns case data for a Sirius case ID.
 
-It makes an authenticated request to the sirius api gateway. 
+It makes an authenticated request to the Sirius API gateway.
 
-The script reads account id, iam role and apigateway url from environment variables.
+The script uses your IAM user credentials to assume the appropriate role, and by default will query the development Sirius API Gateway. The `--production` flag can be used to request a result from the production Sirius API Gateway.
 
-You can set these using direnv
-```bash
-direnv allow
-```
- or by sourcing the .envrc file
-```bash
-source .envrc
-```
+You can provide the script credentials using [aws-vault](https://github.com/99designs/aws-vault)
 
-The script uses your IAM user credentials to assume the appropriate role.
-
-You can provide the script credentials using aws-vault
+Call the development gateway
 
 ```bash
 aws-vault exec identity -- python ./call_api_gateway.py 700000000000
+```
+
+Call the production gateway
+
+```bash
+aws-vault exec identity -- python ./call_api_gateway.py 700000000000 --production
 ```


### PR DESCRIPTION
## Purpose
The Sirius API Gateway IAM policies have been updated to allow UaL operator roles to execute requests. 

This means that individuals no longer have to assume the out of pattern `sirius-api-gateway-access-use-an-lpa role`, and permission to use the gateway is set up when new members are onboarded into the team.

To support this the IAM role and AWS account id used by the call-api-gateway script are updated and brought inside the script.

## Approach

Update script to choose endpoint to call and role to assume using an argument flag.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [x] The product team have tested these changes

