### PR TITLE
Turn on asynchronous workspace cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,17 +18,17 @@ workflows:
           environment: demo
           requires: [redeploy_demo]
 
-  # workspace_cleanup:
-  #   triggers:
-  #     - schedule:
-  #         cron: "0 0,2,4,6,8,10,12,14,16,18,20,22 * * 0-6" # every 2 hours from midnight
-  #         filters:
-  #           branches:
-  #             only:
-  #               - master
-  #   jobs:
-  #     - workspace_cleanup:
-  #         name: workspace_cleanup
+  workspace_cleanup:
+    triggers:
+      - schedule:
+          cron: "0 0,2,4,6,8,10,12,14,16,18,20,22 * * 0-6" # every 2 hours from midnight
+          filters:
+            branches:
+              ignore:
+                - master
+    jobs:
+      - workspace_cleanup:
+          name: workspace_cleanup
 
   pr_build:
       jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ workflows:
           cron: "0 0,2,4,6,8,10,12,14,16,18,20,22 * * 0-6" # every 2 hours from midnight
           filters:
             branches:
-              ignore:
+              only:
                 - master
     jobs:
       - workspace_cleanup:


### PR DESCRIPTION
## Purpose
Turn on asynchronous workspace cleanup

## Approach

Enable a scheduled job that will list out and select each workspace, then the default workspace.
After this is shown to be working ok, the cleanup actions can be enabled also.

## Learning

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

