### PR TITLE
bring 'mark workspace protected' into 'apply dev env'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,11 +99,6 @@ workflows:
                 pdf_build_pr_build,
               ]
 
-        - mark_workspace_as_protected:
-            name: mark_workspace_as_protected
-            filters: { branches: { ignore: [master] } }
-            requires: [dev_apply_environment_terraform]
-
         - ecr_scan_results:
             name: ecr_scan_results_development
             filters: { branches: { ignore: [master] } }
@@ -789,6 +784,7 @@ orbs:
                 terraform init -lock-timeout=300s
                 export TF_WORKSPACE=$(~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                 echo $TF_WORKSPACE
+                ~/project/scripts/pipeline/workspace_cleanup/put_workspace_linux -workspace=$TF_WORKSPACE
                 export IMAGE_TAG=$(~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
                 echo $IMAGE_TAG
                 terraform apply -lock-timeout=300s --auto-approve -var container_version=${IMAGE_TAG}
@@ -1002,20 +998,3 @@ jobs:
             cd terraform/environment
             terraform init -lock-timeout=300s
             ../../scripts/pipeline/workspace_cleanup/workspace_cleanup.sh $(../../scripts/pipeline/workspace_cleanup/get_workspaces_linux)
-
-  mark_workspace_as_protected:
-    docker:
-      - image: hashicorp/terraform
-    parameters:
-      workspace:
-        description: Terraform workspace name
-        type: string
-        default: "${CIRCLE_PULL_REQUEST##*/}-${CIRCLE_BRANCH}"
-    steps:
-      - checkout
-
-      - run:
-          name: Mark Workspace for Cleanup
-          command: |
-            export TF_WORKSPACE=$(~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
-            ~/project/scripts/pipeline/workspace_cleanup/put_workspace_linux -workspace=$TF_WORKSPACE


### PR DESCRIPTION
## Purpose
If CircleCI is a bit congested, there can be a long delay between jobs on the pipeline. If the delay occurs between a successful Terraform environment apply and marking the environment as protected, it is possible that the automated cleanup can remove a brand new environment.

## Approach

Move the command to mark the environment (workspace) as protected inside the job to apply the environment (ideally, before the "environment apply" is attempted).

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

