### PR TITLE
add alt text to uses of LPA acronym

### DIFF
--- a/service-front/app/src/Actor/templates/actor/activate-account-not-found.html.twig
+++ b/service-front/app/src/Actor/templates/actor/activate-account-not-found.html.twig
@@ -22,7 +22,7 @@
                     <ul class="list list-bullet">
                         <li>
                             <p class="govuk-body govuk-!-font-weight-bold">You already have an active account</p>
-                            <p class="govuk-body">If so, you can sign in to your <a href="{{ url('login') }}">existing Use an LPA account</a> to add an LPA.</p>
+                            <p class="govuk-body">If so, you can sign in to your <a href="{{ url('login') }}">existing Use an <abbr title="lasting power of attorney">LPA</abbr> account</a> to add an <abbr title="lasting power of attorney">LPA</abbr>.</p>
                         </li>
                         <li>
                             <p class="govuk-body govuk-!-font-weight-bold">You created the account more than 24 hours ago</p>

--- a/service-front/app/src/Actor/templates/actor/actor-terms-of-use.html.twig
+++ b/service-front/app/src/Actor/templates/actor/actor-terms-of-use.html.twig
@@ -15,26 +15,26 @@
                     <h1 class="govuk-heading-xl">Terms of use</h1>
 
                     <p class="govuk-body">The Use a lasting power of attorney (LPA) service lets you create
-                        ‘access codes’ to give to professionals or organisations so they can view an online summary of an LPA. For example,
+                        ‘access codes’ to give to professionals or organisations so they can view an online summary of an <abbr title="lasting power of attorney">LPA</abbr>. For example,
                         financial institutions, medical professionals, and care organisations.</p>
 
-                    <p class="govuk-body">The service is for donors and attorneys on an LPA.</p>
+                    <p class="govuk-body">The service is for donors and attorneys on an <abbr title="lasting power of attorney">LPA</abbr>.</p>
 
-                    <p class="govuk-body">You should be able to use this service instead of showing someone the original paper LPA. </p>
+                    <p class="govuk-body">You should be able to use this service instead of showing someone the original paper <abbr title="lasting power of attorney">LPA</abbr>. </p>
 
-                    <p class="govuk-body govuk-!-font-weight-bold"> ! You cannot use a download or print out of the LPA summary in place of the
-                        original paper LPA or instead of giving someone an access code</p>
+                    <p class="govuk-body govuk-!-font-weight-bold"> ! You cannot use a download or print out of the <abbr title="lasting power of attorney">LPA</abbr> summary in place of the
+                        original paper <abbr title="lasting power of attorney">LPA</abbr> or instead of giving someone an access code</p>
 
                     <p class="govuk-body">By using this service you agree to these terms of use and the <a class="govuk-link" href="https://www.gov.uk/help/terms-conditions">GOV.UK terms and conditions</a>.</p>
 
                     <h2 class="govuk-heading-m">Your responsibilities as an attorney</h2>
 
-                    <p class="govuk-body">If you’re an attorney, remember that using this service to give someone access to a summary of the LPA, is the same as using the original paper LPA.</p>
+                    <p class="govuk-body">If you’re an attorney, remember that using this service to give someone access to a summary of the <abbr title="lasting power of attorney">LPA</abbr>, is the same as using the original paper <abbr title="lasting power of attorney">LPA</abbr>.</p>
 
-                    <p class="govuk-body">When using an LPA you must always follow the legal responsibilities you agreed to when you signed the LPA. For example, you must always:</p>
+                    <p class="govuk-body">When using an <abbr title="lasting power of attorney">LPA</abbr> you must always follow the legal responsibilities you agreed to when you signed the <abbr title="lasting power of attorney">LPA</abbr>. For example, you must always:</p>
                     <ul class="govuk-list govuk-list--bullet">
                         <li>follow the principles of the <a class="govuk-link" href="https://www.gov.uk/government/publications/mental-capacity-act-code-of-practice">Mental Capacity Act</a></li>
-                        <li>take into account any instructions or preferences the donor set out in their LPA</li>
+                        <li>take into account any instructions or preferences the donor set out in their <abbr title="lasting power of attorney">LPA</abbr></li>
                         <li>act in the best interests of the donor</li>
                     </ul>
 
@@ -48,13 +48,13 @@
 
                     <p class="govuk-body">We recommend that you sign out of your account when you’re not using the service. We’ll automatically sign you out if you’ve not used the service for 60 minutes.</p>
 
-                    <p class="govuk-body">If you download or print a copy of the LPA summary, make sure you keep the information safe and secure.</p>
+                    <p class="govuk-body">If you download or print a copy of the <abbr title="lasting power of attorney">LPA</abbr> summary, make sure you keep the information safe and secure.</p>
 
                     <h3 class="govuk-heading-s">Use access codes responsibly</h3>
 
-                    <p class="govuk-body">When you give someone an LPA access code, you’re giving them access to personal information about the donor and attorneys on an LPA.</p>
+                    <p class="govuk-body">When you give someone an <abbr title="lasting power of attorney">LPA</abbr> access code, you’re giving them access to personal information about the donor and attorneys on an <abbr title="lasting power of attorney">LPA</abbr>.</p>
 
-                    <p class="govuk-body">Keep access codes secure. Only give access codes to professionals and organisations you trust and who have an appropriate need to view the LPA.</p>
+                    <p class="govuk-body">Keep access codes secure. Only give access codes to professionals and organisations you trust and who have an appropriate need to view the <abbr title="lasting power of attorney">LPA</abbr>.</p>
 
                     <p class="govuk-body">We’re not responsible for how personal information, accessed using a code you’ve created, is used, shared, or held.</p>
 
