### PR TITLE
Improve lpa code json parse for code generation

### DIFF
--- a/scripts/generate_actor_codes/README.md
+++ b/scripts/generate_actor_codes/README.md
@@ -5,6 +5,7 @@
 - homebrew
 - python
 - direnv
+- jq: https://stedolan.github.io/jq/
 - aws-vault, with your credentials set up : <https://github.com/99designs/aws-vault>
 - you may need to refer to the onboarding instructions for AWS if you do not have an aws identity set up: <https://ministryofjustice.github.io/opg-new-starter/amazon.html>
 
@@ -26,11 +27,6 @@ The script uses your IAM user credentials to assume the appropriate role.
 
 You can provide the script credentials using aws-vault.
 The environment is the first part of the url e.g. demo or ULM222xyz for example.
-
-**IMPORTANT** when generating actor codes, they need to be sent to the requesting person securely, either using:
-
-- Keybase
-- Password encrypted zip file, and password sent on a separate communication method.
 
 ``` shell
 aws-vault exec identity -- python ./generate_actor_codes.py <environment> <comma separated lpa uids, no spaces>

--- a/scripts/generate_actor_codes/README.md
+++ b/scripts/generate_actor_codes/README.md
@@ -47,23 +47,22 @@ Streaming logs for logstream:
 timestamp: 1588688690503: message:<json_output>
 ```
 
-Copy the json_output from the code generator logs output and push it into a file
+Copy the `<json_output>` from the code generator logs output and push it into a file
 
 ``` shell
 FILENAME=activation_codes_$(date +%Y%m%d)
 mkdir -p /tmp/$FILENAME
-echo '<json_output>' | jq > /tmp/$FILENAME/$FILENAME.txt
+echo '<json_output>' | jq -f transform-lpa-json.jq > /tmp/$FILENAME/$FILENAME.txt
 ```
 
-The preference for the recipient is that the json in the text file is formatted slightly differently than as returned by the code generator.
-
+Please check the resulting  file in `/tmp/$FILENAME/$FILENAME.txt` has the following:
 - All Sirius case numbers should be split with hyphen into 3 groups of 4. e.g `7xxx-xxxx-xxxx`
 - All actor codes should be split with a space into 3 groups of 4. e.g `ABC1 D2E3 FG4H`
 
-Then create an encrypted disk image, copy the file into it and clean up. The script will prompt for a password to create and to open the disk image.
+Then create an encrypted disk image using the script below. The script will prompt for a password to create and to open the disk image.
 
 ``` shell
 ./make_encrypted_image.sh $FILENAME
 ```
 
-Send the encrypted image to the recipient by email and separately let them know what the password is.
+Send the encrypted image to the recipient by slack or keybase and separately let them know what the password is, e.g. via email.

--- a/scripts/generate_actor_codes/transform-lpa-json.jq
+++ b/scripts/generate_actor_codes/transform-lpa-json.jq
@@ -1,0 +1,21 @@
+to_entries
+| map_values(
+    {LPAId :.key
+    | sub( "(?<a>7[0-9]{3})(?<b>[0-9]{4})(?<c>[0-9]{4})";"\(.a)-\(.b)-\(.c)"
+    )
+    }
+  + {
+    	Codes: .value
+    	| map_values(
+      	{
+          id,
+          uId : .uId
+			| sub( "(?<a>7[0-9]{3})(?<b>[0-9]{4})(?<c>[0-9]{4})";"\(.a)-\(.b)-\(.c)"),
+      	  firstname,
+          middlenames,
+          surname,
+          code : .code
+           | sub( "(?<a>[A-Z0-9]{4})(?<b>[A-Z0-9]{4})(?<c>[A-Z0-9]{4})";"\(.a) \(.b) \(.c)"),
+      	  expiry
+    	})
+	})

--- a/scripts/generate_actor_codes/transform-lpa-json.jq
+++ b/scripts/generate_actor_codes/transform-lpa-json.jq
@@ -1,16 +1,14 @@
 to_entries
