### PR TITLE
split circle ci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,202 +19,197 @@ workflows:
           requires: [redeploy_demo]
 
   pr_build:
-    jobs:
-      # Common tasks
-      - use-my-lpa/lint_terraform:
-          name: lint_terraform
-          filters: { branches: { ignore: [master] } }
+    filters: { branches: { ignore: [master] } }
+      jobs:
+        # Common tasks
+        - use-my-lpa/lint_terraform:
+            name: lint_terraform
 
-      - use-my-lpa/node_test_web:
-          name: test_web
-      - use-my-lpa/node_build_web:
-          name: build_web
-          requires: [test_web]
-      - use-my-lpa/node_test_service_pdf:
-          name: test_pdf
+        - use-my-lpa/node_test_web:
+            name: test_web
+        - use-my-lpa/node_build_web:
+            name: build_web
+            requires: [test_web]
+        - use-my-lpa/node_test_service_pdf:
+            name: test_pdf
 
-      - use-my-lpa/docker_build_front_app:
-          name: app_front_build
-          requires: [build_web]
-      - use-my-lpa/docker_build_front_web:
-          name: web_front_build
-          requires: [build_web]
+        - use-my-lpa/docker_build_front_app:
+            name: app_front_build
+            requires: [build_web]
 
-      - use-my-lpa/docker_build_api_app:
-          name: app_api_build
-      - use-my-lpa/docker_build_api_web:
-          name: web_api_build
+        - use-my-lpa/docker_build_front_web:
+            name: web_front_build
+            requires: [build_web]
 
-      - use-my-lpa/docker_build_pdf:
-          name: pdf_build
-          requires: [test_pdf]
+        - use-my-lpa/docker_build_api_app:
+            name: app_api_build
+        - use-my-lpa/docker_build_api_web:
+            name: web_api_build
 
-      - use-my-lpa/coveralls_upload:
-          name: coveralls_upload
-          requires:
-            [app_front_build, app_api_build, test_web, test_pdf]
+        - use-my-lpa/docker_build_pdf:
+            name: pdf_build
+            requires: [test_pdf]
 
-          # Provision and test development
-      - use-my-lpa/apply_shared_terraform:
-          name: dev_apply_shared_terraform
-          filters: { branches: { ignore: [master] } }
-          requires: [lint_terraform]
+        - use-my-lpa/coveralls_upload:
+            name: coveralls_upload
+            requires:
+              [app_front_build, app_api_build, test_web, test_pdf]
 
-      - use-my-lpa/apply_environment_terraform:
-          name: dev_apply_environment_terraform
-          filters: { branches: { ignore: [master] } }
-          requires:
-            [
-              dev_apply_shared_terraform,
-              app_front_build,
-              web_front_build,
-              web_api_build,
-              app_api_build,
-              pdf_build,
-            ]
+            # Provision and test development
+        - use-my-lpa/apply_shared_terraform:
+            name: dev_apply_shared_terraform
+            requires: [lint_terraform]
 
-      - ecr_scan_results:
-          name: ecr_scan_results_development
-          filters: { branches: { ignore: [master] } }
-          requires:
-            [
-              app_front_build,
-              web_front_build,
-              web_api_build,
-              app_api_build,
-              pdf_build,
-              dev_apply_environment_terraform,
-            ]
+        - use-my-lpa/apply_environment_terraform:
+            name: dev_apply_environment_terraform
+            requires:
+              [
+                dev_apply_shared_terraform,
+                app_front_build,
+                web_front_build,
+                web_api_build,
+                app_api_build,
+                pdf_build,
+              ]
 
-      - use-my-lpa/seed_database:
-          name: dev_seed_database
-          filters: { branches: { ignore: [master] } }
-          requires: [dev_apply_environment_terraform]
+        - ecr_scan_results:
+            name: ecr_scan_results_development
+            requires:
+              [
+                app_front_build,
+                web_front_build,
+                web_api_build,
+                app_api_build,
+                pdf_build,
+                dev_apply_environment_terraform,
+              ]
 
-      - use-my-lpa/run_behave_suite:
-          name: dev_run_behave_tests
-          filters: { branches: { ignore: [master] } }
-          requires: [dev_seed_database]
+        - use-my-lpa/seed_database:
+            name: dev_seed_database
+            requires: [dev_apply_environment_terraform]
 
-      - slack_notify_domain:
-          name: post_environment_domains
-          filters: { branches: { ignore: [master] } }
-          requires: [dev_run_behave_tests]
+        - use-my-lpa/run_behave_suite:
+            name: dev_run_behave_tests
+            requires: [dev_seed_database]
 
-      - hold-for-destruction:
-          name: hold_env_for_destruction
-          type: approval
-          filters: { branches: { ignore: [master] } }
-          requires: [dev_run_behave_tests]
+        - slack_notify_domain:
+            name: post_environment_domains
+            requires: [dev_run_behave_tests]
 
-      - use-my-lpa/destroy_dev_environment:
-          name: dev_destroy_environment
-          filters: { branches: { ignore: [master] } }
-          requires: [hold_env_for_destruction]
+        - hold-for-destruction:
+            name: hold_env_for_destruction
+            type: approval
+            requires: [dev_run_behave_tests]
+
+        - use-my-lpa/destroy_dev_environment:
+            name: dev_destroy_environment
+            requires: [hold_env_for_destruction]
+
 
   path_to_live:
-    jobs:
-      # Common tasks
-      - use-my-lpa/node_test_web:
-          name: test_web
-      - use-my-lpa/node_build_web:
-          name: build_web
-          requires: [test_web]
-      - use-my-lpa/node_test_service_pdf:
-          name: test_pdf
+    filters: { branches: { only: [master] } }
+      jobs:
+        # Common tasks
+        - use-my-lpa/node_test_web:
+            name: test_web
+        - use-my-lpa/node_build_web:
+            name: build_web
+            requires: [test_web]
+        - use-my-lpa/node_test_service_pdf:
+            name: test_pdf
 
-      - use-my-lpa/docker_build_front_app:
-          name: app_front_build
-          requires: [build_web]
-      - use-my-lpa/docker_build_front_web:
-          name: web_front_build
-          requires: [build_web]
+        - use-my-lpa/docker_build_front_app:
+            name: app_front_build
+            requires: [build_web]
+        - use-my-lpa/docker_build_front_web:
+            name: web_front_build
+            requires: [build_web]
 
-      - use-my-lpa/docker_build_api_app:
-          name: app_api_build
-      - use-my-lpa/docker_build_api_web:
-          name: web_api_build
+        - use-my-lpa/docker_build_api_app:
+            name: app_api_build
+        - use-my-lpa/docker_build_api_web:
+            name: web_api_build
 
-      - use-my-lpa/docker_build_pdf:
-          name: pdf_build
-          requires: [test_pdf]
+        - use-my-lpa/docker_build_pdf:
+            name: pdf_build
+            requires: [test_pdf]
 
-      - use-my-lpa/coveralls_upload:
-          name: coveralls_upload
-          requires:
-            [app_front_build, app_api_build, test_web, test_pdf]
+        - use-my-lpa/coveralls_upload:
+            name: coveralls_upload
+            requires:
+              [app_front_build, app_api_build, test_web, test_pdf]
 
-      # Provision and test preproduction
-      - use-my-lpa/apply_shared_terraform:
-          name: preprod_apply_shared_terraform
-          workspace: preproduction
-          filters: { branches: { only: [master] } }
+        # Provision and test preproduction
+        - use-my-lpa/apply_shared_terraform:
+            name: preprod_apply_shared_terraform
+            workspace: preproduction
+            filters: { branches: { only: [master] } }
 
-      - use-my-lpa/apply_environment_terraform:
-          name: preprod_apply_environment_terraform
-          workspace: preproduction
-          filters: { branches: { only: [master] } }
-          requires:
-            [
-              preprod_apply_shared_terraform,
-              app_front_build,
-              web_front_build,
-              web_api_build,
-              app_api_build,
-            ]
-      - ecr_scan_results:
-          name: ecr_scan_results_master
-          filters: { branches: { only: [master] } }
-          requires:
-            [
-              app_front_build,
-              web_front_build,
-              web_api_build,
-              app_api_build,
-              pdf_build,
-              preprod_apply_environment_terraform,
-            ]
+        - use-my-lpa/apply_environment_terraform:
+            name: preprod_apply_environment_terraform
+            workspace: preproduction
+            filters: { branches: { only: [master] } }
+            requires:
+              [
+                preprod_apply_shared_terraform,
+                app_front_build,
+                web_front_build,
+                web_api_build,
+                app_api_build,
+              ]
+        - ecr_scan_results:
+            name: ecr_scan_results_master
+            filters: { branches: { only: [master] } }
+            requires:
+              [
+                app_front_build,
+                web_front_build,
+                web_api_build,
+                app_api_build,
+                pdf_build,
+                preprod_apply_environment_terraform,
+              ]
 
-      - use-my-lpa/seed_database:
-          name: preprod_seed_database
-          #workspace: preproduction   # Not needed as the target account is within the config file.
-          filters: { branches: { only: [master] } }
-          requires: [preprod_apply_environment_terraform]
+        - use-my-lpa/seed_database:
+            name: preprod_seed_database
+            #workspace: preproduction   # Not needed as the target account is within the config file.
+            filters: { branches: { only: [master] } }
+            requires: [preprod_apply_environment_terraform]
 
-      - use-my-lpa/run_behave_suite:
-          name: preprod_run_behave_tests
-          workspace: preproduction
-          filters: { branches: { only: [master] } }
-          requires: [preprod_seed_database]
+        - use-my-lpa/run_behave_suite:
+            name: preprod_run_behave_tests
+            workspace: preproduction
+            filters: { branches: { only: [master] } }
+            requires: [preprod_seed_database]
 
-      # Provision and test production
-      - use-my-lpa/apply_shared_terraform:
-          name: production_apply_shared_terraform
-          workspace: production
-          filters: { branches: { only: [master] } }
-          requires: [preprod_run_behave_tests]
-      - use-my-lpa/apply_environment_terraform:
-          name: production_apply_environment_terraform
-          workspace: production
-          filters: { branches: { only: [master] } }
-          requires:
-            [
-              production_apply_shared_terraform,
-              app_front_build,
-              web_front_build,
-              web_api_build,
-              app_api_build,
-            ]
+        # Provision and test production
+        - use-my-lpa/apply_shared_terraform:
+            name: production_apply_shared_terraform
+            workspace: production
+            filters: { branches: { only: [master] } }
+            requires: [preprod_run_behave_tests]
+        - use-my-lpa/apply_environment_terraform:
+            name: production_apply_environment_terraform
+            workspace: production
+            filters: { branches: { only: [master] } }
+            requires:
+              [
+                production_apply_shared_terraform,
+                app_front_build,
+                web_front_build,
+                web_api_build,
+                app_api_build,
+              ]
 
-      - use-my-lpa/run_healthcheck_test:
-          name: prod_run_healthcheck_test
-          filters: { branches: { only: [master] } }
-          requires: [production_apply_environment_terraform]
+        - use-my-lpa/run_healthcheck_test:
+            name: prod_run_healthcheck_test
+            filters: { branches: { only: [master] } }
+            requires: [production_apply_environment_terraform]
 
-      - slack_notify_production_release:
-          name: post_production_release_message
-          filters: { branches: { only: [master] } }
-          requires: [prod_run_healthcheck_test]
+        - slack_notify_production_release:
+            name: post_production_release_message
+            filters: { branches: { only: [master] } }
+            requires: [prod_run_healthcheck_test]
 
 
 orbs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ workflows:
           environment: demo
           requires: [redeploy_demo]
 
+
   pr_build:
       jobs:
         # Common tasks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,219 +23,219 @@ workflows:
       jobs:
         # Common tasks
         - use-my-lpa/lint_terraform:
-            name: lint_terraform
+            name: lint_terraform_pr_build
             filters: { branches: { ignore: [master] } }
 
         - use-my-lpa/node_test_web:
-            name: test_web
+            name: test_web_pr_build
             filters: { branches: { ignore: [master] } }
         - use-my-lpa/node_build_web:
-            name: build_web
+            name: build_web_pr_build
             filters: { branches: { ignore: [master] } }
-            requires: [test_web]
+            requires: [test_web_pr_build]
         - use-my-lpa/node_test_service_pdf:
-            name: test_pdf
+            name: test_pdf_pr_build
             filters: { branches: { ignore: [master] } }
 
         - use-my-lpa/docker_build_front_app:
-            name: app_front_build
+            name: app_front_build_pr_build
             filters: { branches: { ignore: [master] } }
-            requires: [build_web]
+            requires: [build_web_pr_build]
 
         - use-my-lpa/docker_build_front_web:
-            name: web_front_build
+            name: web_front_build_pr_build
             filters: { branches: { ignore: [master] } }
-            requires: [build_web]
+            requires: [build_web_pr_build]
 
         - use-my-lpa/docker_build_api_app:
-            name: app_api_build
+            name: app_api_build_pr_build
             filters: { branches: { ignore: [master] } }
         - use-my-lpa/docker_build_api_web:
-            name: web_api_build
+            name: web_api_build_pr_build
             filters: { branches: { ignore: [master] } }
 
         - use-my-lpa/docker_build_pdf:
-            name: pdf_build
+            name: pdf_build_pr_build
             filters: { branches: { ignore: [master] } }
-            requires: [test_pdf]
+            requires: [test_pdf_pr_build]
 
         - use-my-lpa/coveralls_upload:
-            name: coveralls_upload
+            name: coveralls_upload_pr_build
             filters: { branches: { ignore: [master] } }
             requires:
-              [app_front_build, app_api_build, test_web, test_pdf]
+              [app_front_build_pr_build, app_api_build_pr_build, test_web_pr_build, test_pdf_pr_build]
 
             # Provision and test development
         - use-my-lpa/apply_shared_terraform:
-            name: dev_apply_shared_terraform
+            name: dev_apply_shared_terraform_pr_build
             filters: { branches: { ignore: [master] } }
-            requires: [lint_terraform]
+            requires: [lint_terraform_pr_build]
 
         - use-my-lpa/apply_environment_terraform:
-            name: dev_apply_environment_terraform
+            name: dev_apply_environment_terraform_pr_build
             filters: { branches: { ignore: [master] } }
             requires:
               [
-                dev_apply_shared_terraform,
-                app_front_build,
-                web_front_build,
-                web_api_build,
-                app_api_build,
-                pdf_build,
+                dev_apply_shared_terraform_pr_build,
+                app_front_build_pr_build,
+                web_front_build_pr_build,
+                web_api_build_pr_build,
+                app_api_build_pr_build,
+                pdf_build_pr_build,
               ]
 
         - ecr_scan_results:
-            name: ecr_scan_results_development
+            name: ecr_scan_results_development_pr_build
             filters: { branches: { ignore: [master] } }
             requires:
               [
-                app_front_build,
-                web_front_build,
-                web_api_build,
-                app_api_build,
-                pdf_build,
-                dev_apply_environment_terraform,
+                app_front_build_pr_build,
+                web_front_build_pr_build,
+                web_api_build_pr_build,
+                app_api_build_pr_build,
+                pdf_build_pr_build,
+                dev_apply_environment_terraform_pr_build,
               ]
 
         - use-my-lpa/seed_database:
-            name: dev_seed_database
+            name: dev_seed_database_pr_build
             filters: { branches: { ignore: [master] } }
-            requires: [dev_apply_environment_terraform]
+            requires: [dev_apply_environment_terraform_pr_build]
 
         - use-my-lpa/run_behave_suite:
-            name: dev_run_behave_tests
+            name: dev_run_behave_tests_pr_build
             filters: { branches: { ignore: [master] } }
-            requires: [dev_seed_database]
+            requires: [dev_seed_database_pr_build]
 
         - slack_notify_domain:
-            name: post_environment_domains
+            name: post_environment_domains_pr_build
             filters: { branches: { ignore: [master] } }
-            requires: [dev_run_behave_tests]
+            requires: [dev_run_behave_tests_pr_build]
 
         - hold-for-destruction:
-            name: hold_env_for_destruction
+            name: hold_env_for_destruction_pr_build
             filters: { branches: { ignore: [master] } }
             type: approval
-            requires: [dev_run_behave_tests]
+            requires: [dev_run_behave_tests_pr_build]
 
         - use-my-lpa/destroy_dev_environment:
-            name: dev_destroy_environment
+            name: dev_destroy_environment_pr_build
             filters: { branches: { ignore: [master] } }
-            requires: [hold_env_for_destruction]
+            requires: [hold_env_for_destruction_pr_build]
 
 
   path_to_live:
       jobs:
         # Common tasks
         - use-my-lpa/node_test_web:
-            name: test_web
+            name: test_web_path_to_live
             filters: { branches: { only: [master] } }
         - use-my-lpa/node_build_web:
-            name: build_web
+            name: build_web_path_to_live
             filters: { branches: { only: [master] } }
-            requires: [test_web]
+            requires: [test_web_path_to_live]
         - use-my-lpa/node_test_service_pdf:
-            name: test_pdf
+            name: test_pdf_path_to_live
             filters: { branches: { only: [master] } }
 
         - use-my-lpa/docker_build_front_app:
-            name: app_front_build
+            name: app_front_build_path_to_live
             filters: { branches: { only: [master] } }
-            requires: [build_web]
+            requires: [build_web_path_to_live]
         - use-my-lpa/docker_build_front_web:
-            name: web_front_build
+            name: web_front_build_path_to_live
             filters: { branches: { only: [master] } }
-            requires: [build_web]
+            requires: [build_web_path_to_live]
 
         - use-my-lpa/docker_build_api_app:
-            name: app_api_build
+            name: app_api_build_path_to_live
             filters: { branches: { only: [master] } }
         - use-my-lpa/docker_build_api_web:
-            name: web_api_build
+            name: web_api_build_path_to_live
             filters: { branches: { only: [master] } }
 
         - use-my-lpa/docker_build_pdf:
-            name: pdf_build
+            name: pdf_build_path_to_live
             filters: { branches: { only: [master] } }
-            requires: [test_pdf]
+            requires: [test_pdf_path_to_live]
 
         - use-my-lpa/coveralls_upload:
-            name: coveralls_upload
+            name: coveralls_upload_path_to_live
             filters: { branches: { only: [master] } }
             requires:
-              [app_front_build, app_api_build, test_web, test_pdf]
+              [app_front_build_path_to_live, app_api_build_path_to_live, test_web_path_to_live, test_pdf_path_to_live]
 
         # Provision and test preproduction
         - use-my-lpa/apply_shared_terraform:
-            name: preprod_apply_shared_terraform
+            name: preprod_apply_shared_terraform_path_to_live
             workspace: preproduction
             filters: { branches: { only: [master] } }
 
         - use-my-lpa/apply_environment_terraform:
-            name: preprod_apply_environment_terraform
+            name: preprod_apply_environment_terraform_path_to_live
             workspace: preproduction
             filters: { branches: { only: [master] } }
             requires:
               [
-                preprod_apply_shared_terraform,
-                app_front_build,
-                web_front_build,
-                web_api_build,
-                app_api_build,
+                preprod_apply_shared_terraform_path_to_live,
+                app_front_build_path_to_live,
+                web_front_build_path_to_live,
+                web_api_build_path_to_live,
+                app_api_build_path_to_live,
               ]
         - ecr_scan_results:
-            name: ecr_scan_results_master
+            name: ecr_scan_results_master_path_to_live
             filters: { branches: { only: [master] } }
             requires:
               [
-                app_front_build,
-                web_front_build,
-                web_api_build,
-                app_api_build,
-                pdf_build,
-                preprod_apply_environment_terraform,
+                app_front_build_path_to_live,
+                web_front_build_path_to_live,
+                web_api_build_path_to_live,
+                app_api_build_path_to_live,
+                pdf_build_path_to_live,
+                preprod_apply_environment_terraform_path_to_live,
               ]
 
         - use-my-lpa/seed_database:
-            name: preprod_seed_database
+            name: preprod_seed_database_path_to_live
             #workspace: preproduction   # Not needed as the target account is within the config file.
             filters: { branches: { only: [master] } }
-            requires: [preprod_apply_environment_terraform]
+            requires: [preprod_apply_environment_terraform_path_to_live]
 
         - use-my-lpa/run_behave_suite:
-            name: preprod_run_behave_tests
+            name: preprod_run_behave_tests_path_to_live
             workspace: preproduction
             filters: { branches: { only: [master] } }
-            requires: [preprod_seed_database]
+            requires: [preprod_seed_database_path_to_live]
 
         # Provision and test production
         - use-my-lpa/apply_shared_terraform:
-            name: production_apply_shared_terraform
+            name: production_apply_shared_terraform_path_to_live
             workspace: production
             filters: { branches: { only: [master] } }
-            requires: [preprod_run_behave_tests]
+            requires: [preprod_run_behave_tests_path_to_live]
         - use-my-lpa/apply_environment_terraform:
-            name: production_apply_environment_terraform
+            name: production_apply_environment_terraform_path_to_live
             workspace: production
             filters: { branches: { only: [master] } }
             requires:
               [
-                production_apply_shared_terraform,
-                app_front_build,
-                web_front_build,
-                web_api_build,
-                app_api_build,
+                production_apply_shared_terraform_path_to_live,
+                app_front_build_path_to_live,
+                web_front_build_path_to_live,
+                web_api_build_path_to_live,
+                app_api_build_path_to_live,
               ]
 
         - use-my-lpa/run_healthcheck_test:
-            name: prod_run_healthcheck_test
+            name: prod_run_healthcheck_test_path_to_live
             filters: { branches: { only: [master] } }
-            requires: [production_apply_environment_terraform]
+            requires: [production_apply_environment_terraform_path_to_live]
 
         - slack_notify_production_release:
-            name: post_production_release_message
+            name: post_production_release_message_path_to_live
             filters: { branches: { only: [master] } }
-            requires: [prod_run_healthcheck_test]
+            requires: [prod_run_healthcheck_test_path_to_live]
 
 
 orbs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,16 +67,16 @@ workflows:
 
             # Provision and test development
         - use-my-lpa/apply_shared_terraform:
-            name: dev_apply_shared_terraform_pr_build
+            name: dev_apply_shared_terraform
             filters: { branches: { ignore: [master] } }
             requires: [lint_terraform_pr_build]
 
         - use-my-lpa/apply_environment_terraform:
-            name: dev_apply_environment_terraform_pr_build
+            name: dev_apply_environment_terraform
             filters: { branches: { ignore: [master] } }
             requires:
               [
-                dev_apply_shared_terraform_pr_build,
+                dev_apply_shared_terraform
                 app_front_build_pr_build,
                 web_front_build_pr_build,
                 web_api_build_pr_build,
@@ -85,7 +85,7 @@ workflows:
               ]
 
         - ecr_scan_results:
-            name: ecr_scan_results_development_pr_build
+            name: ecr_scan_results_development
             filters: { branches: { ignore: [master] } }
             requires:
               [
@@ -94,34 +94,34 @@ workflows:
                 web_api_build_pr_build,
                 app_api_build_pr_build,
                 pdf_build_pr_build,
-                dev_apply_environment_terraform_pr_build,
+                dev_apply_environment_terraform,
               ]
 
         - use-my-lpa/seed_database:
-            name: dev_seed_database_pr_build
+            name: dev_seed_database
             filters: { branches: { ignore: [master] } }
-            requires: [dev_apply_environment_terraform_pr_build]
+            requires: [dev_apply_environment_terraform]
 
         - use-my-lpa/run_behave_suite:
-            name: dev_run_behave_tests_pr_build
+            name: dev_run_behave_tests
             filters: { branches: { ignore: [master] } }
-            requires: [dev_seed_database_pr_build]
+            requires: [dev_seed_database]
 
         - slack_notify_domain:
-            name: post_environment_domains_pr_build
+            name: post_environment_domains
             filters: { branches: { ignore: [master] } }
-            requires: [dev_run_behave_tests_pr_build]
+            requires: [dev_run_behave_tests]
 
         - hold-for-destruction:
-            name: hold_env_for_destruction_pr_build
+            name: hold_env_for_destruction
             filters: { branches: { ignore: [master] } }
             type: approval
-            requires: [dev_run_behave_tests_pr_build]
+            requires: [dev_run_behave_tests]
 
         - use-my-lpa/destroy_dev_environment:
-            name: dev_destroy_environment_pr_build
+            name: dev_destroy_environment
             filters: { branches: { ignore: [master] } }
-            requires: [hold_env_for_destruction_pr_build]
+            requires: [hold_env_for_destruction]
 
 
   path_to_live:
@@ -182,6 +182,7 @@ workflows:
                 web_front_build_path_to_live,
                 web_api_build_path_to_live,
                 app_api_build_path_to_live,
+                pdf_build_path_to_live,
               ]
         - ecr_scan_results:
             name: ecr_scan_results_master_path_to_live
@@ -210,32 +211,33 @@ workflows:
 
         # Provision and test production
         - use-my-lpa/apply_shared_terraform:
-            name: production_apply_shared_terraform_path_to_live
+            name: production_apply_shared_terraform
             workspace: production
             filters: { branches: { only: [master] } }
             requires: [preprod_run_behave_tests_path_to_live]
         - use-my-lpa/apply_environment_terraform:
-            name: production_apply_environment_terraform_path_to_live
+            name: production_apply_environment_terraform
             workspace: production
             filters: { branches: { only: [master] } }
             requires:
               [
-                production_apply_shared_terraform_path_to_live,
+                production_apply_shared_terraform,
                 app_front_build_path_to_live,
                 web_front_build_path_to_live,
                 web_api_build_path_to_live,
                 app_api_build_path_to_live,
+                pdf_build_path_to_live,
               ]
 
         - use-my-lpa/run_healthcheck_test:
-            name: prod_run_healthcheck_test_path_to_live
+            name: prod_run_healthcheck_test
             filters: { branches: { only: [master] } }
-            requires: [production_apply_environment_terraform_path_to_live]
+            requires: [production_apply_environment_terraform]
 
         - slack_notify_production_release:
-            name: post_production_release_message_path_to_live
+            name: post_production_release_message
             filters: { branches: { only: [master] } }
-            requires: [prod_run_healthcheck_test_path_to_live]
+            requires: [prod_run_healthcheck_test]
 
 
 orbs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,49 +19,60 @@ workflows:
           requires: [redeploy_demo]
 
   pr_build:
-    filters: { branches: { ignore: [master] } }
       jobs:
         # Common tasks
         - use-my-lpa/lint_terraform:
             name: lint_terraform
+            filters: { branches: { ignore: [master] } }
 
         - use-my-lpa/node_test_web:
             name: test_web
