### PR TITLE
Uml 817 abstract out code verification

### DIFF
--- a/service-api/app/features/context/Acceptance/AccountContext.php
+++ b/service-api/app/features/context/Acceptance/AccountContext.php
@@ -8,9 +8,7 @@ use Aws\Result;
 use Behat\Behat\Context\Context;
 use BehatTest\Context\BaseAcceptanceContextTrait;
 use BehatTest\Context\SetupEnv;
-use Common\Exception\ApiException;
 use DateTime;
-use DateInterval;
 use DateTimeZone;
 use Fig\Http\Message\StatusCodeInterface;
 use GuzzleHttp\Psr7\Response;
@@ -455,6 +453,10 @@ class AccountContext implements Context
         $this->apiFixtures->get('/v1/use-an-lpa/lpas/' . $this->lpaUid)
             ->respondWith(new Response(StatusCodeInterface::STATUS_OK, [], json_encode($this->lpa)));
 
+        // called twice
+        $this->apiFixtures->get('/v1/use-an-lpa/lpas/' . $this->lpaUid)
+            ->respondWith(new Response(StatusCodeInterface::STATUS_OK, [], json_encode($this->lpa)));
+
         $this->apiPost('/v1/actor-codes/summary', [
             'actor-code' => $this->oneTimeCode,
             'uid' => $this->lpaUid,
@@ -547,6 +549,10 @@ class AccountContext implements Context
             ])
         ]));
 
+        $this->apiFixtures->get('/v1/use-an-lpa/lpas/' . $this->lpaUid)
+            ->respondWith(new Response(StatusCodeInterface::STATUS_OK, [], json_encode($this->lpa)));
+
+        // called twice
         $this->apiFixtures->get('/v1/use-an-lpa/lpas/' . $this->lpaUid)
             ->respondWith(new Response(StatusCodeInterface::STATUS_OK, [], json_encode($this->lpa)));
 

--- a/service-api/app/features/context/Integration/AccountContext.php
+++ b/service-api/app/features/context/Integration/AccountContext.php
@@ -18,10 +18,8 @@ use Aws\DynamoDb\Marshaler;
 use Aws\MockHandler as AwsMockHandler;
 use Aws\Result;
 use BehatTest\Context\SetupEnv;
-use Common\Service\Lpa\ViewerCodeService;
-use DateInterval;
-use DateTimeZone;
 use DateTime;
+use DateTimeZone;
 use Exception;
 use Fig\Http\Message\StatusCodeInterface;
 use GuzzleHttp\Psr7\Response;
@@ -660,14 +658,24 @@ class AccountContext extends BaseIntegrationContext
         // ActorCodes::get
         $this->awsFixtures->append(new Result([
             'Item' => $this->marshalAwsResultData([
-                    'SiriusUid' => $this->lpaUid,
-                    'Active'    => true,
-                    'Expires'   => '2021-09-25T00:00:00Z',
-                    'ActorCode' => $this->passcode,
-                    'ActorLpaId'=> $this->actorLpaId,
+                    'SiriusUid'  => $this->lpaUid,
+                    'Active'     => true,
+                    'Expires'    => '2021-09-25T00:00:00Z',
+                    'ActorCode'  => $this->passcode,
+                    'ActorLpaId' => $this->actorLpaId,
                 ])
         ]));
 
