### PR TITLE
Handle dashboard status check when actor is the donor

### DIFF
--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -94,6 +94,15 @@ class AccountContext implements Context
     }
 
     /**
+     * @Given /^I am the donor$/
+     */
+    public function iAmTheDonor()
+    {
+        $this->lpaData['actor']['type'] = 'donor';
+        unset($this->lpaData['actor']['details']['systemStatus']);
+    }
+
+    /**
      * @Given /^I am inactive against the LPA on my account$/
      */
     public function iAmInactiveAgainstTheLpaOnMyAccount()

--- a/service-front/app/features/donor-dashboard.feature
+++ b/service-front/app/features/donor-dashboard.feature
@@ -1,0 +1,29 @@
+@actor @donorDashboard
+Feature: The user is able to see correct information on their dashboard
+  As a user
+  I want to be able to see any LPA's I have added on my dashboard
+  So that I can see their details and perform actions on them
+
+  Background:
+    Given I am a user of the lpa application
+    And I am currently signed in
+    And I have added an LPA to my account
+    And I am the donor
+
+  @ui
+  Scenario Outline: As a user I can see the number of active access codes an LPA has
+    Given I have 2 codes for one of my LPAs
+    When I am on the dashboard page
+    Then I can see that my LPA has <noActiveCodes> with expiry dates <code1Expiry> <code2Expiry>
+
+    Examples:
+      | noActiveCodes                | code1Expiry                | code2Expiry               |
+      | 2 active codes               |  2021-04-01T23:59:59+01:00 | 2021-04-01T23:59:59+01:00 |
+      | 1 active code                |  2019-01-05T23:59:59+00:00 | 2022-01-05T23:59:59+00:00 |
+      | No organisations have access |  2019-01-05T23:59:59+00:00 | 2019-01-05T23:59:59+00:00 |
+
+  @ui
+  Scenario: As a user I can see the number of active access codes an LPA has
+    Given I have added an LPA to my account
+    When I am on the dashboard page
+    Then I can see that no organisations have access to my LPA

--- a/service-front/app/src/Actor/src/Handler/LpaDashboardHandler.php
+++ b/service-front/app/src/Actor/src/Handler/LpaDashboardHandler.php
@@ -80,7 +80,7 @@ class LpaDashboardHandler extends AbstractHandler implements UserAware
             );
 
             $lpas[$lpaKey]['activeCodeCount'] = $shareCodes['activeCodeCount'];
-            $lpas[$lpaKey]['actorActive'] = $lpaData['actor']['details']->getSystemStatus();
+            $lpas[$lpaKey]['actorActive'] = $lpaData['actor']['type'] === 'donor' || $lpaData['actor']['details']->getSystemStatus();
         }
 
         return new HtmlResponse($this->renderer->render('actor::lpa-dashboard', [

--- a/test-data/api-gateway.json
+++ b/test-data/api-gateway.json
@@ -27,8 +27,7 @@
           "addressLine3": ""
         }
       ],
-      "companyName": null,
-      "systemStatus": true
+      "companyName": null
     },
     "applicationType": "Classic",
     "caseSubtype": "pfa",
@@ -152,8 +151,7 @@
           "addressLine3": ""
         }
       ],
-      "companyName": null,
-      "systemStatus": true
+      "companyName": null
     },
     "applicationType": "Classic",
     "caseSubtype": "pfa",
@@ -252,8 +250,7 @@
           "addressLine3": ""
         }
       ],
-      "companyName": null,
-      "systemStatus": true
+      "companyName": null
     },
     "applicationType": "Classic",
     "caseSubtype": "pfa",
@@ -401,8 +398,7 @@
           "addressLine3": ""
         }
       ],
-      "companyName": null,
-      "systemStatus": true
+      "companyName": null
     },
     "applicationType": "Classic",
     "caseSubtype": "pfa",
@@ -501,8 +497,7 @@
           "addressLine3": ""
         }
       ],
-      "companyName": null,
-      "systemStatus": true
+      "companyName": null
     },
     "applicationType": "Classic",
     "caseSubtype": "pfa",
@@ -601,8 +596,7 @@
           "addressLine3": ""
         }
       ],
-      "companyName": null,
-      "systemStatus": true
+      "companyName": null
     },
     "applicationType": "Classic",
     "caseSubtype": "pfa",
@@ -701,8 +695,7 @@
           "addressLine3": ""
         }
       ],
-      "companyName": null,
-      "systemStatus": true
+      "companyName": null
     },
     "applicationType": "Classic",
     "caseSubtype": "pfa",


### PR DESCRIPTION
## Purpose

Fix donors who added LPAs being able to see the dashboard. 

Fixes UML-679

## Approach

The response for a donor doesn't seem to include `systemStatus`, which was naively being checked to see if the actor was active. I've changed it to check whether the actor is a donor first.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Refunds service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