@@ -74,8 +74,8 @@
 
                     <h2 class="govuk-heading-m">Let us know if you want us to change the LPA</h2>
 
-                    <p class="govuk-body">When professionals and organisations view the LPA summary, it’s important they see up to date information.</p>
-                    <p class="govuk-body">Let the Office of the Public Guardian (OPG) know if <a class="govuk-link" href="https://www.gov.uk/power-of-attorney/change-your-lasting-power-of-attorney">changes need to be made to information in an LPA</a>.
+                    <p class="govuk-body">When professionals and organisations view the <abbr title="lasting power of attorney">LPA</abbr> summary, it’s important they see up to date information.</p>
+                    <p class="govuk-body">Let the Office of the Public Guardian (OPG) know if <a class="govuk-link" href="https://www.gov.uk/power-of-attorney/change-your-lasting-power-of-attorney">changes need to be made to information in an <abbr title="lasting power of attorney">LPA</abbr></a>.
                         We’ll then update the lasting power of attorney register and make the changes for you to the online summary.
                     </p>
 
@@ -84,19 +84,19 @@
                         <li>the donor or an attorney changes their name or address</li>
                         <li>the donor wants to remove an attorney</li>
                         <li>an attorney dies or can no longer act</li>
-                        <li>the donor wants to cancel their LPA</li>
+                        <li>the donor wants to cancel their <abbr title="lasting power of attorney">LPA</abbr></li>
                     </ul>
 
                     <p class="govuk-body">Once you’ve let us know about a change, it may be a few days before this shows on the online service.</p>
 
                     <p class="govuk-body">Please let us know if changes need to be made as soon as you can.</p>
 
-                    <p class="govuk-body"><b>Only the Court of Protection can change a registered LPA</b>. You must not make changes to the paper LPA with a pen, correction fluid or in any other way.
-                        This applies to all changes, even small things like correcting a spelling mistake in someone’s name. If you change the LPA, you may not be able to use it anymore.</p>
+                    <p class="govuk-body"><b>Only the Court of Protection can change a registered <abbr title="lasting power of attorney">LPA</abbr></b>. You must not make changes to the paper <abbr title="lasting power of attorney">LPA</abbr> with a pen, correction fluid or in any other way.
+                        This applies to all changes, even small things like correcting a spelling mistake in someone’s name. If you change the <abbr title="lasting power of attorney">LPA</abbr>, you may not be able to use it anymore.</p>
 
                     <h2 class="govuk-heading-m">The online summary</h2>
 
-                    <p class="govuk-body">Screenshots, downloads or print outs of the online LPA summary are not proof of an LPA and may not show the latest status of an LPA.</p>
+                    <p class="govuk-body">Screenshots, downloads or print outs of the online <abbr title="lasting power of attorney">LPA</abbr> summary are not proof of an <abbr title="lasting power of attorney">LPA</abbr> and may not show the latest status of an <abbr title="lasting power of attorney">LPA</abbr>.</p>
 
                     <h2 class="govuk-heading-m">Governing law</h2>
                     <p class="govuk-body">These terms of use are governed by the laws of England and Wales, including:</p>

--- a/service-front/app/src/Actor/templates/actor/change-details.html.twig
+++ b/service-front/app/src/Actor/templates/actor/change-details.html.twig
@@ -23,7 +23,7 @@
                     <h1 class="govuk-heading-xl">Let us know if a donor or attorney's details change</h1>
 
                     <p class="govuk-body">It's important that we hold up-to-date information about donors and attorneys. This is because the first
-                        time you show an LPA to an organisation, they might ask you to confirm that your name and address match what’s on the LPA.</p>
+                        time you show an <abbr title="lasting power of attorney">LPA</abbr> to an organisation, they might ask you to confirm that your name and address match what’s on the <abbr title="lasting power of attorney">LPA</abbr>.</p>
 
                     <p class="govuk-body">You should contact us if:</p>
 
@@ -34,9 +34,9 @@
                         <li>a date of birth is wrong</li>
                     </ul>
 
-                    <p class="govuk-body">We’ll update the online LPA summary and our records.</p>
+                    <p class="govuk-body">We’ll update the online <abbr title="lasting power of attorney">LPA</abbr> summary and our records.</p>
 
-                    <p class="govuk-body">Do not make any changes to the paper LPA yourself. If you do, you’ll no longer be able to use the LPA.</p>
+                    <p class="govuk-body">Do not make any changes to the paper <abbr title="lasting power of attorney">LPA</abbr> yourself. If you do, you’ll no longer be able to use the <abbr title="lasting power of attorney">LPA</abbr>.</p>
 
                     <h2 class="govuk-heading-m">How to let us know</h2>
 

--- a/service-front/app/src/Actor/templates/actor/check-access-codes.html.twig
+++ b/service-front/app/src/Actor/templates/actor/check-access-codes.html.twig
@@ -61,7 +61,7 @@
 
                             <h2 class="govuk-heading-m">Active codes</h2>
 
-                            <p class="govuk-body">Give an organisation their access code so they can view this LPA.</p>
+                            <p class="govuk-body">Give an organisation their access code so they can view this <abbr title="lasting power of attorney">LPA</abbr>.</p>
 
                             <div class="govuk-inset-text">
                                 <p class="govuk-body-s">
@@ -86,7 +86,7 @@
                             <h2 class="govuk-heading-m">Inactive codes</h2>
 
                             <p class="govuk-body">The following codes will no longer work.<br>
