### PR TITLE
Uml 748 log retention

### DIFF
--- a/terraform/account/cloudwatch.tf
+++ b/terraform/account/cloudwatch.tf
@@ -1,5 +1,6 @@
 resource "aws_cloudwatch_log_group" "use-an-lpa" {
-  name = "use-an-lpa"
+  name              = "use-an-lpa"
+  retention_in_days = local.account.retention_in_days
 
   tags = merge(
     local.default_tags,
@@ -8,4 +9,3 @@ resource "aws_cloudwatch_log_group" "use-an-lpa" {
     },
   )
 }
-

--- a/terraform/account/locals.tf
+++ b/terraform/account/locals.tf
@@ -5,8 +5,9 @@ variable "account_mapping" {
 variable "accounts" {
   type = map(
     object({
-      account_id    = string
-      is_production = bool
+      account_id        = string
+      is_production     = bool
+      retention_in_days = number
     })
   )
 }

--- a/terraform/account/terraform.tfvars.json
+++ b/terraform/account/terraform.tfvars.json
@@ -7,15 +7,18 @@
   "accounts": {
     "development": {
       "account_id": "367815980639",
-      "is_production": false
+      "is_production": false,
+      "retention_in_days": 7
     },
     "preproduction": {
       "account_id": "888228022356",
-      "is_production": false
+      "is_production": false,
+      "retention_in_days": 7
     },
     "production": {
       "account_id": "690083044361",
-      "is_production": true
+      "is_production": true,
+      "retention_in_days": 120
     }
   }
 


### PR DESCRIPTION
## Purpose
Logs should only be kept for as long as they are needed

Fixes UML-748

## Approach

Add a log retention policy to the AWS Log Group.
Set the number of days based on the account.

After the number of days, log events in the AWS Log Group will automatically be deleted by AWS Cloudwatch.

## Learning

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

