### PR TITLE
add environment name to the awslog stream prefix

### DIFF
--- a/terraform/environment/actor_ecs.tf
+++ b/terraform/environment/actor_ecs.tf
@@ -131,7 +131,7 @@ locals {
         "options": {
             "awslogs-group": "${data.aws_cloudwatch_log_group.use-an-lpa.name}",
             "awslogs-region": "eu-west-1",
-            "awslogs-stream-prefix": "actor-web.use-an-lpa"
+            "awslogs-stream-prefix": "${local.environment}.actor-web.use-an-lpa"
         }
     },
     "environment": [
@@ -176,7 +176,7 @@ EOF
         "options": {
             "awslogs-group": "${data.aws_cloudwatch_log_group.use-an-lpa.name}",
             "awslogs-region": "eu-west-1",
-            "awslogs-stream-prefix": "actor-app.use-an-lpa"
+            "awslogs-stream-prefix": "${local.environment}.actor-app.use-an-lpa"
         }
     },
     "secrets" : [

--- a/terraform/environment/api_ecs.tf
+++ b/terraform/environment/api_ecs.tf
@@ -180,7 +180,7 @@ locals {
         "options": {
             "awslogs-group": "${data.aws_cloudwatch_log_group.use-an-lpa.name}",
             "awslogs-region": "eu-west-1",
-            "awslogs-stream-prefix": "api-web.use-an-lpa"
+            "awslogs-stream-prefix": "${local.environment}.api-web.use-an-lpa"
         }
     },
     "environment": [
@@ -225,7 +225,7 @@ EOF
         "options": {
             "awslogs-group": "${data.aws_cloudwatch_log_group.use-an-lpa.name}",
             "awslogs-region": "eu-west-1",
-            "awslogs-stream-prefix": "api-app.use-an-lpa"
+            "awslogs-stream-prefix": "${local.environment}.api-app.use-an-lpa"
         }
     },
     "environment": [

--- a/terraform/environment/code_creation_ecs.tf
+++ b/terraform/environment/code_creation_ecs.tf
@@ -94,7 +94,7 @@ locals {
         "options": {
             "awslogs-group": "${data.aws_cloudwatch_log_group.use-an-lpa.name}",
             "awslogs-region": "eu-west-1",
-            "awslogs-stream-prefix": "code-creation-app.use-an-lpa"
+            "awslogs-stream-prefix": "${local.environment}.code-creation-app.use-an-lpa"
         }
     },
     "environment": [

--- a/terraform/environment/pdf_ecs.tf
+++ b/terraform/environment/pdf_ecs.tf
@@ -126,11 +126,11 @@ locals {
         "options": {
             "awslogs-group": "${data.aws_cloudwatch_log_group.use-an-lpa.name}",
             "awslogs-region": "eu-west-1",
-            "awslogs-stream-prefix": "pdf-app.use-an-lpa"
+            "awslogs-stream-prefix": "${local.environment}.pdf-app.use-an-lpa"
         }
     }
   }
-  
+
 EOF
 
 }
@@ -138,4 +138,3 @@ EOF
 output "pdf_app_deployed_version" {
   value = "${data.aws_ecr_repository.use_an_lpa_pdf.repository_url}:${var.container_version}"
 }
-

--- a/terraform/environment/viewer_ecs.tf
+++ b/terraform/environment/viewer_ecs.tf
@@ -131,7 +131,7 @@ locals {
         "options": {
             "awslogs-group": "${data.aws_cloudwatch_log_group.use-an-lpa.name}",
             "awslogs-region": "eu-west-1",
-            "awslogs-stream-prefix": "viewer-web.use-an-lpa"
+            "awslogs-stream-prefix": "${local.environment}.viewer-web.use-an-lpa"
         }
     },
     "environment": [
@@ -176,7 +176,7 @@ EOF
         "options": {
             "awslogs-group": "${data.aws_cloudwatch_log_group.use-an-lpa.name}",
             "awslogs-region": "eu-west-1",
-            "awslogs-stream-prefix": "viewer-app.use-an-lpa"
+            "awslogs-stream-prefix": "${local.environment}.viewer-app.use-an-lpa"
         }
     },
     "environment": [


### PR DESCRIPTION
## Purpose
Finding the correct logs for your environment in the development account can be difficult because they all share the same log group and stream prefix.

Fixes UML-749

## Approach

Add the environment name to the AWS logs stream prefix.

Now in Cloudwatch Insights, you can isolate logs using 

```
filter @logStream like /(?i)(environment_name)/
```

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

