### PR TITLE
clean up workspaces less frequently

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
   workspace_cleanup:
     triggers:
       - schedule:
-          cron: "0 0,2,4,6,8,10,12,14,16,18,20,22 * * 0-6" # every 2 hours from midnight
+          cron: "0 6,18 * * 0-6" # every 2 hours from midnight
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
   workspace_cleanup:
     triggers:
       - schedule:
-          cron: "0 6,18 * * 0-6" # every 2 hours from midnight
+          cron: "0 6,18 * * 0-6" # twice a day at 6am and 6pm
           filters:
             branches:
               only:


### PR DESCRIPTION
## Purpose
Reduce the frequency of workspace cleanup jobs

## Approach

Run twice during the day at 6am and 6pm instead of every two hours

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