+        $this->apiFixtures->get('/v1/use-an-lpa/lpas/' . $this->lpaUid)
+            ->respondWith(
+                new Response(
+                    StatusCodeInterface::STATUS_OK,
+                    [],
+                    json_encode($this->lpa)
+                )
+            );
+
+        // this is now called twice
         $this->apiFixtures->get('/v1/use-an-lpa/lpas/' . $this->lpaUid)
             ->respondWith(
                 new Response(
@@ -682,7 +690,6 @@ class AccountContext extends BaseIntegrationContext
         $validatedLpa = $actorCodeService->validateDetails($this->passcode, $this->lpaUid, $this->userDob);
 
         assertEquals($validatedLpa['lpa']['uId'], $this->lpaUid);
-
     }
 
     /**
@@ -712,6 +719,16 @@ class AccountContext extends BaseIntegrationContext
             ])
         ]));
 
+        $this->apiFixtures->get('/v1/use-an-lpa/lpas/' . $this->lpaUid)
+            ->respondWith(
+                new Response(
+                    StatusCodeInterface::STATUS_OK,
+                    [],
+                    json_encode($this->lpa)
+                )
+            );
+
+        // this is now called twice
         $this->apiFixtures->get('/v1/use-an-lpa/lpas/' . $this->lpaUid)
             ->respondWith(
                 new Response(

--- a/service-api/app/src/App/src/ConfigProvider.php
+++ b/service-api/app/src/App/src/ConfigProvider.php
@@ -6,8 +6,8 @@ namespace App;
 
 use Aws;
 use Http;
-use Psr;
 use Laminas;
+use Psr;
 
 /**
  * The configuration provider for the App module
@@ -42,15 +42,21 @@ class ConfigProvider
                 Http\Client\HttpClient::class => Http\Adapter\Guzzle6\Client::class,
 
                 // allows value setting on the container at runtime.
-                Service\Container\ModifiableContainerInterface::class => Service\Container\PhpDiModifiableContainer::class,
+                Service\Container\ModifiableContainerInterface::class
+                    => Service\Container\PhpDiModifiableContainer::class,
 
                 // Data Access
                 DataAccess\Repository\ActorCodesInterface::class => DataAccess\DynamoDb\ActorCodes::class,
                 DataAccess\Repository\ActorUsersInterface::class => DataAccess\DynamoDb\ActorUsers::class,
-                DataAccess\Repository\ViewerCodeActivityInterface::class => DataAccess\DynamoDb\ViewerCodeActivity::class,
+                DataAccess\Repository\ViewerCodeActivityInterface::class
+                    => DataAccess\DynamoDb\ViewerCodeActivity::class,
                 DataAccess\Repository\ViewerCodesInterface::class => DataAccess\DynamoDb\ViewerCodes::class,
                 DataAccess\Repository\UserLpaActorMapInterface::class => DataAccess\DynamoDb\UserLpaActorMap::class,
                 DataAccess\Repository\LpasInterface::class => DataAccess\ApiGateway\Lpas::class,
+
+                // Validation Strategy
+                Service\ActorCodes\CodeValidationStrategyInterface::class
+                    => Service\ActorCodes\DynamoCodeValidationStrategy::class
             ],
 
             'factories'  => [

--- a/service-api/app/src/App/src/Exception/ActorCodeMarkAsUsedException.php
+++ b/service-api/app/src/App/src/Exception/ActorCodeMarkAsUsedException.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace App\Exception;
 
+/**
+ * Class ActorCodeMarkAsUsedException
+ *
+ * Thrown when an upstream service fails to mark an actor code as used.
+ *
+ * @package App\Exception
+ */
 class ActorCodeMarkAsUsedException extends \Exception
 {
-
 }

--- a/service-api/app/src/App/src/Exception/ActorCodeMarkAsUsedException.php
+++ b/service-api/app/src/App/src/Exception/ActorCodeMarkAsUsedException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+class ActorCodeMarkAsUsedException extends \Exception
+{
+
+}

--- a/service-api/app/src/App/src/Exception/ActorCodeValidationException.php
+++ b/service-api/app/src/App/src/Exception/ActorCodeValidationException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+class ActorCodeValidationException extends \Exception
+{
+
+}

--- a/service-api/app/src/App/src/Exception/ActorCodeValidationException.php
+++ b/service-api/app/src/App/src/Exception/ActorCodeValidationException.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace App\Exception;
 
+/**
+ * Class ActorCodeValidationException
+ *
+ * Thrown when a set of actor code credentials (incl. DoB and LPA uId) fail to validate.
+ *
+ * @package App\Exception
+ */
 class ActorCodeValidationException extends \Exception
 {
-
 }

--- a/service-api/app/src/App/src/Service/ActorCodes/ActorCodeService.php
+++ b/service-api/app/src/App/src/Service/ActorCodes/ActorCodeService.php
@@ -4,48 +4,45 @@ declare(strict_types=1);
 
 namespace App\Service\ActorCodes;
 
-use App\DataAccess\Repository;
+use App\DataAccess\{Repository\ActorCodesInterface,
+    Repository\KeyCollisionException,
+    Repository\UserLpaActorMapInterface};
+use App\Exception\{ActorCodeMarkAsUsedException, ActorCodeValidationException};
 use App\Service\Lpa\LpaService;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
 
 class ActorCodeService
 {
-    /**
-     * @var Repository\ActorCodesInterface
-     */
-    private $actorCodesRepository;
+    private CodeValidationStrategyInterface $codeValidator;
 
-    /**
-     * @var Repository\UserLpaActorMapInterface
-     */
-    private $userLpaActorMapRepository;
+    private ActorCodesInterface $actorCodesRepository;
 
-    /**
-     * @var LpaService
-     */
-    private $lpaService;
+    private UserLpaActorMapInterface $userLpaActorMapRepository;
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private LpaService $lpaService;
+
+    private LoggerInterface $logger;
 
     /**
      * ActorCodeService constructor.
-     * @param Repository\ActorCodesInterface $viewerCodesRepository
-     * @param Repository\UserLpaActorMapInterface $userLpaActorMapRepository
+     *
+     * @param CodeValidationStrategyInterface $codeValidator
+     * @param ActorCodesInterface $actorCodesRepository
+     * @param UserLpaActorMapInterface $userLpaActorMapRepository
      * @param LpaService $lpaService
      * @param LoggerInterface $logger
      */
     public function __construct(
-        Repository\ActorCodesInterface $viewerCodesRepository,
-        Repository\UserLpaActorMapInterface $userLpaActorMapRepository,
+        CodeValidationStrategyInterface $codeValidator,
+        ActorCodesInterface $actorCodesRepository,
+        UserLpaActorMapInterface $userLpaActorMapRepository,
         LpaService $lpaService,
         LoggerInterface $logger
     ) {
+        $this->codeValidator = $codeValidator;
         $this->lpaService = $lpaService;
-        $this->actorCodesRepository = $viewerCodesRepository;
+        $this->actorCodesRepository = $actorCodesRepository;
         $this->userLpaActorMapRepository = $userLpaActorMapRepository;
         $this->logger = $logger;
     }
@@ -59,74 +56,23 @@ class ActorCodeService
      */
     public function validateDetails(string $code, string $uid, string $dob): ?array
     {
-        $details = $this->actorCodesRepository->get($code);
+        try {
+            $actorUid = $this->codeValidator->validateCode($code, $uid, $dob);
 
-        if (is_null($details)) {
-            $this->logger->info('Validating code could not find details for code {code}', ['code' => $code]);
+            $lpa = $this->lpaService->getByUid($uid);
+
+            $actor = $this->lpaService->lookupActiveActorInLpa($lpa->getData(), $actorUid);
+
+            $lpaData = $lpa->getData();
+            unset($lpaData['original_attorneys']);
+
+            return [
+                'actor' => $actor,
+                'lpa' => $lpaData
+            ];
+        } catch (ActorCodeValidationException $acve) {
             return null;
         }
-
-        if ($details['Active'] !== true) {
-            $this->logger->info('Validating code {code} is inactive', ['code' => $code]);
-            return null;
-        }
-
-        $lpa = $this->lpaService->getByUid($details['SiriusUid']);
-
-        if (is_null($lpa)) {
-            $this->logger->error('Validating code could not find LPA for SiriusUid {SiriusUid}', ['SiriusUid' => $details['SiriusUid']]);
-            return null;
-        }
-
-        $actor = $this->lpaService->lookupActiveActorInLpa($lpa->getData(), $details['ActorLpaId']);
-
-        if (is_null($actor)) {
-            $this->logger->error('Validating code could not find actor {ActorLpaId} in LPA for SiriusUid {SiriusUid}',
-                [
-                   'ActorLpaId' => $details['ActorLpaId'],
-                   'SiriusUid' => $details['SiriusUid'],
-                ]
-            );
-            return null;
-        }
-
-        if ($code !== $details['ActorCode'] ) {
-            $this->logger->info('Validating code {code} did not match {expected}',
-                [
-                    'code' => $code,
-                    'expected' => $details['ActorCode'],
-                ]
-            );
-            return null;
-        }
-
-        if ($uid !== $lpa->getData()['uId']) {
-            $this->logger->info('Validating code uid {uid} did not match {expected}',
-                [
-                    'uid' => $uid,
-                    'expected' => $lpa->getData()['uId'],
-                ]
-            );
-            return null;
-        }
-
-        if ($dob !== $actor['details']['dob']) {
-            $this->logger->info('Validating code dob {dob} did not match {expected}',
-                [
-                    'dob' => $dob,
-                    'expected' => $actor['details']['dob'],
-                ]
-            );
-            return null;
-        }
-
-        $lpaData = $lpa->getData();
-        unset($lpaData['original_attorneys']);
-
-        return [
-            'actor' => $actor,
-            'lpa' => $lpaData
-        ];
     }
 
 
@@ -173,7 +119,7 @@ class ActorCodeService
                 );
 
                 $added = true;
-            } catch (Repository\KeyCollisionException $e) {
+            } catch (KeyCollisionException $e) {
                 // Allows the loop to repeat with a new ID.
             }
         } while (!$added);
@@ -181,8 +127,8 @@ class ActorCodeService
         //----
 
         try {
-            $this->actorCodesRepository->flagCodeAsUsed($code);
-        } catch (\Exception $e) {
+            $this->codeValidator->flagCodeAsUsed($code);
+        } catch (ActorCodeMarkAsUsedException $e) {
             $this->userLpaActorMapRepository->delete($id);
         }
 

--- a/service-api/app/src/App/src/Service/ActorCodes/CodeValidationStrategyInterface.php
+++ b/service-api/app/src/App/src/Service/ActorCodes/CodeValidationStrategyInterface.php
@@ -25,8 +25,7 @@ interface CodeValidationStrategyInterface
      * Marks a one-time-use actor code as used and returns the id of the UserLpaActorMap linking record.
      *
      * @param string $code
