### PR TITLE
UML-807 - Remove unused certificates

### DIFF
--- a/terraform/account/certificate.tf
+++ b/terraform/account/certificate.tf
@@ -3,27 +3,6 @@ data "aws_route53_zone" "opg_service_justice_gov_uk" {
   name     = "opg.service.justice.gov.uk"
 }
 
-//------------------------
-// Viewer Certificates
-
-resource "aws_route53_record" "certificate_validation_viewer" {
-  provider = aws.management
-  name     = aws_acm_certificate.certificate_viewer.domain_validation_options[0].resource_record_name
-  type     = aws_acm_certificate.certificate_viewer.domain_validation_options[0].resource_record_type
-  zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
-  records  = [aws_acm_certificate.certificate_viewer.domain_validation_options[0].resource_record_value]
-  ttl      = 60
-}
-
-resource "aws_acm_certificate_validation" "certificate_viewer" {
-  certificate_arn         = aws_acm_certificate.certificate_viewer.arn
-  validation_record_fqdns = [aws_route53_record.certificate_validation_viewer.fqdn]
-}
-
-resource "aws_acm_certificate" "certificate_viewer" {
-  domain_name       = "${local.dev_wildcard}viewer.${local.dns_namespace_acc}use-an-lpa.opg.service.justice.gov.uk"
-  validation_method = "DNS"
-}
 
 //------------------------
 // Actors Certificates

--- a/terraform/account/certificate.tf
+++ b/terraform/account/certificate.tf
@@ -3,30 +3,6 @@ data "aws_route53_zone" "opg_service_justice_gov_uk" {
   name     = "opg.service.justice.gov.uk"
 }
 
-
-//------------------------
-// Actors Certificates
-
-resource "aws_route53_record" "certificate_validation_actor" {
-  provider = aws.management
-  name     = aws_acm_certificate.certificate_actor.domain_validation_options[0].resource_record_name
-  type     = aws_acm_certificate.certificate_actor.domain_validation_options[0].resource_record_type
-  zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
-  records  = [aws_acm_certificate.certificate_actor.domain_validation_options[0].resource_record_value]
-  ttl      = 60
-}
-
-resource "aws_acm_certificate_validation" "certificate_actor" {
-  certificate_arn         = aws_acm_certificate.certificate_actor.arn
-  validation_record_fqdns = [aws_route53_record.certificate_validation_actor.fqdn]
-}
-
-resource "aws_acm_certificate" "certificate_actor" {
-  domain_name       = "${local.dev_wildcard}actor.${local.dns_namespace_acc}use-an-lpa.opg.service.justice.gov.uk"
-  validation_method = "DNS"
-}
-
-
 //------------------------
 // View Certificates
 

--- a/terraform/environment/shared_data_sources.tf
+++ b/terraform/environment/shared_data_sources.tf
@@ -26,14 +26,6 @@ data "aws_cloudwatch_log_group" "use-an-lpa" {
   name = "use-an-lpa"
 }
 
-data "aws_acm_certificate" "certificate_viewer" {
-  domain = "${local.dev_wildcard}viewer.${local.dns_namespace_acc}use-an-lpa.opg.service.justice.gov.uk"
-}
-
-data "aws_acm_certificate" "certificate_actor" {
-  domain = "${local.dev_wildcard}actor.${local.dns_namespace_acc}use-an-lpa.opg.service.justice.gov.uk"
-}
-
 data "aws_acm_certificate" "certificate_view" {
   domain = "${local.dev_wildcard}view.lastingpowerofattorney.opg.service.justice.gov.uk"
 }


### PR DESCRIPTION
## Purpose
The environment build is looking for a certificate that is not required.

Fixes UML-807

## Approach

Remove the data sources for the certificates in the Terraform environment configuration.
Remove the certificates from the Terraform account configuration

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

