### PR TITLE
Added inputmode=email for native keyboards

### DIFF
--- a/service-front/app/src/Common/templates/partials/govuk_form.html.twig
+++ b/service-front/app/src/Common/templates/partials/govuk_form.html.twig
@@ -34,6 +34,7 @@
 
         <input class="govuk-input {{- block('input_extra_class') -}} {{- block('input_error_class') -}}"
                 id="{{ element.getName() }}" name="{{ element.getName() }}" type="{{ type }}" value="{{ value }}"
+                {% if inputmode is defined %}inputmode="{{ inputmode }}"{% endif %}
                 {% if spellcheck is defined %}spellcheck="{{ spellcheck }}"{% endif %}
                 {% if autocomplete is defined %}autocomplete="{{ autocomplete }}"{% endif %} />
 
@@ -48,6 +49,7 @@
 
 {%- block form_input_email -%}
     {%- set type = type|default('email') -%}
+    {%- set inputmode = 'email' -%}
     {%- set autocomplete = 'email' -%}
     {%- set spellcheck = 'false' -%}
     {%- set value = element.getValue() -%}


### PR DESCRIPTION
## Purpose
Adds further inbuilt virutal keyboard functionality for email addresses

Fixes UML-865

## Approach

Implements the DAC report suggestions

## Learning

Cool stuff here for how you can take advantage of other field types https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