-     * @return string The id of the new UserLpaActorMap record
      * @throws ActorCodeMarkAsUsedException Thrown when the act of marking a code as used fails
      */
-    public function flagCodeAsUsed(string $code): string;
+    public function flagCodeAsUsed(string $code);
 }

--- a/service-api/app/src/App/src/Service/ActorCodes/CodeValidationStrategyInterface.php
+++ b/service-api/app/src/App/src/Service/ActorCodes/CodeValidationStrategyInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\ActorCodes;
+
+use App\Exception\ActorCodeMarkAsUsedException;
+use App\Exception\ActorCodeValidationException;
+
+interface CodeValidationStrategyInterface
+{
+    /**
+     * Checks that the given combination of parameters is a valid one-time-use actor code and returns the
+     * actors uId from the Sirius record if that is the case.
+     *
+     * @param string $code
+     * @param string $uid
+     * @param string $dob
+     * @return string The actor Uid from Sirius
+     * @throws ActorCodeValidationException Thrown when the validation of a set of details fails
+     */
+    public function validateCode(string $code, string $uid, string $dob): string;
+
+    /**
+     * Marks a one-time-use actor code as used and returns the id of the UserLpaActorMap linking record.
+     *
+     * @param string $code
+     * @return string The id of the new UserLpaActorMap record
+     * @throws ActorCodeMarkAsUsedException Thrown when the act of marking a code as used fails
+     */
+    public function flagCodeAsUsed(string $code): string;
+}

--- a/service-api/app/src/App/src/Service/ActorCodes/DynamoCodeValidationStrategy.php
+++ b/service-api/app/src/App/src/Service/ActorCodes/DynamoCodeValidationStrategy.php
@@ -99,7 +99,7 @@ class DynamoCodeValidationStrategy implements CodeValidationStrategyInterface
     /**
      * @inheritDoc
      */
-    public function flagCodeAsUsed(string $code): string
+    public function flagCodeAsUsed(string $code)
     {
         try {
             $this->actorCodesRepository->flagCodeAsUsed($code);

--- a/service-api/app/src/App/src/Service/ActorCodes/DynamoCodeValidationStrategy.php
+++ b/service-api/app/src/App/src/Service/ActorCodes/DynamoCodeValidationStrategy.php
@@ -46,6 +46,17 @@ class DynamoCodeValidationStrategy implements CodeValidationStrategyInterface
             throw new ActorCodeValidationException('Code already used');
         }
 
+        if ($uid !== $details['SiriusUid']) {
+            $this->logger->info(
+                'Uid {uid} did not match {expected} when validating actor code',
+                [
+                    'uid' => $uid,
+                    'expected' => $details['SiriusUid'],
+                ]
+            );
+            throw new ActorCodeValidationException('Bad LPA uId');
+        }
+
         $lpa = $this->lpaService->getByUid($details['SiriusUid']);
 
         if (is_null($lpa)) {
@@ -69,17 +80,6 @@ class DynamoCodeValidationStrategy implements CodeValidationStrategyInterface
                 ]
             );
             throw new ActorCodeValidationException('Actor not in LPA');