-                                If an organisation asks to see this LPA again, you can <a href="{{ path('lpa.create-code', {}, {'lpa':  actorToken }) }}">make them a new code</a>.
+                                If an organisation asks to see this <abbr title="lasting power of attorney">LPA</abbr> again, you can <a href="{{ path('lpa.create-code', {}, {'lpa':  actorToken }) }}">make them a new code</a>.
                             </p>
 
                             <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">

--- a/service-front/app/src/Actor/templates/actor/confirm-cancel-code.html.twig
+++ b/service-front/app/src/Actor/templates/actor/confirm-cancel-code.html.twig
@@ -16,7 +16,7 @@
                     <h1 class="govuk-heading-xl">Are you sure you want to cancel this code?</h1>
 
                     <p class="govuk-body">You're about to cancel the access code for {{ form.get('organisation').getValue() }}</p><br>
-                    <p class="govuk-body">Doing this will stop the organisation from accessing the LPA summary. You can give access again by creating a new code.</p>
+                    <p class="govuk-body">Doing this will stop the organisation from accessing the <abbr title="lasting power of attorney">LPA</abbr> summary. You can give access again by creating a new code.</p>
 
                     {{ govuk_form_open(form) }}
 

--- a/service-front/app/src/Actor/templates/actor/confirm-delete-account.html.twig
+++ b/service-front/app/src/Actor/templates/actor/confirm-delete-account.html.twig
@@ -17,16 +17,16 @@
                     <p class="govuk-body">If you delete your Use a lasting power of attorney account:</p>
 
                     <ul class="govuk-list govuk-list--bullet">
-                        <li>any LPAs you added will be removed</li>
-                        <li>you‘ll not be able to see how those LPAs are being used</li>
+                        <li>any <abbr title="lasting powers of attorney">LPAs</abbr> you added will be removed</li>
+                        <li>you‘ll not be able to see how those <abbr title="lasting powers of attorney">LPAs</abbr> are being used</li>
                     </ul>
 
-                    <p class="govuk-body">If you want to use the LPA online after you've deleted your account, you’ll need to contact us.</p>
+                    <p class="govuk-body">If you want to use the <abbr title="lasting power of attorney">LPA</abbr> online after you've deleted your account, you’ll need to contact us.</p>
 
-                    <p class="govuk-body">You can still use paper versions of these LPAs if:</p>
+                    <p class="govuk-body">You can still use paper versions of these <abbr title="lasting powers of attorney">LPAs</abbr> if:</p>
 
                     <ul class="govuk-list govuk-list--bullet">
-                        <li>the LPAs are still valid</li>
+                        <li>the <abbr title="lasting powers of attorney">LPAs</abbr> are still valid</li>
                         <li>you have not been removed as an attorney</li>
                     </ul><br>
 

--- a/service-front/app/src/Actor/templates/actor/home-page.html.twig
+++ b/service-front/app/src/Actor/templates/actor/home-page.html.twig
@@ -19,14 +19,14 @@
                 <p class="govuk-body">If you are a donor or attorney on a lasting power of attorney (LPA), you can use this service to:</p>
 
                 <ul class="govuk-list govuk-list--bullet">
-                    <li>give organisations access to the online summary of an LPA by making a secure access code</li>
-                    <li>keep track of which organisations have been given online access to the LPA</li>
-                    <li>view the LPA summary yourself</li>
+                    <li>give organisations access to the online summary of an <abbr title="lasting power of attorney">LPA</abbr> by making a secure access code</li>
+                    <li>keep track of which organisations have been given online access to the <abbr title="lasting power of attorney">LPA</abbr></li>
+                    <li>view the <abbr title="lasting power of attorney">LPA</abbr> summary yourself</li>
                 </ul>
 
-                <p class="govuk-body">Organisations should accept this online summary, rather than asking you to show or post them the paper LPA.</p>
+                <p class="govuk-body">Organisations should accept this online summary, rather than asking you to show or post them the paper <abbr title="lasting power of attorney">LPA</abbr>.</p>
 
-                <div class="govuk-inset-text">This service is only for LPAs made in England or Wales.</div>
+                <div class="govuk-inset-text">This service is only for <abbr title="lasting powers of attorney">LPAs</abbr> made in England or Wales.</div>
 
                 <p class="govuk-body"><a href="{{ path('login') }}" class="govuk-link">Sign in to your existing account</a></p>
 
@@ -36,7 +36,7 @@
                         <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
                     </svg>
                 </a>
-                
+
             </div>
         </div>
 

--- a/service-front/app/src/Actor/templates/actor/instructions-preferences.html.twig
+++ b/service-front/app/src/Actor/templates/actor/instructions-preferences.html.twig
@@ -18,7 +18,7 @@
                 </h1>
                 <div class="govuk-grid-column-two-thirds">
 
-                        <p class="govuk-body">If an LPA has instructions or preferences we cannot show these online. Organisations might ask to see the paper LPA so that they can read the instructions and preferences.</p>
+                        <p class="govuk-body">If an <abbr title="lasting power of attorney">LPA</abbr> has instructions or preferences we cannot show these online. Organisations might ask to see the paper <abbr title="lasting power of attorney">LPA</abbr> so that they can read the instructions and preferences.</p>
                         <p class="govuk-body">In some older LPA's, instructions and preferences are called 'restrictions and conditions'.</p>
                 </div>
             </div>

--- a/service-front/app/src/Actor/templates/actor/login.html.twig
+++ b/service-front/app/src/Actor/templates/actor/login.html.twig
@@ -26,7 +26,7 @@
                             </h1>
                         </legend>
 
