### PR TITLE
fix docker file composer flag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,6 +138,7 @@ services:
       - --no-interaction
       - --no-scripts
       - --optimize-autoloader
+      - --ignore-platform-reqs
 
   # ---------------------------
   # API


### PR DESCRIPTION
## Purpose
To Fix the Docker file for the front-composer, which requires the --ignore-platform-reqs flag.Associated with UML-300 Brute force changes.

Fixes UML-300

## Approach
Add the additional flag to the docker-compose file for front-composer. 
There are also auto-linting changes here.

## Learning
N/A

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