+            filters: { branches: { ignore: [master] } }
         - use-my-lpa/node_build_web:
             name: build_web
+            filters: { branches: { ignore: [master] } }
             requires: [test_web]
         - use-my-lpa/node_test_service_pdf:
             name: test_pdf
+            filters: { branches: { ignore: [master] } }
 
         - use-my-lpa/docker_build_front_app:
             name: app_front_build
+            filters: { branches: { ignore: [master] } }
             requires: [build_web]
 
         - use-my-lpa/docker_build_front_web:
             name: web_front_build
+            filters: { branches: { ignore: [master] } }
             requires: [build_web]
 
         - use-my-lpa/docker_build_api_app:
             name: app_api_build
+            filters: { branches: { ignore: [master] } }
         - use-my-lpa/docker_build_api_web:
             name: web_api_build
+            filters: { branches: { ignore: [master] } }
 
         - use-my-lpa/docker_build_pdf:
             name: pdf_build
+            filters: { branches: { ignore: [master] } }
             requires: [test_pdf]
 
         - use-my-lpa/coveralls_upload:
             name: coveralls_upload
+            filters: { branches: { ignore: [master] } }
             requires:
               [app_front_build, app_api_build, test_web, test_pdf]
 
             # Provision and test development
         - use-my-lpa/apply_shared_terraform:
             name: dev_apply_shared_terraform
+            filters: { branches: { ignore: [master] } }
             requires: [lint_terraform]
 
         - use-my-lpa/apply_environment_terraform:
             name: dev_apply_environment_terraform
+            filters: { branches: { ignore: [master] } }
             requires:
               [
                 dev_apply_shared_terraform,
@@ -74,6 +85,7 @@ workflows:
 
         - ecr_scan_results:
             name: ecr_scan_results_development
+            filters: { branches: { ignore: [master] } }
             requires:
               [
                 app_front_build,
@@ -86,56 +98,69 @@ workflows:
 
         - use-my-lpa/seed_database:
             name: dev_seed_database
+            filters: { branches: { ignore: [master] } }
             requires: [dev_apply_environment_terraform]
 
         - use-my-lpa/run_behave_suite:
             name: dev_run_behave_tests
+            filters: { branches: { ignore: [master] } }
             requires: [dev_seed_database]
 
         - slack_notify_domain:
             name: post_environment_domains
+            filters: { branches: { ignore: [master] } }
             requires: [dev_run_behave_tests]
 
         - hold-for-destruction:
             name: hold_env_for_destruction
+            filters: { branches: { ignore: [master] } }
             type: approval
             requires: [dev_run_behave_tests]
 
         - use-my-lpa/destroy_dev_environment:
             name: dev_destroy_environment
+            filters: { branches: { ignore: [master] } }
             requires: [hold_env_for_destruction]
 
 
   path_to_live:
-    filters: { branches: { only: [master] } }
       jobs:
         # Common tasks
         - use-my-lpa/node_test_web:
             name: test_web
+            filters: { branches: { only: [master] } }
         - use-my-lpa/node_build_web:
             name: build_web
+            filters: { branches: { only: [master] } }
             requires: [test_web]
         - use-my-lpa/node_test_service_pdf:
             name: test_pdf
+            filters: { branches: { only: [master] } }
 
         - use-my-lpa/docker_build_front_app:
             name: app_front_build
+            filters: { branches: { only: [master] } }
             requires: [build_web]
         - use-my-lpa/docker_build_front_web:
             name: web_front_build
+            filters: { branches: { only: [master] } }
             requires: [build_web]
 
         - use-my-lpa/docker_build_api_app:
             name: app_api_build
+            filters: { branches: { only: [master] } }
         - use-my-lpa/docker_build_api_web:
             name: web_api_build
+            filters: { branches: { only: [master] } }
 
         - use-my-lpa/docker_build_pdf:
             name: pdf_build
+            filters: { branches: { only: [master] } }
             requires: [test_pdf]
 
         - use-my-lpa/coveralls_upload:
             name: coveralls_upload
+            filters: { branches: { only: [master] } }
             requires:
               [app_front_build, app_api_build, test_web, test_pdf]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ workflows:
           environment: demo
           requires: [redeploy_demo]
 
-  path_to_live:
+  pr_build:
     jobs:
       # Common tasks
       - use-my-lpa/lint_terraform:
@@ -54,7 +54,7 @@ workflows:
           requires:
             [app_front_build, app_api_build, test_web, test_pdf]
 
-            # Provision and test development
+          # Provision and test development
       - use-my-lpa/apply_shared_terraform:
           name: dev_apply_shared_terraform
           filters: { branches: { ignore: [master] } }
@@ -71,7 +71,7 @@ workflows:
               web_api_build,
               app_api_build,
               pdf_build,
-              ]
+            ]
 
       - ecr_scan_results:
           name: ecr_scan_results_development
@@ -111,6 +111,38 @@ workflows:
           name: dev_destroy_environment
           filters: { branches: { ignore: [master] } }
           requires: [hold_env_for_destruction]
+
+  path_to_live:
+    jobs:
+      # Common tasks
+      - use-my-lpa/node_test_web:
+          name: test_web
+      - use-my-lpa/node_build_web:
+          name: build_web
+          requires: [test_web]
+      - use-my-lpa/node_test_service_pdf:
+          name: test_pdf
+
+      - use-my-lpa/docker_build_front_app:
+          name: app_front_build
+          requires: [build_web]
+      - use-my-lpa/docker_build_front_web:
+          name: web_front_build
+          requires: [build_web]
+
+      - use-my-lpa/docker_build_api_app:
+          name: app_api_build
+      - use-my-lpa/docker_build_api_web:
+          name: web_api_build
+
+      - use-my-lpa/docker_build_pdf:
+          name: pdf_build
+          requires: [test_pdf]
+
+      - use-my-lpa/coveralls_upload:
+          name: coveralls_upload
+          requires:
+            [app_front_build, app_api_build, test_web, test_pdf]
 
       # Provision and test preproduction
       - use-my-lpa/apply_shared_terraform:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ workflows:
             filters: { branches: { ignore: [master] } }
             requires:
               [
-                dev_apply_shared_terraform
+                dev_apply_shared_terraform,
                 app_front_build_pr_build,
                 web_front_build_pr_build,
                 web_api_build_pr_build,
@@ -167,17 +167,17 @@ workflows:
 
         # Provision and test preproduction
         - use-my-lpa/apply_shared_terraform:
-            name: preprod_apply_shared_terraform_path_to_live
+            name: preprod_apply_shared_terraform
             workspace: preproduction
             filters: { branches: { only: [master] } }
 
         - use-my-lpa/apply_environment_terraform:
-            name: preprod_apply_environment_terraform_path_to_live
+            name: preprod_apply_environment_terraform
             workspace: preproduction
             filters: { branches: { only: [master] } }
             requires:
               [
-                preprod_apply_shared_terraform_path_to_live,
+                preprod_apply_shared_terraform,
                 app_front_build_path_to_live,
                 web_front_build_path_to_live,
                 web_api_build_path_to_live,
@@ -185,7 +185,7 @@ workflows:
                 pdf_build_path_to_live,
               ]
         - ecr_scan_results:
-            name: ecr_scan_results_master_path_to_live
+            name: ecr_scan_results_master
             filters: { branches: { only: [master] } }
             requires:
               [
@@ -194,27 +194,27 @@ workflows:
                 web_api_build_path_to_live,
                 app_api_build_path_to_live,
                 pdf_build_path_to_live,
-                preprod_apply_environment_terraform_path_to_live,
+                preprod_apply_environment_terraform,
               ]
 
         - use-my-lpa/seed_database:
-            name: preprod_seed_database_path_to_live
+            name: preprod_seed_database
             #workspace: preproduction   # Not needed as the target account is within the config file.
             filters: { branches: { only: [master] } }
-            requires: [preprod_apply_environment_terraform_path_to_live]
+            requires: [preprod_apply_environment_terraform]
 
         - use-my-lpa/run_behave_suite:
-            name: preprod_run_behave_tests_path_to_live
+            name: preprod_run_behave_tests
             workspace: preproduction
             filters: { branches: { only: [master] } }
-            requires: [preprod_seed_database_path_to_live]
+            requires: [preprod_seed_database]
 
         # Provision and test production
         - use-my-lpa/apply_shared_terraform:
             name: production_apply_shared_terraform
             workspace: production
             filters: { branches: { only: [master] } }
-            requires: [preprod_run_behave_tests_path_to_live]
+            requires: [preprod_run_behave_tests]
         - use-my-lpa/apply_environment_terraform:
             name: production_apply_environment_terraform
             workspace: production


### PR DESCRIPTION
## Purpose
Splits the workflow into pr_build and path_to_live with their relevant jobs

Fixes UML-576

## Approach

Duplicated existing path to live workflow renamed 'pr_build', and removed jobs that were not relevant to the pr build (master only filter). Repeated the opposite for the path to live workflow, removing irrelevant jobs containing ignore master filter

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