-                        <p class="govuk-body">If you made an LPA online, you'll still need to <a href="{{ path('create-account') }}" class="govuk-link">make an account</a> to use this service.</p>
+                        <p class="govuk-body">If you made an <abbr title="lasting power of attorney">LPA</abbr> online, you'll still need to <a href="{{ path('create-account') }}" class="govuk-link">make an account</a> to use this service.</p>
 
                         {{ govuk_form_element(form.get('__csrf')) }}
 

--- a/service-front/app/src/Actor/templates/actor/lpa-add.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-add.html.twig
@@ -20,7 +20,7 @@
 
                 <h1 class="govuk-heading-xl">Add a lasting power of attorney</h1>
 
-                <p class="govuk-body-l">You'll need the details from the letter we sent you when the LPA was registered.</p>
+                <p class="govuk-body-l">You'll need the details from the letter we sent you when the <abbr title="lasting power of attorney">LPA</abbr> was registered.</p>
 
                 {{ govuk_form_open(form) }}
 
@@ -37,8 +37,8 @@
                         </summary>
                         <div class="govuk-details__text">
                             <ul class="govuk-list govuk-list--bullet">
-                                <li>The reference number is printed on the letter that told you the LPA had been registered.</li>
-                                <li>You can also find the reference number on the LPA or any related letters from the Office of the Public Guardian.</li>
+                                <li>The reference number is printed on the letter that told you the <abbr title="lasting power of attorney">LPA</abbr> had been registered.</li>
+                                <li>You can also find the reference number on the <abbr title="lasting power of attorney">LPA</abbr> or any related letters from the Office of the Public Guardian.</li>
                                 <li>It may be marked 'OPG reference number' or 'Our ref' or 'Case number'.</li>
                             </ul>
 
@@ -58,7 +58,7 @@
                             </span>
                         </summary>
                         <div class="govuk-details__text">
-                            <p>Your activation key is printed on the letter that told you the LPA had been registered. The donor and each attorney will have their own unique activation key.</p>
+                            <p>Your activation key is printed on the letter that told you the <abbr title="lasting power of attorney">LPA</abbr> had been registered. The donor and each attorney will have their own unique activation key.</p>
                             <p>
                                 If you cannot find it, please call us:<br/>
                                 Telephone: 0300 456 0300<br/>

--- a/service-front/app/src/Actor/templates/actor/lpa-blank-dashboard.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-blank-dashboard.html.twig
@@ -21,15 +21,15 @@
                     <details class="govuk-details" data-module="govuk-details">
                         <summary class="govuk-details__summary">
                         <span class="govuk-details__summary-text">
-                          What can I do with my LPAs?
+                          What can I do with my <abbr title="lasting powers of attorney">LPAs</abbr>?
                         </span>
                         </summary>
                         <div class="govuk-details__text">
                             <p>From this page you can:</p>
                             <ul class="govuk-list govuk-list--bullet">
-                                <li>give organisations access to an online summary of an LPA by making a secure access code</li>
-                                <li>keep track of the organisations that have online access to an LPA</li>
-                                <li>view an LPA summary</li>
+                                <li>give organisations access to an online summary of an <abbr title="lasting power of attorney">LPA</abbr> by making a secure access code</li>
+                                <li>keep track of the organisations that have online access to an <abbr title="lasting power of attorney">LPA</abbr></li>
+                                <li>view an <abbr title="lasting power of attorney">LPA</abbr> summary</li>
                             </ul>
                         </div>
                     </details>

--- a/service-front/app/src/Actor/templates/actor/lpa-create-viewercode.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-create-viewercode.html.twig
@@ -46,7 +46,7 @@
                         <p class="govuk-body">The organisation could be a bank, energy provider, or another business.</p>
                     {% endif %}
 
-                    <p class="govuk-body">Email <a href="mailto:lpa.research@digital.justice.gov.uk">lpa.research@digital.justice.gov.uk</a> to find out if the organisation is taking part in the trial and how to give them the access code. If you need to show the LPA to more than one organisation, list the organisations in one email.</p>
+                    <p class="govuk-body">Email <a href="mailto:lpa.research@digital.justice.gov.uk">lpa.research@digital.justice.gov.uk</a> to find out if the organisation is taking part in the trial and how to give them the access code. If you need to show the <abbr title="lasting power of attorney">LPA</abbr> to more than one organisation, list the organisations in one email.</p>
 
                     {{ govuk_form_element(form.get('org_name'), { 'label': 'Organisation name', 'hint': 'This is for your reference only', 'attr' : {'class': 'govuk-!-width-one-half'} }) }}
 

--- a/service-front/app/src/Actor/templates/actor/lpa-dashboard.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-dashboard.html.twig
@@ -21,15 +21,15 @@
                 <details class="govuk-details" data-module="govuk-details">
                     <summary class="govuk-details__summary">
                         <span class="govuk-details__summary-text">
-                          What can I do with my LPAs?
+                          What can I do with my <abbr title="lasting powers of attorney">LPAs</abbr>?
                         </span>
                     </summary>
                     <div class="govuk-details__text">
                         <p>From this page you can:</p>
                         <ul class="govuk-list govuk-list--bullet">
