### PR TITLE
Uml 686 email input

### DIFF
--- a/service-front/app/src/Actor/src/Form/CreateAccount.php
+++ b/service-front/app/src/Actor/src/Form/CreateAccount.php
@@ -33,7 +33,7 @@ class CreateAccount extends AbstractForm implements InputFilterProviderInterface
 
         $this->add([
             'name' => 'email',
-            'type' => 'Text',
+            'type' => 'Email',
         ]);
 
         $this->add([

--- a/service-front/app/src/Actor/src/Form/Login.php
+++ b/service-front/app/src/Actor/src/Form/Login.php
@@ -39,7 +39,7 @@ class Login extends AbstractForm implements InputFilterProviderInterface
 
         $this->add([
             'name' => 'email',
-            'type' => 'Text',
+            'type' => 'Email',
         ]);
 
         $this->add([

--- a/service-front/app/src/Actor/src/Form/PasswordResetRequest.php
+++ b/service-front/app/src/Actor/src/Form/PasswordResetRequest.php
@@ -28,7 +28,7 @@ class PasswordResetRequest extends AbstractForm implements InputFilterProviderIn
 
         $this->add([
             'name' => 'email',
-            'type' => 'Text',
+            'type' => 'Email',
         ]);
 
         $this->add([

--- a/service-front/app/src/Actor/src/Form/PasswordResetRequest.php
+++ b/service-front/app/src/Actor/src/Form/PasswordResetRequest.php
@@ -33,7 +33,7 @@ class PasswordResetRequest extends AbstractForm implements InputFilterProviderIn
 
         $this->add([
             'name' => 'email_confirm',
-            'type' => 'Text',
+            'type' => 'Email',
         ]);
     }
 

--- a/service-front/app/src/Actor/templates/actor/login.html.twig
+++ b/service-front/app/src/Actor/templates/actor/login.html.twig
@@ -30,7 +30,7 @@
 
                         {{ govuk_form_element(form.get('__csrf')) }}
 
-                        {{ govuk_form_element(form.get('email'), { 'label': 'Email address', 'attr': { 'class': 'govuk-!-width-one-half', 'auto-complete': 'username' } }) }}
+                        {{ govuk_form_element(form.get('email'), { 'label': 'Email address', 'attr': { 'class': 'govuk-!-width-one-half' } }) }}
 
                         {{ govuk_form_element(form.get('password'), { 'label': 'Password', 'attr': { 'class': 'govuk-!-width-one-half', 'auto-complete': 'current-password' } }) }}
 

--- a/service-front/app/src/Actor/templates/actor/password-reset-request.html.twig
+++ b/service-front/app/src/Actor/templates/actor/password-reset-request.html.twig
@@ -27,7 +27,7 @@
 
                         <input type="hidden" name="__csrf" value="{{ form.get('__csrf').value }}">
 
-                        {{ govuk_form_element(form.get('email'), { 'label': 'Email address', 'attr': { 'class': 'govuk-!-width-two-thirds', 'auto-complete': 'username' } }) }}
+                        {{ govuk_form_element(form.get('email'), { 'label': 'Email address', 'attr': { 'class': 'govuk-!-width-two-thirds' } }) }}
 
                         {{ govuk_form_element(form.get('email_confirm'), { 'label': 'Confirm your email address', 'attr': { 'class': 'govuk-!-width-two-thirds' } }) }}
 

--- a/service-front/app/src/Common/src/View/Twig/GovUKLaminasFormExtension.php
+++ b/service-front/app/src/Common/src/View/Twig/GovUKLaminasFormExtension.php
@@ -30,6 +30,7 @@ class GovUKLaminasFormExtension extends AbstractExtension
         Element\Csrf::class     => 'form_input_hidden',
         Element\Hidden::class   => 'form_input_hidden',
         Element\Password::class => 'form_input_password',
+        Element\Email::class    => 'form_input_email',
         Element\Text::class     => 'form_input_text',
         //  Fieldsets
         Date::class             => 'form_fieldset_date',

--- a/service-front/app/src/Common/templates/partials/govuk_form.html.twig
+++ b/service-front/app/src/Common/templates/partials/govuk_form.html.twig
@@ -33,7 +33,9 @@
         {% endif %}
 
         <input class="govuk-input {{- block('input_extra_class') -}} {{- block('input_error_class') -}}"
-               id="{{ element.getName() }}" name="{{ element.getName() }}" type="{{ type }}" value="{{ value }}" />
+                id="{{ element.getName() }}" name="{{ element.getName() }}" type="{{ type }}" value="{{ value }}"
+                {% if spellcheck is defined %}spellcheck="{{ spellcheck }}"{% endif %}
+                {% if autocomplete is defined %}autocomplete="{{ autocomplete }}"{% endif %} />
 
         {% if element.getName() == 'org_name' %}
             <button data-prevent-double-click="true" type="submit" class="govuk-button">
@@ -44,6 +46,13 @@
     </div>
 {%- endblock form_element_simple -%}
 
+{%- block form_input_email -%}
+    {%- set type = type|default('email') -%}
+    {%- set autocomplete = 'email' -%}
+    {%- set spellcheck = 'false' -%}
+    {%- set value = element.getValue() -%}
+    {{ block('form_element_simple') }}
+{%- endblock form_input_email -%}
 
 {%- block form_input_text -%}
     {%- set type = type|default('text') -%}

--- a/service-front/app/test/ActorTest/Form/CreateAccountTest.php
+++ b/service-front/app/test/ActorTest/Form/CreateAccountTest.php
@@ -33,7 +33,7 @@ class CreateAccountTest extends TestCase implements TestsLaminasForm
     {
         return [
             '__csrf'           => Csrf::class,
-            'email'            => Text::class,
+            'email'            => Email::class,
             'password'         => Password::class,
             'password_confirm' => Password::class,
             'terms'            => Checkbox::class,

--- a/service-front/app/test/ActorTest/Form/CreateAccountTest.php
+++ b/service-front/app/test/ActorTest/Form/CreateAccountTest.php
@@ -10,7 +10,7 @@ use Common\Form\Element\Csrf;
 use CommonTest\Form\{TestsLaminasForm, LaminasFormTests};
 use PHPUnit\Framework\TestCase;
 use Mezzio\Csrf\CsrfGuardInterface;
-use Laminas\Form\Element\{Checkbox, Password, Text};
+use Laminas\Form\Element\{Checkbox, Password, Email};
 
 class CreateAccountTest extends TestCase implements TestsLaminasForm
 {

--- a/service-front/app/test/ActorTest/Form/LoginTest.php
+++ b/service-front/app/test/ActorTest/Form/LoginTest.php
@@ -33,7 +33,7 @@ class LoginTest extends TestCase implements TestsLaminasForm
     {
         return [
             '__csrf'           => Csrf::class,
-            'email'            => Text::class,
+            'email'            => Email::class,
             'password'         => Password::class,
         ];
     }

--- a/service-front/app/test/ActorTest/Form/LoginTest.php
+++ b/service-front/app/test/ActorTest/Form/LoginTest.php
@@ -10,7 +10,7 @@ use Common\Form\Element\Csrf;
 use CommonTest\Form\{TestsLaminasForm, LaminasFormTests};
 use PHPUnit\Framework\TestCase;
 use Mezzio\Csrf\CsrfGuardInterface;
-use Laminas\Form\Element\{Password, Text};
+use Laminas\Form\Element\{Password, Email};
 
 class LoginTest extends TestCase implements TestsLaminasForm
 {

--- a/service-front/app/test/ActorTest/Form/PasswordResetRequestTest.php
+++ b/service-front/app/test/ActorTest/Form/PasswordResetRequestTest.php
@@ -10,7 +10,7 @@ use Common\Form\Element\Csrf;
 use CommonTest\Form\{TestsLaminasForm, LaminasFormTests};
 use PHPUnit\Framework\TestCase;
 use Mezzio\Csrf\CsrfGuardInterface;
-use Laminas\Form\Element\Text;
+use Laminas\Form\Element\Email;
 
 class PasswordResetRequestTest extends TestCase implements TestsLaminasForm
 {

--- a/service-front/app/test/ActorTest/Form/PasswordResetRequestTest.php
+++ b/service-front/app/test/ActorTest/Form/PasswordResetRequestTest.php
@@ -33,8 +33,8 @@ class PasswordResetRequestTest extends TestCase implements TestsLaminasForm
     {
         return [
             '__csrf'           => Csrf::class,
-            'email'            => Text::class,
-            'email_confirm'    => Text::class,
+            'email'            => Email::class,
+            'email_confirm'    => Email::class,
         ];
     }
 


### PR DESCRIPTION
## Purpose
Allows the use of the Form Email type and updates existing components. Will show the email keyboard on mobile devices.

Fixes UML-686

## Approach

Adds the Email type to the list of available field Types

## Learning

None

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes

