### PR TITLE
Uml-750 remove Z and 2 chars from code gen

### DIFF
--- a/service-api/app/src/App/src/Service/ViewerCodes/CodeGenerator.php
+++ b/service-api/app/src/App/src/Service/ViewerCodes/CodeGenerator.php
@@ -14,7 +14,7 @@ class CodeGenerator
     /**
      * The characters allowed to appear in the code.
      */
-    const ALLOWED_CHARACTERS = '2346789QWERTYUPADFGHJKLZXCVBNM';
+    const ALLOWED_CHARACTERS = '346789QWERTYUPADFGHJKLXCVBNM';
 
     /**
      * Generates a random code of length CODE_LENGTH, using only the characters in ALLOWED_CHARACTERS.

--- a/service-api/app/test/AppTest/Service/ViewerCodes/CodeGeneratorTest.php
+++ b/service-api/app/test/AppTest/Service/ViewerCodes/CodeGeneratorTest.php
@@ -18,7 +18,7 @@ class CodeGeneratorTest extends TestCase
          * Thus them appearing here.
          */
         $this->assertEquals(12, CodeGenerator::CODE_LENGTH);
-        $this->assertEquals('2346789QWERTYUPADFGHJKLZXCVBNM', CodeGenerator::ALLOWED_CHARACTERS);
+        $this->assertEquals('346789QWERTYUPADFGHJKLXCVBNM', CodeGenerator::ALLOWED_CHARACTERS);
     }
 
     /**


### PR DESCRIPTION
## Purpose
To Remove Z and 2 from the code generator, which is ambiguous to our users. 
We do not validate that these characters are valid on entry, as there may still be codes out there that use these.

Fixes UML-750

## Approach

- Remove the characters Z and 2 from the generator
- Adjust PHPUnit Test to match.

## Learning

N/A

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [ ] The product team have tested these changes