-                            <li>give organisations access to an online summary of this LPA by making a secure access code</li>
-                            <li>keep track of which organisations have been given online access to the LPA</li>
-                            <li>view the LPA summary</li>
+                            <li>give organisations access to an online summary of this <abbr title="lasting power of attorney">LPA</abbr> by making a secure access code</li>
+                            <li>keep track of which organisations have been given online access to the <abbr title="lasting power of attorney">LPA</abbr></li>
+                            <li>view the <abbr title="lasting power of attorney">LPA</abbr> summary</li>
                         </ul>
                     </div>
                 </details>

--- a/service-front/app/src/Actor/templates/actor/lpa-not-found.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-not-found.html.twig
@@ -15,7 +15,7 @@
 
                     <h1 class="govuk-heading-xl">We could not find that lasting power of attorney</h1>
 
-                    <p class="govuk-body">We could not find a lasting power of attorney with the activation key, LPA reference number and date of birth you entered.</p>
+                    <p class="govuk-body">We could not find a lasting power of attorney with the activation key, <abbr title="lasting power of attorney">LPA</abbr> reference number and date of birth you entered.</p>
 
                     <p class="govuk-body">If you're sure you entered the right information, please contact us on 0300 456 0300.</p>
 

--- a/service-front/app/src/Actor/templates/actor/lpa-removed.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-removed.html.twig
@@ -18,10 +18,10 @@
 
                     <h1 class="govuk-heading-xl">We've removed an LPA from your account</h1>
 
-                    <p class="govuk-body">We've removed an LPA from your account because either:</p>
+                    <p class="govuk-body">We've removed an <abbr title="lasting power of attorney">LPA</abbr> from your account because either:</p>
 
                     <ul class="govuk-list govuk-list--bullet">
-                        <li>you can no longer act as an attorney on the LPA</li>
+                        <li>you can no longer act as an attorney on the <abbr title="lasting power of attorney">LPA</abbr></li>
                         <li>you've told us you no longer want to be an attorney</li>
                         <li>the donor has removed you as an attorney</li>
                     </ul>

--- a/service-front/app/src/Actor/templates/actor/partials/lpa-details.html.twig
+++ b/service-front/app/src/Actor/templates/actor/partials/lpa-details.html.twig
@@ -44,7 +44,7 @@
 </dl>
 {%  if not actorActive %}
     <div class="lpa-inactive-notice" >
-        <p class="govuk-body govuk-!-padding-2 govuk-!-margin-left-2 govuk-!-margin-bottom-0">You no longer have access to this LPA.
+        <p class="govuk-body govuk-!-padding-2 govuk-!-margin-left-2 govuk-!-margin-bottom-0">You no longer have access to this <abbr title="lasting power of attorney">LPA</abbr>.
             <a class="govuk-!-margin-left-3 govuk-link" href="{{ path('lpa.removed') }}"> Why is this?</a>
         </p>
     </div>
@@ -56,4 +56,3 @@
     </p>
     </div>
 {% endif %}
-

--- a/service-front/app/src/Actor/templates/actor/password-reset-request-done.html.twig
+++ b/service-front/app/src/Actor/templates/actor/password-reset-request-done.html.twig
@@ -21,7 +21,7 @@
                     folder &mdash; your email system may have blocked it by mistake.</p>
 
                 <p class="govuk-body">If it does not arrive at all, please check that you've given us the correct email address for your
-                    existing LPA account &mdash; we'll only send a password reset link to the email address belonging to an account.</p>
+                    existing <abbr title="lasting power of attorney">LPA</abbr> account &mdash; we'll only send a password reset link to the email address belonging to an account.</p>
             </div>
         </div>
     </main>

--- a/service-front/app/src/Actor/templates/actor/start-page.html.twig
+++ b/service-front/app/src/Actor/templates/actor/start-page.html.twig
@@ -24,15 +24,15 @@
                     <p class="govuk-body">To create an account you'll need to provide your email address and create a password.</p>
 
                     <h2 class="govuk-heading-m">2. Add a lasting power of attorney</h2>
-                    <p class="govuk-body">To add an LPA, you'll need:</p>
+                    <p class="govuk-body">To add an <abbr title="lasting power of attorney">LPA</abbr>, you'll need:</p>
                     <ul class="govuk-list govuk-list--bullet">
-                        <li>your activation key for the LPA</li>
-                        <li>the reference number of the LPA</li>
+                        <li>your activation key for the <abbr title="lasting power of attorney">LPA</abbr></li>
+                        <li>the reference number of the <abbr title="lasting power of attorney">LPA</abbr></li>
                     </ul>
                     <p class="govuk-body">
-                        You can find these on letter that told you the LPA had been registered.
+                        You can find these on letter that told you the <abbr title="lasting power of attorney">LPA</abbr> had been registered.
                     </p>
-                    <p class="govuk-body">If you're an attorney or donor on more than one LPA, you can add all those LPAs to your account.</p>
+                    <p class="govuk-body">If you're an attorney or donor on more than one <abbr title="lasting power of attorney">LPA</abbr>, you can add all those <abbr title="lasting power of attorney">LPA</abbr>s to your account.</p>
 
                     <a href="{{ path('create-account') }}" role="button" draggable="false" class="govuk-button govuk-button" data-module="govuk-button">
                         Create account

--- a/service-front/app/src/Actor/templates/actor/view-lpa-summary.html.twig
+++ b/service-front/app/src/Actor/templates/actor/view-lpa-summary.html.twig
@@ -49,11 +49,11 @@
                     <p class="govuk-body body-alt-1">
                         {% if lpa.caseSubtype == "pfa" %}
                             {% if lpa.attorneyActDecisions == 'When Registered' %}
-                                While the donor has mental capacity, this LPA should only be used with the donor’s permission
+                                While the donor has mental capacity, this <abbr title="lasting power of attorney">LPA</abbr> should only be used with the donor’s permission
                             {% elseif lpa.attorneyActDecisions == 'Loss of capacity' %}
-                                This LPA can only be used when the donor has lost capacity
+                                This <abbr title="lasting power of attorney">LPA</abbr> can only be used when the donor has lost capacity
                             {% elseif lpa.attorneyActDecisions == null %}
-                                This LPA can be used as soon as it's registered unless instructions say otherwise.
+                                This <abbr title="lasting power of attorney">LPA</abbr> can be used as soon as it's registered unless instructions say otherwise.
                             {% endif %}
                         {% else %}
                             {% if lpa.lifeSustainingTreatment|lower == 'option a' %}
@@ -107,7 +107,7 @@
                             {% elseif lpa.caseAttorneyJointlyAndSeverally %}
                                 Attorneys can make decisions jointly (together) and severally (separately)
                             {% elseif lpa.caseAttorneyJointlyAndJointlyAndSeverally %}
-                                Attorneys must make some decisions jointly (together) and can make some decisions severally (separately). Check the paper LPA to find out what decisions must be made jointly.
+                                Attorneys must make some decisions jointly (together) and can make some decisions severally (separately). Check the paper <abbr title="lasting power of attorney">LPA</abbr> to find out what decisions must be made jointly.
                             {% endif %}
                         </dd>
                     </div>
@@ -153,7 +153,7 @@
                         <dt class="govuk-summary-list__key">Preferences</dt>
                         <dd class="govuk-summary-list__value">
                             {% if lpa.applicationHasGuidance %}
-                                Yes, the donor made preferences on their LPA.<br>To view these, ask to see the paper LPA
+                                Yes, the donor made preferences on their <abbr title="lasting power of attorney">LPA</abbr>.<br>To view these, ask to see the paper <abbr title="lasting power of attorney">LPA</abbr>
                             {% else %}
                                 No
                             {% endif %}
@@ -164,7 +164,7 @@
                         <dt class="govuk-summary-list__key">Instructions</dt>
                         <dd class="govuk-summary-list__value">
                             {% if lpa.applicationHasRestrictions %}
-                                Yes, the donor set instructions on their LPA.<br>To view these, ask to see the paper LPA
+                                Yes, the donor set instructions on their <abbr title="lasting power of attorney">LPA</abbr>.<br>To view these, ask to see the paper <abbr title="lasting power of attorney">LPA</abbr>
                             {% else %}
                                 No
                             {% endif %}
@@ -176,11 +176,11 @@
                             <dt class="govuk-summary-list__key">When can the LPA be used?</dt>
                             <dd class="govuk-summary-list__value">
                                 {% if lpa.attorneyActDecisions == 'When Registered' %}
-                                    While the donor has mental capacity, this LPA should only be used with the donor’s permission
+                                    While the donor has mental capacity, this <abbr title="lasting power of attorney">LPA</abbr> should only be used with the donor’s permission
                                 {% elseif lpa.attorneyActDecisions == 'Loss of capacity' %}
-                                    This LPA can only be used when the donor has lost capacity
+                                    This <abbr title="lasting power of attorney">LPA</abbr> can only be used when the donor has lost capacity
                                 {% elseif lpa.attorneyActDecisions == null %}
-                                    This LPA can be used as soon as it's registered unless instructions say otherwise.
+                                    This <abbr title="lasting power of attorney">LPA</abbr> can be used as soon as it's registered unless instructions say otherwise.
                                 {% endif %}
                             </dd>
                         </div>
@@ -193,7 +193,7 @@
                                 {% elseif lpa.lifeSustainingTreatment|lower == 'option b' %}
                                     The attorneys do not have the authority to make decisions about life-sustaining treatment
                                 {% else %}
-                                    To view this, ask to see the paper LPA
+                                    To view this, ask to see the paper <abbr title="lasting power of attorney">LPA</abbr>
                                 {% endif %}
                             </dd>
                         </div>
@@ -226,7 +226,7 @@
             <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
             <strong class="govuk-warning-text__text">
                 <span class="govuk-warning-text__assistive">Warning</span>
-                You cannot use a download or print out of this LPA summary in place of the original paper LPA or instead of giving someone an access code.
+                You cannot use a download or print out of this <abbr title="lasting power of attorney">LPA</abbr> summary in place of the original paper <abbr title="lasting power of attorney">LPA</abbr> or instead of giving someone an access code.
             </strong>
         </div>
 

--- a/service-front/app/src/Actor/templates/actor/your-details.html.twig
+++ b/service-front/app/src/Actor/templates/actor/your-details.html.twig
@@ -48,7 +48,7 @@
                             </dl>
 
                     <div class="govuk-inset-text">
-                        <span>Need to update the online LPA summary?</span><br>
+                        <span>Need to update the online <abbr title="lasting power of attorney">LPA</abbr> summary?</span><br>
                         <span>
                              <a class="govuk-link" href="{{ path('lpa.change-details') }}">Change a donor or attorney's details</a>
                         </span>

--- a/service-front/app/src/Viewer/templates/viewer/check-code-cancelled.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/check-code-cancelled.html.twig
@@ -13,7 +13,7 @@
 
                     <h1 class="govuk-heading-xl">The access code you entered has been cancelled</h1>
 
-                    <p class="govuk-body">To see this LPA, ask the donor or attorney you’re dealing with to make a new code.</p>
+                    <p class="govuk-body">To see this <abbr title="lasting power of attorney">LPA</abbr>, ask the donor or attorney you’re dealing with to make a new code.</p>
 
                     <a href="{{ path('enter-code') }}" role="button" draggable="false" class="govuk-button">
                         Enter another code

--- a/service-front/app/src/Viewer/templates/viewer/check-code-expired.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/check-code-expired.html.twig
@@ -14,7 +14,7 @@
                     <h1 class="govuk-heading-xl">The access code you entered has expired</h1>
 
                     <p class="govuk-body">Access codes expire 30 days after they’re made.</p> <br>
-                    <p class="govuk-body">To see this LPA, ask the donor or attorney you’re dealing with to make a new code.</p>
+                    <p class="govuk-body">To see this <abbr title="lasting power of attorney">LPA</abbr>, ask the donor or attorney you’re dealing with to make a new code.</p>
 
                     <a href="{{ path('enter-code') }}" role="button" draggable="false" class="govuk-button">
                         Enter another code

--- a/service-front/app/src/Viewer/templates/viewer/check-code-found.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/check-code-found.html.twig
@@ -40,13 +40,13 @@
                     <details class="govuk-details" role="group">
                         <summary class="govuk-details__summary">
                             <span class="govuk-details__summary-text">
-                                If you need to access this LPA after {{ lpa_date(expires) }}
+                                If you need to access this <abbr title="lasting power of attorney">LPA</abbr> after {{ lpa_date(expires) }}
                             </span>
                         </summary>
                         <div class="govuk-details__text">
-                            <p class="govuk-body">You will be able to view this LPA until {{ lpa_date(expires) }}. After this date, the access code will expire.</p>
+                            <p class="govuk-body">You will be able to view this <abbr title="lasting power of attorney">LPA</abbr> until {{ lpa_date(expires) }}. After this date, the access code will expire.</p>
 
-                            <p class="govuk-body">If your organisation needs more time to process this LPA, or if you need to view the LPA again at a later date, ask the the donor or attorney to generate a new access code for you. They can do this at <a class="govuk-link" href="https://use.lastingpowerofattorney.opg.service.justice.gov.uk">https://use.lastingpowerofattorney.opg.service.justice.gov.uk</a></p>
+                            <p class="govuk-body">If your organisation needs more time to process this <abbr title="lasting power of attorney">LPA</abbr>, or if you need to view the <abbr title="lasting power of attorney">LPA</abbr> again at a later date, ask the the donor or attorney to generate a new access code for you. They can do this at <a class="govuk-link" href="https://use.lastingpowerofattorney.opg.service.justice.gov.uk">https://use.lastingpowerofattorney.opg.service.justice.gov.uk</a></p>
 
                             <p class="govuk-body">Codes expire 30 days after they are generated.</p>
                         </div>

--- a/service-front/app/src/Viewer/templates/viewer/enter-code.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/enter-code.html.twig
@@ -37,9 +37,9 @@
                         </div>
 
                         <div class="govuk-inset-text">
-                            <p class="govuk-!-font-weight-bold">What is an LPA access code?</p>
+                            <p class="govuk-!-font-weight-bold">What is an <abbr title="lasting power of attorney">LPA</abbr> access code?</p>
 
-                            An LPA access code is a unique code given to you by the donor or an attorney named on a lasting power of attorney.
+                            An <abbr title="lasting power of attorney">LPA</abbr> access code is a unique code given to you by the donor or an attorney named on a lasting power of attorney.
                         </div>
 
                         <p class="govuk-body">By continuing you agree to our <a href = "{{ path('viewer-terms-of-use') }}" class="govuk-link">terms of use</a>.</p>

--- a/service-front/app/src/Viewer/templates/viewer/home-page.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/home-page.html.twig
@@ -15,14 +15,14 @@
 
                 <ul class="govuk-list govuk-list--bullet">
                     <li>view a summary of a lasting power of attorney (LPA)</li>
-                    <li>check whether an LPA is currently valid</li>
-                    <li>see who the attorneys are on an LPA</li>
-                    <li>check when an LPA can be used</li>
+                    <li>check whether an <abbr title="lasting power of attorney">LPA</abbr> is currently valid</li>
+                    <li>see who the attorneys are on an <abbr title="lasting power of attorney">LPA</abbr></li>
+                    <li>check when an <abbr title="lasting power of attorney">LPA</abbr> can be used</li>
                 </ul>
 
-                <p class="govuk-body">You should be able to use this service instead of asking to see the original paper LPA.</p>
+                <p class="govuk-body">You should be able to use this service instead of asking to see the original paper <abbr title="lasting power of attorney">LPA</abbr>.</p>
 
-                <p class="govuk-body">To use this service, you’ll need an ‘LPA access code’ from the donor or an attorney. Codes expire 30 days after they are made.</p>
+                <p class="govuk-body">To use this service, you’ll need an ‘<abbr title="lasting power of attorney">LPA</abbr> access code’ from the donor or an attorney. Codes expire 30 days after they are made.</p>
 
                 <div class="govuk-inset-text">Use a different service if you want to <a href="https://use.lastingpowerofattorney.opg.service.justice.gov.uk" class="govuk-link">make a code to use your own LPA</a> .</div>
 

--- a/service-front/app/src/Viewer/templates/viewer/viewer-terms-of-use.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/viewer-terms-of-use.html.twig
@@ -14,15 +14,15 @@
 
                 <h1 class="govuk-heading-xl">Terms of use</h1>
 
-                <p class="govuk-body">The Use a lasting power of attorney (LPA) service lets donors and attorneys share a summary of an LPA with professionals or organisations by creating a unique ‘access code’.
-                    View a lasting power of attorney is the part of this service that lets you see a summary of an LPA, using the access code given to you by the donor or an attorney.
+                <p class="govuk-body">The Use a lasting power of attorney (LPA) service lets donors and attorneys share a summary of an <abbr title="lasting power of attorney">LPA</abbr> with professionals or organisations by creating a unique ‘access code’.
+                    View a lasting power of attorney is the part of this service that lets you see a summary of an <abbr title="lasting power of attorney">LPA</abbr>, using the access code given to you by the donor or an attorney.
                     This part of the service is for professionals or organisations providing a service to the donor. For example, financial institutions, medical professionals, and care organisations.
-                    You can use this service instead of asking to see the original paper LPA.</p>
+                    You can use this service instead of asking to see the original paper <abbr title="lasting power of attorney">LPA</abbr>.</p>
 
                 <p class="govuk-body">By using this service you:</p>
                 <ul class="govuk-list govuk-list--bullet">
                     <li>agree to these terms of use and the <a class="govuk-link" href="https://www.gov.uk/help/terms-conditions">GOV.UK terms and conditions</a></li>
-                    <li>confirm that a donor or attorney wants you to view the LPA and has given you an access code</li>
+                    <li>confirm that a donor or attorney wants you to view the <abbr title="lasting power of attorney">LPA</abbr> and has given you an access code</li>
                 </ul>
 
                 <p class="govuk-body govuk-!-font-weight-bold">! It can be a criminal offence to use someone’s personal information without their permission.</p>
@@ -30,7 +30,7 @@
                 <h2 class="govuk-heading-m">Information security</h2>
 
                 <p class="govuk-body">You and your organisation are responsible for your use of View a lasting power of attorney.</p>
-                <p class="govuk-body">If you download a copy of an LPA summary, or record details of the summary, <b>your organisation becomes the ‘data controller’ of that information.</b> This means your organisation will be responsible for keeping the information safe and secure, in line with Data Protection Act 2018.</p>
+                <p class="govuk-body">If you download a copy of an <abbr title="lasting power of attorney">LPA</abbr> summary, or record details of the summary, <b>your organisation becomes the ‘data controller’ of that information.</b> This means your organisation will be responsible for keeping the information safe and secure, in line with Data Protection Act 2018.</p>
 
                 <h3 class="govuk-heading-s">Accessing the service securely</h3>
 
@@ -44,21 +44,21 @@
 
                 <h2 class="govuk-heading-m">Keeping information up to date</h2>
 
-                <p class="govuk-body">LPAs can change. For example, attorneys may change, people’s names or addresses may change, or the donor may cancel their LPA.</p>
+                <p class="govuk-body"><abbr title="lasting powers of attorney">LPAs</abbr> can change. For example, attorneys may change, people’s names or addresses may change, or the donor may cancel their LPA.</p>
 
-                <p class="govuk-body">We use OPG’s records about registered LPAs to keep this service up to date. However:</p>
+                <p class="govuk-body">We use OPG’s records about registered <abbr title="lasting powers of attorney">LPAs</abbr> to keep this service up to date. However:</p>
                 <ul class="govuk-list govuk-list--bullet">
                     <li>we rely on donors and attorneys to tell us about any changes</li>
-                    <li>once we’re told about a change, it may take several days before we update the LPA summary on the service</li>
+                    <li>once we’re told about a change, it may take several days before we update the <abbr title="lasting power of attorney">LPA</abbr> summary on the service</li>
                 </ul>
 
                 <h2 class="govuk-heading-m">The online summary</h2>
 
-                <p class="govuk-body">Any screenshots, downloads or printouts of the LPA summary are not proof of an LPA and may not show the latest status of an LPA.</p>
+                <p class="govuk-body">Any screenshots, downloads or printouts of the <abbr title="lasting power of attorney">LPA</abbr> summary are not proof of an <abbr title="lasting power of attorney">LPA</abbr> and may not show the latest status of an <abbr title="lasting power of attorney">LPA</abbr>.</p>
 
                 <h2 class="govuk-heading-m">Tracking use of the service</h2>
 
-                <p class="govuk-body">We keep a record of when an access code has been used to view an LPA. This information is available to the donor and attorneys.</p>
+                <p class="govuk-body">We keep a record of when an access code has been used to view an <abbr title="lasting power of attorney">LPA</abbr>. This information is available to the donor and attorneys.</p>
                 <p class="govuk-body">The information will be stored securely and used in line with our <a class="govuk-link" href="https://www.lastingpowerofattorney.service.gov.uk/privacy-notice">privacy notice</a> and cookie policy.</p>
 
                 <h2 class="govuk-heading-m">If you suspect fraud or abuse</h2>

--- a/service-front/web/src/scss/_lpa-typography.scss
+++ b/service-front/web/src/scss/_lpa-typography.scss
@@ -18,3 +18,9 @@ button.org-cancel {
   text-decoration: underline;
   cursor: pointer;
 }
+
+abbr,
+abbr[title] {
+    cursor: help;
+    text-decoration: none;
+}


### PR DESCRIPTION
## Purpose
It was requested that Acronym Markdown should be added in the alpha assessment. This will allow users to hover "LPA" and "LPAs" so alt text will be displayed explaining the meaning of these acronyms.
https://opgtransform.atlassian.net/browse/UML-873

Fixes UML-####

Find all instances of "LPA" and "LPAs" and change to:
`<abbr title="lasting power of attorney">LPA</abbr>`
and
`<abbr title="lasting powers of attorney">LPAs</abbr>`

## Learning

N/A

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

