### PR TITLE
UML-605 Require pdf_build for prod and pre-prod terraform apply jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,7 @@ workflows:
               web_front_build,
               web_api_build,
               app_api_build,
+              pdf_build,
             ]
       - ecr_scan_results:
           name: ecr_scan_results_master
@@ -172,6 +173,7 @@ workflows:
               web_front_build,
               web_api_build,
               app_api_build,
+              pdf_build,
             ]
 
       - use-my-lpa/run_healthcheck_test:


### PR DESCRIPTION
## Purpose

There is a missing requirement on the path to live for UAL.the preprod and prod apply environment jobs should require pdf_build.

Fixes UML-605

## Approach

It adds `pdf_build` to the `requires` list for the relevant jobs.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Refunds service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

