### PR TITLE
Fix docker typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In all cases commands are run with a docker-compose command prefix
 
 ```shell
 # This should replace all instances of <DOCKER_COMPOSE> in commands given below
-docker-compose -f docker-compose.yml -f docker-compose-dependencies.yml
+docker-compose -f docker-compose.yml -f docker-compose.dependencies.yml
 ```
 
 Build docker-compose files with no cache option.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,7 +183,7 @@ services:
 
       # Local only
       AWS_ACCESS_KEY_ID: "-"
-      AWS_ENDPOINT_DYNAMODB: http://localstack:4569
+      AWS_ENDPOINT_DYNAMODB: http://localstack:14569
       AWS_SECRET_ACCESS_KEY: "-"
       LOGGING_LEVEL: "100" # \Monolog\Logger::DEBUG
       ENABLE_XDEBUG: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,6 +185,7 @@ services:
       AWS_ACCESS_KEY_ID: "-"
       AWS_ENDPOINT_DYNAMODB: http://localstack:14569
       AWS_SECRET_ACCESS_KEY: "-"
+      LPA_CODES_STATIC_AUTH_TOKEN: asdf1234567890
       LOGGING_LEVEL: "100" # \Monolog\Logger::DEBUG
       ENABLE_XDEBUG: "true"
       PHP_IDE_CONFIG: serverName=api-app

--- a/service-api/docker/seeding/start.sh
+++ b/service-api/docker/seeding/start.sh
@@ -83,7 +83,7 @@ python /app/seeding/dynamodb.py
 
 if ! [[ -z "${CODES_ENDPOINT}" ]]; then
   # Setup the local codes service
-  /usr/local/bin/waitforit -address=tcp://${CODES_ENDPOINT}:4343 -timeout 60 -retry 6000 -debug
+  /usr/local/bin/waitforit -address=tcp://${CODES_ENDPOINT} -timeout 60 -retry 6000 -debug
   curl -X POST -H 'Authorization: asdf1234567890' http://${CODES_ENDPOINT}/setup/dynamodb/create/table
 fi
 


### PR DESCRIPTION
## Purpose
LPA Codes seeding cannot run because of a duplication of the port in the waitforit command.

## Approach

Remove extra port in command

## Learning


## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