-| map_values(
-    {LPAId :.key
-    | sub( "(?<a>7[0-9]{3})(?<b>[0-9]{4})(?<c>[0-9]{4})";"\(.a)-\(.b)-\(.c)"
-    )
-    }
+| map_values({
+  ActorLPAId :.key
+  | sub( "(?<a>7\\d{3})(?<b>\\d{4})(?<c>\\d{4})";"\(.a)-\(.b)-\(.c)")}
   + {
-    	Codes: .value
+    	availableCodes: .value
     	| map_values(
       	{
           id,
           uId : .uId
-			| sub( "(?<a>7[0-9]{3})(?<b>[0-9]{4})(?<c>[0-9]{4})";"\(.a)-\(.b)-\(.c)"),
+			| sub( "(?<a>7\\d{3})(?<b>\\d{4})(?<c>\\d{4})";"\(.a)-\(.b)-\(.c))"),
       	  firstname,
           middlenames,
           surname,
@@ -18,4 +16,5 @@ to_entries
            | sub( "(?<a>[A-Z0-9]{4})(?<b>[A-Z0-9]{4})(?<c>[A-Z0-9]{4})";"\(.a) \(.b) \(.c)"),
       	  expiry
     	})
-	})
+	}
+)

--- a/scripts/generate_actor_codes/transform-lpa-json.jq
+++ b/scripts/generate_actor_codes/transform-lpa-json.jq
@@ -8,7 +8,7 @@ to_entries
       	{
           id,
           uId : .uId
-			| sub( "(?<a>7\\d{3})(?<b>\\d{4})(?<c>\\d{4})";"\(.a)-\(.b)-\(.c))"),
+			| sub( "(?<a>7\\d{3})(?<b>\\d{4})(?<c>\\d{4})";"\(.a)-\(.b)-\(.c)"),
       	  firstname,
           middlenames,
           surname,

--- a/scripts/generate_actor_codes/transform-lpa-json.jq
+++ b/scripts/generate_actor_codes/transform-lpa-json.jq
@@ -5,16 +5,16 @@ to_entries
   + {
     	availableCodes: .value
     	| map_values(
-      	{
-          id,
-          uId : .uId
-			| sub( "(?<a>7\\d{3})(?<b>\\d{4})(?<c>\\d{4})";"\(.a)-\(.b)-\(.c)"),
-      	  firstname,
-          middlenames,
-          surname,
-          code : .code
-           | sub( "(?<a>[A-Z0-9]{4})(?<b>[A-Z0-9]{4})(?<c>[A-Z0-9]{4})";"\(.a) \(.b) \(.c)"),
-      	  expiry
+    	{
+    	    id,
+            uId : .uId
+                | sub( "(?<a>7\\d{3})(?<b>\\d{4})(?<c>\\d{4})";"\(.a)-\(.b)-\(.c)"),
+            firstname,
+            middlenames,
+            surname,
+            code : .code
+                | sub( "(?<a>[A-Z0-9]{4})(?<b>[A-Z0-9]{4})(?<c>[A-Z0-9]{4})";"\(.a) \(.b) \(.c)"),
+            expiry
     	})
 	}
 )


### PR DESCRIPTION
## Purpose

- Add a jq transform file that will format the LPA id's and actor codes automatically in the correct format.
- To make our dev lives a little easier 😄 

## Approach
- Add a jq filter transform file that will take the `json_output` as mentioned in the readme and edit in place the fields needed. 
 - The structure of the json changes slightly but shouldn't be an issue for the business to use.
 - update readme with new details of what to do.

## Learning
using Jq play and jq Term to work out from a dummy set of data how to do it.
- https://jqterm.com/
- https://jqplay.org/

also using the manuals and docs:
- https://stedolan.github.io/jq/

Stack Exchange 😃 
- https://stackoverflow.com/questions/55048593/replacing-values-in-json-with-jq-and-regex

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [X] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