-        }
-
-        if ($uid !== $lpa->getData()['uId']) {
-            $this->logger->info(
-                'Uid {uid} did not match {expected} when validating actor code',
-                [
-                    'uid' => $uid,
-                    'expected' => $lpa->getData()['uId'],
-                ]
-            );
-            throw new ActorCodeValidationException('Bad LPA uId');
         }
 
         if ($dob !== $actor['details']['dob']) {

--- a/service-api/app/src/App/src/Service/ActorCodes/DynamoCodeValidationStrategy.php
+++ b/service-api/app/src/App/src/Service/ActorCodes/DynamoCodeValidationStrategy.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\ActorCodes;
+
+use App\DataAccess\Repository\ActorCodesInterface;
+use App\Exception\ActorCodeMarkAsUsedException;
+use App\Exception\ActorCodeValidationException;
+use App\Service\Lpa\LpaService;
+use Psr\Log\LoggerInterface;
+
+class DynamoCodeValidationStrategy implements CodeValidationStrategyInterface
+{
+    private LoggerInterface $logger;
+
+    private ActorCodesInterface $actorCodesRepository;
+
+    private LpaService $lpaService;
+
+    public function __construct(
+        ActorCodesInterface $actorCodesRepository,
+        LpaService $lpaService,
+        LoggerInterface $logger
+    ) {
+        $this->actorCodesRepository = $actorCodesRepository;
+        $this->lpaService = $lpaService;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validateCode(string $code, string $uid, string $dob): string
+    {
+        $details = $this->actorCodesRepository->get($code);
+
+        if (is_null($details)) {
+            $this->logger->info('Could not find details for code {code} when validating actor code', ['code' => $code]);
+            throw new ActorCodeValidationException('Code not found');
+        }
+
+        if ($details['Active'] !== true) {
+            $this->logger->info('{code} is inactive', ['code' => $code]);
+
+            throw new ActorCodeValidationException('Code already used');
+        }
+
+        $lpa = $this->lpaService->getByUid($details['SiriusUid']);
+
+        if (is_null($lpa)) {
+            $this->logger->error(
+                'Could not find LPA for SiriusUid {SiriusUid} when validating actor code',
+                [
+                    'SiriusUid' => $details['SiriusUid']
+                ]
+            );
+            throw new ActorCodeValidationException('LPA not found');
+        }
+
+        $actor = $this->lpaService->lookupActiveActorInLpa($lpa->getData(), (string)$details['ActorLpaId']);
+
+        if (is_null($actor)) {
+            $this->logger->error(
+                'Could not find actor {ActorLpaId} in LPA for SiriusUid {SiriusUid} when validating actor code',
+                [
+                    'ActorLpaId' => $details['ActorLpaId'],
+                    'SiriusUid' => $details['SiriusUid'],
+                ]
+            );
+            throw new ActorCodeValidationException('Actor not in LPA');
+        }
+
+        if ($uid !== $lpa->getData()['uId']) {
+            $this->logger->info(
+                'Uid {uid} did not match {expected} when validating actor code',
+                [
+                    'uid' => $uid,
+                    'expected' => $lpa->getData()['uId'],
+                ]
+            );
+            throw new ActorCodeValidationException('Bad LPA uId');
+        }
+
+        if ($dob !== $actor['details']['dob']) {
+            $this->logger->info(
+                'Dob {dob} did not match {expected} when validating actor code',
+                [
+                    'dob' => $dob,
+                    'expected' => $actor['details']['dob'],
+                ]
+            );
+            throw new ActorCodeValidationException('Bad date of birth');
+        }
+
+        return $actor['details']['uId'];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function flagCodeAsUsed(string $code): string
+    {
+        try {
+            $this->actorCodesRepository->flagCodeAsUsed($code);
+        } catch (\Exception $e) {
+            throw new ActorCodeMarkAsUsedException("Failed to mark code as used", 500, $e);
+        }
+    }
+}

--- a/service-api/app/src/App/src/Service/Lpa/LpaService.php
+++ b/service-api/app/src/App/src/Service/Lpa/LpaService.php
@@ -3,7 +3,6 @@
 namespace App\Service\Lpa;
 
 use App\DataAccess\Repository;
-use App\Exception\BadRequestException;
 use App\Exception\GoneException;
 use DateTime;
 use Psr\Log\LoggerInterface;
@@ -43,15 +42,14 @@ class LpaService
      * @var LoggerInterface
      */
     private $logger;
-    
+
     public function __construct(
         Repository\ViewerCodesInterface $viewerCodesRepository,
         Repository\ViewerCodeActivityInterface $viewerCodeActivityRepository,
         Repository\LpasInterface $lpaRepository,
         Repository\UserLpaActorMapInterface $userLpaActorMapRepository,
         LoggerInterface $logger
-    )
-    {
+    ) {
         $this->viewerCodesRepository = $viewerCodesRepository;
         $this->viewerCodeActivityRepository = $viewerCodeActivityRepository;
         $this->lpaRepository = $lpaRepository;
@@ -200,7 +198,6 @@ class LpaService
         // at this point as we only want to acknowledge if a code has expired iff donor surname matched.
 
         if (!isset($viewerCodeData['Expires']) || !($viewerCodeData['Expires'] instanceof DateTime)) {
-
             $this->logger->info('The code {code} entered by user to view LPA does not have an expiry date set.', ['code' => $viewerCode]);
             throw new RuntimeException("'Expires' field missing or invalid.");
         }
@@ -214,7 +211,6 @@ class LpaService
             $this->logger->info('The code {code} entered by user is cancelled.', ['code' => $viewerCode]);
             throw new GoneException('Share code cancelled');
         }
-        //---
 
         if ($logActivity) {
             // Record the lookup in the activity table
@@ -244,12 +240,13 @@ class LpaService
      * Given an LPA and an Actor ID, this returns the actor's details, and what type of actor they are.
      *
      * TODO: Confirm if we need to look in Trust Corporations, or if an active Trust Corporation would appear in `attorneys`.
+     * TODO: Remove dual checks for id/uId when code validation API goes live
      *
      * @param array $lpa
-     * @param int $actorId
+     * @param string $actorId
      * @return array|null
      */
-    public function lookupActiveActorInLpa(array $lpa, int $actorId): ?array
+    public function lookupActiveActorInLpa(array $lpa, string $actorId): ?array
     {
         $actor = null;
         $actorType = null;
@@ -257,38 +254,37 @@ class LpaService
         // Determine if the actor is a primary attorney
         if (isset($lpa['original_attorneys']) && is_array($lpa['original_attorneys'])) {
             foreach ($lpa['original_attorneys'] as $attorney) {
-                if ($attorney['id'] == $actorId) {
-                    switch (self::attorneyStatus($attorney)) {
-                    case self::ACTIVE_ATTORNEY:
-                        $actor = $attorney;
-                        $actorType = 'primary-attorney';
-                        break;
+                if ((string)$attorney['id'] === $actorId || $attorney['uId'] === $actorId) {
+                    switch ($this->attorneyStatus($attorney)) {
+                        case self::ACTIVE_ATTORNEY:
+                            $actor = $attorney;
+                            $actorType = 'primary-attorney';
+                            break;
 
-                    case self::GHOST_ATTORNEY:
-                        $this->logger->info('Looked up attorney {id} but is a ghost', ['id' => $attorney['id']]);
-                        break;
+                        case self::GHOST_ATTORNEY:
+                            $this->logger->info('Looked up attorney {id} but is a ghost', ['id' => $attorney['id']]);
+                            break;
 
-                    case self::INACTIVE_ATTORNEY:
-                        $this->logger->info('Looked up attorney {id} but is inactive', ['id' => $attorney['id']]);
-                        break;
+                        case self::INACTIVE_ATTORNEY:
+                            $this->logger->info('Looked up attorney {id} but is inactive', ['id' => $attorney['id']]);
+                            break;
                     }
                 }
             }
         } elseif (isset($lpa['attorneys']) && is_array($lpa['attorneys'])) {
             foreach ($lpa['attorneys'] as $attorney) {
-                if ($attorney['id'] == $actorId) {
+                if ((string)$attorney['id'] === $actorId || $attorney['uId'] === $actorId) {
                     $actor = $attorney;
                     $actorType = 'primary-attorney';
                 }
             }
         }
 
-        // If no an attorney, check if they're the donor.
+        // If not an attorney, check if they're the donor.
         if (
             is_null($actor) &&
-            isset($lpa['donor']) &&
-            is_array($lpa['donor']) &&
-            $lpa['donor']['id'] == $actorId
+            isset($lpa['donor']) && is_array($lpa['donor']) &&
+            ((string)$lpa['donor']['id'] === $actorId || $lpa['donor']['uId'] === $actorId)
         ) {
             $actor = $lpa['donor'];
             $actorType = 'donor';
@@ -304,7 +300,8 @@ class LpaService
         ];
     }
 
-    private function attorneyStatus(array $attorney): int {
+    private function attorneyStatus(array $attorney): int
+    {
         if (empty($attorney['firstname']) && empty($attorney['surname'])) {
             return self::GHOST_ATTORNEY;
         }

--- a/service-api/app/src/App/src/Service/Lpa/LpaService.php
+++ b/service-api/app/src/App/src/Service/Lpa/LpaService.php
@@ -75,7 +75,7 @@ class LpaService
         if ($lpaData['attorneys'] !== null) {
             $lpaData['original_attorneys'] = $lpaData['attorneys'];
             $lpaData['attorneys'] = array_values(array_filter($lpaData['attorneys'], function ($attorney) {
-                return self::attorneyStatus($attorney) === self::ACTIVE_ATTORNEY;
+                return $this->attorneyStatus($attorney) === self::ACTIVE_ATTORNEY;
             }));
         }
 

--- a/service-api/app/test/AppTest/Service/ActorCodes/ActorCodeServiceTest.php
+++ b/service-api/app/test/AppTest/Service/ActorCodes/ActorCodeServiceTest.php
@@ -5,45 +5,61 @@ declare(strict_types=1);
 namespace AppTest\Service\Lpa;
 
 use App\DataAccess\Repository;
+use App\DataAccess\Repository\ActorCodesInterface;
+use App\DataAccess\Repository\UserLpaActorMapInterface;
+use App\Exception\ActorCodeMarkAsUsedException;
+use App\Exception\ActorCodeValidationException;
 use App\Service\ActorCodes\ActorCodeService;
+use App\Service\ActorCodes\CodeValidationStrategyInterface;
 use App\Service\Lpa\LpaService;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\LoggerInterface;
 
 class ActorCodeServiceTest extends TestCase
 {
     /**
-     * @var Repository\ActorCodesInterface
+     * @var ActorCodesInterface|ObjectProphecy
      */
     private $actorCodesInterfaceProphecy;
 
     /**
-     * @var LpaService
+     * @var CodeValidationStrategyInterface|ObjectProphecy
+     */
+    private $codeValidatorProphecy;
+
+    /**
+     * @var LpaService|ObjectProphecy
      */
     private $lpaServiceProphecy;
 
     /**
-     * @var Repository\UserLpaActorMapInterface
+     * @var UserLpaActorMapInterface|ObjectProphecy
      */
     private $userLpaActorMapInterfaceProphecy;
 
     /**
-     * @var LoggerInterface
+     * @var LoggerInterface|ObjectProphecy
      */
     private $loggerProphecy;
 
     public function setUp()
     {
+        $this->codeValidatorProphecy = $this->prophesize(CodeValidationStrategyInterface::class);
         $this->lpaServiceProphecy = $this->prophesize(LpaService::class);
-        $this->actorCodesInterfaceProphecy = $this->prophesize(Repository\ActorCodesInterface::class);
-        $this->userLpaActorMapInterfaceProphecy = $this->prophesize(Repository\UserLpaActorMapInterface::class);
+        $this->actorCodesInterfaceProphecy = $this->prophesize(ActorCodesInterface::class);
+        $this->userLpaActorMapInterfaceProphecy = $this->prophesize(UserLpaActorMapInterface::class);
         $this->loggerProphecy = $this->prophesize(LoggerInterface::class);
     }
 
     /** @test */
     public function confirmation_with_invalid_details()
     {
+        $this->codeValidatorProphecy->validateCode('test-code', 'test-uid', 'test-dob')
+            ->shouldBeCalled()
+            ->willThrow(new ActorCodeValidationException());
+
         $service = $this->getActorCodeService();
 
         $result = $service->confirmDetails('test-code', 'test-uid', 'test-dob', 'test-user');
@@ -56,10 +72,9 @@ class ActorCodeServiceTest extends TestCase
     {
         $this->initValidParameterSet();
 
-        $this->actorCodesInterfaceProphecy->flagCodeAsUsed('test-code')
+        $this->codeValidatorProphecy->flagCodeAsUsed('test-code')
+            ->willReturn('id-of-db-row')
             ->shouldBeCalled();
-
-        //---
 
         $service = $this->getActorCodeService();
 
@@ -74,8 +89,8 @@ class ActorCodeServiceTest extends TestCase
     {
         $this->initValidParameterSet();
 
-        $this->actorCodesInterfaceProphecy->flagCodeAsUsed('test-code')
-            ->willThrow(new \Exception());
+        $this->codeValidatorProphecy->flagCodeAsUsed('test-code')
+            ->willThrow(new ActorCodeMarkAsUsedException());
 
         $this->userLpaActorMapInterfaceProphecy->create(
             Argument::that(
@@ -108,36 +123,15 @@ class ActorCodeServiceTest extends TestCase
     /** @test */
     public function successful_validation()
     {
-        $testCode = 'test-code';
-        $testUid = 'test-uid';
-        $testDob = 'test-dob';
-
-        $mockLpa = [
-            'uId' => $testUid,
-        ];
-
-        $mockActor = [
-            'details' => ['dob' => $testDob],
-        ];
-
-        $this->actorCodesInterfaceProphecy->get($testCode)->willReturn(
-            [
-                'Active' => true,
-                'SiriusUid' => $testUid,
-                'ActorLpaId' => 1,
-                'ActorCode' => $testCode,
-            ]
-        )->shouldBeCalled();
-
-        $this->lpaServiceProphecy->getByUid($testUid)->willReturn(
-            new Repository\Response\Lpa($mockLpa, null)
-        )->shouldBeCalled();
-
-        $this->lpaServiceProphecy->lookupActiveActorInLpa(Argument::type('array'), Argument::type('int'))
-            ->willReturn($mockActor)
-            ->shouldBeCalled();
-
-        //---
+        [
+            $testCode,
+            $testUid,
+            $testDob,
+            $testActorId,
+            $testActorUid,
+            $mockLpa,
+            $mockActor,
+        ] = $this->initValidParameterSet();
 
         $service = $this->getActorCodeService();
 
@@ -151,217 +145,15 @@ class ActorCodeServiceTest extends TestCase
     }
 
     /** @test */
-    public function validation_with_invalid_actor()
+    public function validation_fails()
     {
-        $testCode = 'test-code';
-        $testUid = 'test-uid';
-        $testDob = 'test-dob';
+        $testCode     = 'test-code';
+        $testUid      = 'test-uid';
+        $testDob      = 'test-dob';
 
-        $this->actorCodesInterfaceProphecy->get($testCode)->willReturn(
-            [
-                'Active' => true,
-                'SiriusUid' => $testUid,
-                'ActorLpaId' => 1,
-                'ActorCode' => 'different-actor-code',
-            ]
-        )->shouldBeCalled();
-
-        $this->lpaServiceProphecy->getByUid($testUid)->willReturn(
-            new Repository\Response\Lpa([], null)
-        )->shouldBeCalled();
-
-        $this->lpaServiceProphecy->lookupActiveActorInLpa(Argument::type('array'), Argument::type('int'))
-            ->willReturn(
-                [
-                    'details' => ['dob' => $testDob],
-                ]
-            )->shouldBeCalled();
-
-        //---
-
-        $service = $this->getActorCodeService();
-
-        $result = $service->validateDetails($testCode, $testUid, $testDob);
-
-        $this->assertNull($result);
-    }
-
-    /** @test */
-    public function validation_with_invalid_actor_code()
-    {
-        $testCode = 'test-code';
-        $testUid = 'test-uid';
-        $testDob = 'test-dob';
-
-        $this->actorCodesInterfaceProphecy->get($testCode)->willReturn(null)->shouldBeCalled();
-
-        //---
-
-        $service = $this->getActorCodeService();
-
-        $result = $service->validateDetails($testCode, $testUid, $testDob);
-
-        $this->assertNull($result);
-    }
-
-    /** @test */
-    public function validation_with_invalid_dob()
-    {
-        $testCode = 'test-code';
-        $testUid = 'test-uid';
-        $testDob = 'test-dob';
-
-        $this->actorCodesInterfaceProphecy->get($testCode)->willReturn(
-            [
-                'Active' => true,
-                'SiriusUid' => $testUid,
-                'ActorLpaId' => 1,
-                'ActorCode' => $testCode,
-            ]
-        )->shouldBeCalled();
-
-        $this->lpaServiceProphecy->getByUid($testUid)->willReturn(
-            new Repository\Response\Lpa(
-                [
-                    'uId' => $testUid,
-                ],
-                null
-            )
-        )->shouldBeCalled();
-
-        $this->lpaServiceProphecy->lookupActiveActorInLpa(Argument::type('array'), Argument::type('int'))
-            ->willReturn(
-                [
-                    'details' => ['dob' => 'different-dob'],
-                ]
-            )->shouldBeCalled();
-
-        //---
-
-        $service = $this->getActorCodeService();
-
-        $result = $service->validateDetails($testCode, $testUid, $testDob);
-
-        $this->assertNull($result);
-    }
-
-    /** @test */
-    public function validation_with_invalid_uid()
-    {
-        $testCode = 'test-code';
-        $testUid = 'test-uid';
-        $testDob = 'test-dob';
-
-        $this->actorCodesInterfaceProphecy->get($testCode)->willReturn(
-            [
-                'Active' => true,
-                'SiriusUid' => $testDob,
-                'ActorLpaId' => 1,
-                'ActorCode' => $testCode,
-            ]
-        )->shouldBeCalled();
-
-        $this->lpaServiceProphecy->getByUid($testDob)->willReturn(
-            new Repository\Response\Lpa(
-                [
-                    'uId' => 'different-uid',
-                ],
-                null
-            )
-        )->shouldBeCalled();
-
-        $this->lpaServiceProphecy->lookupActiveActorInLpa(Argument::type('array'), Argument::type('int'))->willReturn(
-            [
-                'details' => ['dob' => $testDob],
-            ]
-        )->shouldBeCalled();
-
-        //---
-
-        $service = $this->getActorCodeService();
-
-        $result = $service->validateDetails($testCode, $testUid, $testDob);
-
-        $this->assertNull($result);
-    }
-
-    /** @test */
-    public function validation_with_missing_actor()
-    {
-        $testCode = 'test-code';
-        $testUid = 'test-uid';
-        $testDob = 'test-dob';
-
-        $mockSiriusId = 'mock-id';
-
-        $mockLpa = new Repository\Response\Lpa([], null);
-
-        $this->actorCodesInterfaceProphecy->get($testCode)->willReturn(
-            [
-                'Active' => true,
-                'SiriusUid' => $mockSiriusId,
-                'ActorLpaId' => 1,
-            ]
-        )->shouldBeCalled();
-
-        $this->lpaServiceProphecy->getByUid($mockSiriusId)->willReturn(
-            $mockLpa
-        )->shouldBeCalled();
-
-        $this->lpaServiceProphecy->lookupActiveActorInLpa(Argument::type('array'), Argument::type('int'))
-            ->willReturn(null)
+        $this->codeValidatorProphecy->validateCode($testCode, $testUid, $testDob)
+            ->willThrow(new ActorCodeValidationException())
             ->shouldBeCalled();
-
-        //---
-
-        $service = $this->getActorCodeService();
-
-        $result = $service->validateDetails($testCode, $testUid, $testDob);
-
-        $this->assertNull($result);
-    }
-
-    //-------------------------------------
-
-    /** @test */
-    public function validation_with_missing_lpa()
-    {
-        $testCode = 'test-code';
-        $testUid = 'test-uid';
-        $testDob = 'test-dob';
-
-        $mockSiriusId = 'mock-id';
-
-        $this->actorCodesInterfaceProphecy->get($testCode)->willReturn(
-            [
-                'Active' => true,
-                'SiriusUid' => $mockSiriusId,
-            ]
-        )->shouldBeCalled();
-
-        $this->lpaServiceProphecy->getByUid($mockSiriusId)->willReturn(null)->shouldBeCalled();
-
-        //---
-
-        $service = $this->getActorCodeService();
-
-        $result = $service->validateDetails($testCode, $testUid, $testDob);
-
-        $this->assertNull($result);
-    }
-
-    /** @test */
-    public function validation_with_valid_actor_code_that_is_inactive()
-    {
-        $testCode = 'test-code';
-        $testUid = 'test-uid';
-        $testDob = 'test-dob';
-
-        $this->actorCodesInterfaceProphecy->get($testCode)->willReturn(
-            [
-                'Active' => false,
-            ]
-        )->shouldBeCalled();
 
         $service = $this->getActorCodeService();
 
@@ -373,6 +165,7 @@ class ActorCodeServiceTest extends TestCase
     private function getActorCodeService(): ActorCodeService
     {
         return new ActorCodeService(
+            $this->codeValidatorProphecy->reveal(),
             $this->actorCodesInterfaceProphecy->reveal(),
             $this->userLpaActorMapInterfaceProphecy->reveal(),
             $this->lpaServiceProphecy->reveal(),
@@ -380,12 +173,13 @@ class ActorCodeServiceTest extends TestCase
         );
     }
 
-    private function initValidParameterSet()
+    private function initValidParameterSet(): array
     {
         $testCode = 'test-code';
         $testUid = 'test-uid';
         $testDob = 'test-dob';
         $testActorId = 1;
+        $testActorUid = '123456789012';
 
         $mockLpa = [
             'uId' => $testUid,
@@ -394,26 +188,31 @@ class ActorCodeServiceTest extends TestCase
         $mockActor = [
             'details' => [
                 'dob' => $testDob,
-                'id' => $testActorId,
+                'id'  => $testActorId,
+                'uId' => $testActorUid,
             ],
         ];
 
-        $this->actorCodesInterfaceProphecy->get($testCode)->willReturn(
-            [
-                'Active' => true,
-                'SiriusUid' => $testUid,
-                'ActorLpaId' => $testActorId,
-                'ActorCode' => $testCode,
-            ]
-        )->shouldBeCalled();
+        $this->codeValidatorProphecy->validateCode($testCode, $testUid, $testDob)
+            ->willReturn($testActorUid)
+            ->shouldBeCalled();
 
         $this->lpaServiceProphecy->getByUid($testUid)->willReturn(
             new Repository\Response\Lpa($mockLpa, null)
         )->shouldBeCalled();
 
-        $this->lpaServiceProphecy->lookupActiveActorInLpa(Argument::type('array'), Argument::type('int'))
+        $this->lpaServiceProphecy->lookupActiveActorInLpa(Argument::type('array'), Argument::type('string'))
             ->willReturn($mockActor)
             ->shouldBeCalled();
-    }
 
+        return [
+            $testCode,
+            $testUid,
+            $testDob,
+            $testActorId,
+            $testActorUid,
+            $mockLpa,
+            $mockActor,
+        ];
+    }
 }

--- a/service-api/app/test/AppTest/Service/ActorCodes/DynamoCodeValidationStrategyTest.php
+++ b/service-api/app/test/AppTest/Service/ActorCodes/DynamoCodeValidationStrategyTest.php
@@ -1,0 +1,298 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppTest\Service\ActorCodes;
+
+use App\DataAccess\Repository\ActorCodesInterface;
+use App\DataAccess\Repository\Response\Lpa;
+use App\Exception\ActorCodeMarkAsUsedException;
+use App\Exception\ActorCodeValidationException;
+use App\Service\ActorCodes\DynamoCodeValidationStrategy;
+use App\Service\Lpa\LpaService;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Log\LoggerInterface;
+
+class DynamoCodeValidationStrategyTest extends TestCase
+{
+    /** @var ObjectProphecy|ActorCodesInterface */
+    private ObjectProphecy $actorCodeRepositoryProphecy;
+
+    /** @var ObjectProphecy|LoggerInterface */
+    private ObjectProphecy $loggerProphecy;
+
+    /** @var ObjectProphecy|LpaService */
+    private ObjectProphecy $lpaServiceProphecy;
+
+    public function initDependencies(): void
+    {
+        $this->actorCodeRepositoryProphecy = $this->prophesize(ActorCodesInterface::class);
+        $this->lpaServiceProphecy = $this->prophesize(LpaService::class);
+        $this->loggerProphecy = $this->prophesize(LoggerInterface::class);
+    }
+
+    /** @test */
+    public function it_will_validate_a_code(): void
+    {
+        $this->initDependencies();
+
+        $this->actorCodeRepositoryProphecy
+            ->get('actor-code')
+            ->willReturn(
+                [
+                    'Active'     => true,
+                    'SiriusUid'  => 'lpa-uid',
+                    'ActorLpaId' => 'actor-lpa-id'
+                ]
+            );
+
+        $lpa = new Lpa(
+            [
+                'uId' => 'lpa-uid'
+            ],
+            new \DateTime('now')
+        );
+
+        $this->lpaServiceProphecy
+            ->getByUid('lpa-uid')
+            ->willReturn($lpa);
+
+        $this->lpaServiceProphecy
+            ->lookupActiveActorInLpa($lpa->getData(), 'actor-lpa-id')
+            ->willReturn(
+                [
+                    'details' => [
+                        'uId' => 'actor-uid',
+                        'dob' => 'actor-dob'
+                    ]
+                ]
+            );
+
+        $strategy = new DynamoCodeValidationStrategy(
+            $this->actorCodeRepositoryProphecy->reveal(),
+            $this->lpaServiceProphecy->reveal(),
+            $this->loggerProphecy->reveal()
+        );
+
+        $actorUId = $strategy->validateCode('actor-code', 'lpa-uid', 'actor-dob');
+
+        $this->assertEquals('actor-uid', $actorUId);
+    }
+
+    /** @test */
+    public function it_wont_validate_a_nonexistant_code(): void
+    {
+        $this->initDependencies();
+
+        $strategy = new DynamoCodeValidationStrategy(
+            $this->actorCodeRepositoryProphecy->reveal(),
+            $this->lpaServiceProphecy->reveal(),
+            $this->loggerProphecy->reveal()
+        );
+
+        $this->expectException(ActorCodeValidationException::class);
+        $actorUId = $strategy->validateCode('actor-code', 'lpa-uid', 'actor-dob');
+    }
+
+    /** @test */
+    public function it_wont_validate_an_expired_code(): void
+    {
+        $this->initDependencies();
+
+        $this->actorCodeRepositoryProphecy
+            ->get('actor-code')
+            ->willReturn(
+                [
+                    'Active' => false
+                ]
+            );
+
+        $strategy = new DynamoCodeValidationStrategy(
+            $this->actorCodeRepositoryProphecy->reveal(),
+            $this->lpaServiceProphecy->reveal(),
+            $this->loggerProphecy->reveal()
+        );
+
+        $this->expectException(ActorCodeValidationException::class);
+        $actorUId = $strategy->validateCode('actor-code', 'lpa-uid', 'actor-dob');
+    }
+
+    /** @test */
+    public function it_wont_validate_a_mismatched_lpa_uid(): void
+    {
+        $this->initDependencies();
+
+        $this->actorCodeRepositoryProphecy
+            ->get('actor-code')
+            ->willReturn(
+                [
+                    'Active'     => true,
+                    'SiriusUid'  => 'different-lpa-uid',
+                    'ActorLpaId' => 'actor-lpa-id'
+                ]
+            );
+
+        $strategy = new DynamoCodeValidationStrategy(
+            $this->actorCodeRepositoryProphecy->reveal(),
+            $this->lpaServiceProphecy->reveal(),
+            $this->loggerProphecy->reveal()
+        );
+
+        $this->expectException(ActorCodeValidationException::class);
+        $actorUId = $strategy->validateCode('actor-code', 'lpa-uid', 'actor-dob');
+    }
+
+    /** @test */
+    public function it_wont_validate_a_code_when_lpa_not_found(): void
+    {
+        $this->initDependencies();
+
+        $this->actorCodeRepositoryProphecy
+            ->get('actor-code')
+            ->willReturn(
+                [
+                    'Active'     => true,
+                    'SiriusUid'  => 'lpa-uid',
+                    'ActorLpaId' => 'actor-lpa-id'
+                ]
+            );
+
+        $this->lpaServiceProphecy
+            ->getByUid('lpa-uid')
+            ->willReturn(null);
+
+        $strategy = new DynamoCodeValidationStrategy(
+            $this->actorCodeRepositoryProphecy->reveal(),
+            $this->lpaServiceProphecy->reveal(),
+            $this->loggerProphecy->reveal()
+        );
+
+        $this->expectException(ActorCodeValidationException::class);
+        $actorUId = $strategy->validateCode('actor-code', 'lpa-uid', 'actor-dob');
+    }
+
+    /** @test */
+    public function it_wont_validate_a_code_with_a_mismatched_actor(): void
+    {
+        $this->initDependencies();
+
+        $this->actorCodeRepositoryProphecy
+            ->get('actor-code')
+            ->willReturn(
+                [
+                    'Active'     => true,
+                    'SiriusUid'  => 'lpa-uid',
+                    'ActorLpaId' => 'actor-lpa-id'
+                ]
+            );
+
+        $lpa = new Lpa(
+            [
+                'uId' => 'lpa-uid'
+            ],
+            new \DateTime('now')
+        );
+
+        $this->lpaServiceProphecy
+            ->getByUid('lpa-uid')
+            ->willReturn($lpa);
+
+        $this->lpaServiceProphecy
+            ->lookupActiveActorInLpa($lpa->getData(), 'actor-lpa-id')
+            ->willReturn(null);
+
+        $strategy = new DynamoCodeValidationStrategy(
+            $this->actorCodeRepositoryProphecy->reveal(),
+            $this->lpaServiceProphecy->reveal(),
+            $this->loggerProphecy->reveal()
+        );
+
+        $this->expectException(ActorCodeValidationException::class);
+        $actorUId = $strategy->validateCode('actor-code', 'lpa-uid', 'actor-dob');
+    }
+
+    /** @test */
+    public function it_wont_validate_a_code_with_a_bad_dob(): void
+    {
+        $this->initDependencies();
+
+        $this->actorCodeRepositoryProphecy
+            ->get('actor-code')
+            ->willReturn(
+                [
+                    'Active'     => true,
+                    'SiriusUid'  => 'lpa-uid',
+                    'ActorLpaId' => 'actor-lpa-id'
+                ]
+            );
+
+        $lpa = new Lpa(
+            [
+                'uId' => 'lpa-uid'
+            ],
+            new \DateTime('now')
+        );
+
+        $this->lpaServiceProphecy
+            ->getByUid('lpa-uid')
+            ->willReturn($lpa);
+
+        $this->lpaServiceProphecy
+            ->lookupActiveActorInLpa($lpa->getData(), 'actor-lpa-id')
+            ->willReturn(
+                [
+                    'details' => [
+                        'uId' => 'actor-uid',
+                        'dob' => 'different-dob'
+                    ]
+                ]
+            );
+
+        $strategy = new DynamoCodeValidationStrategy(
+            $this->actorCodeRepositoryProphecy->reveal(),
+            $this->lpaServiceProphecy->reveal(),
+            $this->loggerProphecy->reveal()
+        );
+
+        $this->expectException(ActorCodeValidationException::class);
+        $actorUId = $strategy->validateCode('actor-code', 'lpa-uid', 'actor-dob');
+    }
+
+    /** @test */
+    public function it_will_flag_a_code_as_used(): void
+    {
+        $this->initDependencies();
+
+        $this->actorCodeRepositoryProphecy
+            ->flagCodeAsUsed('actor-code')
+            ->shouldBeCalled();
+
+        $strategy = new DynamoCodeValidationStrategy(
+            $this->actorCodeRepositoryProphecy->reveal(),
+            $this->lpaServiceProphecy->reveal(),
+            $this->loggerProphecy->reveal()
+        );
+
+        $strategy->flagCodeAsUsed('actor-code');
+    }
+
+    /** @test */
+    public function it_will_handle_an_exception_when_flagging_a_code_as_used(): void
+    {
+        $this->initDependencies();
+
+        $this->actorCodeRepositoryProphecy
+            ->flagCodeAsUsed('actor-code')
+            ->willThrow(new \Exception());
+
+        $strategy = new DynamoCodeValidationStrategy(
+            $this->actorCodeRepositoryProphecy->reveal(),
+            $this->lpaServiceProphecy->reveal(),
+            $this->loggerProphecy->reveal()
+        );
+
+        $this->expectException(ActorCodeMarkAsUsedException::class);
+        $strategy->flagCodeAsUsed('actor-code');
+    }
+}

--- a/service-api/app/test/AppTest/Service/Lpa/LpaServiceTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/LpaServiceTest.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace AppTest\Service\Lpa;
 
-use Laminas\Validator\Date;
+use App\DataAccess\Repository;
+use App\DataAccess\Repository\Response\Lpa;
+use App\Service\Lpa\LpaService;
+use DateTime;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
-use DateTime;
-use App\DataAccess\Repository;
-use App\Service\Lpa\LpaService;
-use PHPUnit\Framework\TestCase;
-use App\DataAccess\Repository\Response\Lpa;
 
 class LpaServiceTest extends TestCase
 {
@@ -503,18 +502,32 @@ class LpaServiceTest extends TestCase
     {
         $lpa = [
             'donor' => [
-                'id' => 1,
+                'id'  => 1,
+                'uId' => '123456789012'
             ]
         ];
 
         $service = $this->getLpaService();
 
-        $result = $service->lookupActiveActorInLpa($lpa, 1);
+        $result = $service->lookupActiveActorInLpa($lpa, '1');
 
-        $this->assertEquals([
-            'type' => 'donor',
-            'details' => $lpa['donor'],
-        ], $result);
+        $this->assertEquals(
+            [
+                'type' => 'donor',
+                'details' => $lpa['donor'],
+            ],
+            $result
+        );
+
+        $result = $service->lookupActiveActorInLpa($lpa, '123456789012');
+
+        $this->assertEquals(
+            [
+                'type' => 'donor',
+                'details' => $lpa['donor'],
+            ],
+            $result
+        );
     }
 
     /** @test */
@@ -525,20 +538,45 @@ class LpaServiceTest extends TestCase
                 'id' => 1,
             ],
             'original_attorneys' => [
-                ['id' => 1, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true],
-                ['id' => 3, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true],
-                ['id' => 7, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true]
+                ['id' => 1, 'uId' => '123456789012', 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true],
+                ['id' => 3, 'uId' => '234567890123', 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true],
+                ['id' => 7, 'uId' => '345678901234', 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true]
             ],
         ];
 
         $service = $this->getLpaService();
 
-        $result = $service->lookupActiveActorInLpa($lpa, 3);
+        $result = $service->lookupActiveActorInLpa($lpa, '3');
 
-        $this->assertEquals([
-            'type' => 'primary-attorney',
-            'details' => ['id' => 3, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true],
-        ], $result);
+        $this->assertEquals(
+            [
+                'type' => 'primary-attorney',
+                'details' => [
+                    'id' => 3,
+                    'uId' => '234567890123',
+                    'firstname' => 'A',
+                    'surname' => 'B',
+                    'systemStatus' => true
+                ],
+            ],
+            $result
+        );
+
+        $result = $service->lookupActiveActorInLpa($lpa, '234567890123');
+
+        $this->assertEquals(
+            [
+                'type' => 'primary-attorney',
+                'details' => [
+                    'id' => 3,
+                    'uId' => '234567890123',
+                    'firstname' => 'A',
+                    'surname' => 'B',
+                    'systemStatus' => true
+                ],
+            ],
+            $result
+        );
     }
 
     /** @test */
@@ -549,21 +587,30 @@ class LpaServiceTest extends TestCase
                 'id' => 1,
             ],
             'original_attorneys' => [
-                ['id' => 2, 'systemStatus' => true],
-                ['id' => 3, 'firstname' => 'A', 'systemStatus' => true],
-                ['id' => 7, 'surname' => 'B', 'systemStatus' => true]
+                ['id' => 2, 'uId' => '123456789012', 'systemStatus' => true],
+                ['id' => 3, 'uId' => '234567890123', 'firstname' => 'A', 'systemStatus' => true],
+                ['id' => 7, 'uId' => '345678901234', 'surname' => 'B', 'systemStatus' => true]
             ],
         ];
 
         $service = $this->getLpaService();
 
-        $result = $service->lookupActiveActorInLpa($lpa, 2);
+        $result = $service->lookupActiveActorInLpa($lpa, '2');
         $this->assertNull($result);
 
-        $result = $service->lookupActiveActorInLpa($lpa, 3);
+        $result = $service->lookupActiveActorInLpa($lpa, '123456789012');
+        $this->assertNull($result);
+
+        $result = $service->lookupActiveActorInLpa($lpa, '3');
         $this->assertNotNull($result);
 
-        $result = $service->lookupActiveActorInLpa($lpa, 7);
+        $result = $service->lookupActiveActorInLpa($lpa, '234567890123');
+        $this->assertNotNull($result);
+
+        $result = $service->lookupActiveActorInLpa($lpa, '7');
+        $this->assertNotNull($result);
+
+        $result = $service->lookupActiveActorInLpa($lpa, '345678901234');
         $this->assertNotNull($result);
     }
 
@@ -575,16 +622,18 @@ class LpaServiceTest extends TestCase
                 'id' => 1,
             ],
             'original_attorneys' => [
-                ['id' => 1, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true],
-                ['id' => 3, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => false],
-                ['id' => 7, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true]
+                ['id' => 1, 'uId' => '123456789012', 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true],
+                ['id' => 3, 'uId' => '234567890123', 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => false],
+                ['id' => 7, 'uId' => '345678901234', 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true]
             ],
         ];
 
         $service = $this->getLpaService();
 
-        $result = $service->lookupActiveActorInLpa($lpa, 3);
+        $result = $service->lookupActiveActorInLpa($lpa, '3');
+        $this->assertNull($result);
 
+        $result = $service->lookupActiveActorInLpa($lpa, '234567890123');
         $this->assertNull($result);
     }
 }


### PR DESCRIPTION
## Purpose
Abstracts our actor one time use code usage and verification out into a strategy interface so that we can replace it with the new microservice that deals with those things

Fixes UML-817

## Approach
Creation of a new `CodeValidationStrategyInterface` and associated `DynamoCodeValidationStrategy` to migrate our existing strategy to the new interface.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes

