### PR TITLE
UML-617 add code coverage ignore on LpasCollectionHandler

### DIFF
--- a/service-api/app/src/App/src/Handler/LpasCollectionHandler.php
+++ b/service-api/app/src/App/src/Handler/LpasCollectionHandler.php
@@ -14,6 +14,7 @@ use RuntimeException;
 /**
  * Class LpaSearchHandler
  * @package App\Handler
+ * @codeCoverageIgnore
  */
 class LpasCollectionHandler implements RequestHandlerInterface
 {


### PR DESCRIPTION
## Purpose
To place @codecoverageignore tag onto any Service-API handlers that can be done.

Fixes UML-617

### Result of work:

- 1 handler had this change made. 
- There are no feature tests for the exception paths in most cases, with one happy path scenario missed. 
- The linked tickets cover the handlers to have these covered. 
- Where a @codecoverageignore is missed or not,  it has been noted on each of the tickets.

## Approach
as above 😄 

## Learning

Turns out to be 1 only where this could be done. We discovered a load of exception paths that need testing, and tickets have been raised in the backlog for this. it may be the tickets need further analysis, and amalgamation may be possible in some cases e.g. when some of the testing paths are similar.

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

