### PR TITLE
UML 757 rework test expectations for code generation to include timezone

### DIFF
--- a/service-api/app/features/context/Acceptance/AccountContext.php
+++ b/service-api/app/features/context/Acceptance/AccountContext.php
@@ -11,6 +11,7 @@ use BehatTest\Context\SetupEnv;
 use Common\Exception\ApiException;
 use DateTime;
 use DateInterval;
+use DateTimeZone;
 use Fig\Http\Message\StatusCodeInterface;
 use GuzzleHttp\Psr7\Response;
 
@@ -954,7 +955,7 @@ class AccountContext implements Context
         $response = $this->getResponseAsJson();
 
         $codeExpiry = (new DateTime($response['expires']))->format('Y-m-d');
-        $in30Days = ((new DateTime('now'))->add(new DateInterval('P30D'))->format('Y-m-d'));
+        $in30Days = (new DateTime('23:59:59 +30 days', new DateTimeZone('Europe/London')))->format('Y-m-d');
 
         assertArrayHasKey('code', $response);
         assertNotNull($response['code']);

--- a/service-api/app/features/context/Integration/AccountContext.php
+++ b/service-api/app/features/context/Integration/AccountContext.php
@@ -20,6 +20,7 @@ use Aws\Result;
 use BehatTest\Context\SetupEnv;
 use Common\Service\Lpa\ViewerCodeService;
 use DateInterval;
+use DateTimeZone;
 use DateTime;
 use Exception;
 use Fig\Http\Message\StatusCodeInterface;
@@ -910,7 +911,7 @@ class AccountContext extends BaseIntegrationContext
         $codeData = $viewerCodeService->addCode($this->userLpaActorToken, $this->userId, $this->organisation);
 
         $codeExpiry = (new DateTime($codeData['expires']))->format('Y-m-d');
-        $in30Days = ((new DateTime('now'))->add(new DateInterval('P30D'))->format('Y-m-d'));
+        $in30Days = (new DateTime('23:59:59 +30 days', new DateTimeZone('Europe/London')))->format('Y-m-d');
 
         assertArrayHasKey('code', $codeData);
         assertNotNull($codeData['code']);


### PR DESCRIPTION
## Purpose
To Fix tests that fail erroneously around code generation, if run around midnight BST.  
The code expiry dates are being generated in Europe/London Timezone.
However, tests are not taking this into account, testing with an expected date in UTC. 
This fix is to align the expectation correctly with the actual. 

***No functional code was changed, only Behat tests.***

Fixes UML-757

## Approach

- Use the correct date time zone.
- update date notation to a relative date and time.
- This was tested locally with the changes and by setting the local machine time to midnight (00:00:00). 
- Also tested by running with current date-time.

## Learning

`DateTimeZone` format
https://www.php.net/manual/en/class.datetimezone.php

`DateTime` formats
https://www.php.net/manual/en/datetime.formats.php


## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

