### PR TITLE
UML-779 Add Privacy notice to Actor front end

### DIFF
--- a/service-front/app/config/routes.php
+++ b/service-front/app/config/routes.php
@@ -84,6 +84,9 @@ $actorRoutes = function (Application $app, MiddlewareFactory $factory, Container
     $app->get('/lpa/terms-of-use', [
         Actor\Handler\ActorTermsOfUseHandler::class
     ], 'lpa.terms-of-use');
+    $app->get('/lpa/privacy-notice', [
+        Actor\Handler\ActorPrivacyNoticeHandler::class
+    ], 'lpa.privacy-notice');
     $app->route('/change-password', [
         Mezzio\Authentication\AuthenticationMiddleware::class,
         Actor\Handler\ChangePasswordHandler::class

--- a/service-front/app/features/actor-privacy-notice.feature
+++ b/service-front/app/features/actor-privacy-notice.feature
@@ -1,0 +1,18 @@
+@actor @privacyNotice
+Feature: View privacy notice from the terms of use page
+  As a user
+  I want to check the privacy notice
+  So that I can understand how my private data will be handled by the service
+
+  @ui
+  Scenario: user wants to see the privacy notice
+    Given I am on the create account page
+    When I request to see the actor terms of use
+    And I request to see the actor privacy notice
+    Then I can see the actor privacy notice
+
+  @ui
+  Scenario: The user can go back to the terms of use page from the actor privacy notice page
+    Given I am on the actor privacy notice page
+    When I request to go back to the terms of use page
+    Then I am taken back to the terms of use page

--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -2190,6 +2190,14 @@ class AccountContext implements Context
     }
 
     /**
+     * @When /^I request to see the actor privacy notice$/
+     */
+    public function iRequestToSeeTheActorPrivacyNoticePage()
+    {
+        $this->ui->clickLink('privacy notice');
+    }
+
+    /**
      * @Then /^I can see the actor terms of use$/
      */
     public function iCanSeeTheActorTermsOfUse()
@@ -2198,7 +2206,14 @@ class AccountContext implements Context
         $this->ui->assertPageContainsText('Terms of use');
         $this->ui->assertPageContainsText('The service is for donors and attorneys on an LPA.');
     }
-
+    /**
+     * @Then /^I can see the actor privacy notice$/
+     */
+    public function iCanSeeTheActorPrivacyNotice()
+    {
+        $this->ui->assertPageAddress('/lpa/privacy-notice');
+        $this->ui->assertPageContainsText('Privacy notice');
+    }
     /**
      * @Given /^I am on the actor terms of use page$/
      */
@@ -2207,11 +2222,20 @@ class AccountContext implements Context
         $this->ui->visit('/lpa/terms-of-use');
         $this->ui->assertPageAddress('/lpa/terms-of-use');
     }
+    /**
+     * @Given /^I am on the actor privacy notice page$/
+     */
+    public function iAmOnTheActorPrivacyNoticePage()
+    {
+        $this->ui->visit('/lpa/privacy-notice');
+        $this->ui->assertPageAddress('/lpa/privacy-notice');
+    }
 
     /**
      * @When /^I request to go back to the create account page$/
+     * @When /^I request to go back to the terms of use page$/
      */
-    public function iRequestToGoBackToTheCreateAccountPage()
+    public function iRequestToGoBackToTheSpecifiedPage()
     {
         $this->ui->clickLink('Back');
     }
@@ -2222,6 +2246,14 @@ class AccountContext implements Context
     public function iAmTakenBackToTheCreateAccountPage()
     {
         $this->ui->assertPageAddress('/create-account');
+    }
+
+    /**
+     * @Then /^I am taken back to the terms of use page$/
+     */
+    public function iAmTakenBackToTheTermsOfUsePage()
+    {
+        $this->ui->assertPageAddress('/lpa/terms-of-use');
     }
 
     /**
@@ -3382,4 +3414,3 @@ class AccountContext implements Context
         $this->ui->pressButton('Continue');
     }
 }
-

--- a/service-front/app/src/Actor/src/Handler/ActorPrivacyNoticeHandler.php
+++ b/service-front/app/src/Actor/src/Handler/ActorPrivacyNoticeHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace Actor\Handler;
+
+
+use Common\Handler\AbstractHandler;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\Response\HtmlResponse;
+
+class ActorPrivacyNoticeHandler extends AbstractHandler
+{
+    /**
+     * @param ServerRequestInterface $request
+     * @return ResponseInterface
+     */
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        return new HtmlResponse($this->renderer->render('actor::actor-privacy-notice'));
+    }
+}

--- a/service-front/app/src/Actor/src/Handler/ActorPrivacyNoticeHandler.php
+++ b/service-front/app/src/Actor/src/Handler/ActorPrivacyNoticeHandler.php
@@ -9,6 +9,11 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Response\HtmlResponse;
 
+/**
+ * Class ActorPrivacyNoticeHandler
+ * @package Actor\Handler
+ * @codeCoverageIgnore
+ */
 class ActorPrivacyNoticeHandler extends AbstractHandler
 {
     /**

--- a/service-front/app/src/Actor/templates/actor/actor-privacy-notice.html.twig
+++ b/service-front/app/src/Actor/templates/actor/actor-privacy-notice.html.twig
@@ -1,0 +1,257 @@
+{% extends '@actor/layout.html.twig' %}
+
+{% block html_title %}Privacy Notice - {{ parent() }} {% endblock %}
+
+{% block content %}
+<div class="govuk-width-container">
+{{ include('@partials/new-service.html.twig') }}
+
+    <a class="govuk-link govuk-back-link" href="{{ path('lpa.terms-of-use') }}">Back</a>
+    <main class="govuk-main-wrapper" id="main-content" role="main">
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <h1 class="govuk-heading-xl">Privacy notice</h1>
+                <p class="govuk-body-l">
+                    This privacy notice explains why the
+                    Office of the Public Guardian (OPG) collects personal data when you use the ‘Use a lasting power of attorney’ (LPA) service.
+                </p>
+                <p class="govuk-body">
+                    This privacy notice also explains:
+                </p>
+
+                <ul class="govuk-list govuk-list--bullet">
+                        <li>
+                            how we store your data
+                        </li>
+                        <li>
+                            what we do with your data
+                        </li>
+                        <li>
+                            how you can get a copy of the data we have about you
+                        </li>
+                        <li>
+                            how you can complain if you think we’ve done something wrong
+                        </li>
+                    </ul>
+
+                <p class="govuk-body">
+                    You should read this privacy notice alongside:
+                </p>
+                   <ul class="govuk-list govuk-list--bullet">
+                    <li>
+                        <a class="govuk-link" href="https://www.gov.uk/government/organisations/office-of-the-public-guardian/about/personal-information-charter">
+                        OPG’s personal information charter
+                        </a>,
+                    which sets out the standards you can expect when we ask for, use or share your personal information
+                    </li>
+                    <li>
+                        <a class="govuk-link" href=https://www.gov.uk/government/publications/opg-privacy-notice-lasting-and-enduring-powers-of-attorney">
+                        OPG’s lasting power of attorney privacy notice
+                        </a>,
+                    which explains how we use and protect your data when you’re named on an <abbr title="lasting power of attorney">LPA</abbr>
+                    </li>
+                </ul>
+
+                <h2 class="govuk-heading-m">Who manages the Use a lasting power of attorney service</h2>
+                <p class="govuk-body">This service is managed by OPG, which is an executive agency sponsored by the Ministry of Justice (MOJ).</p>
+                <p class="govuk-body">MOJ is the data controller for the personal data we store.
+                    <a class="govuk-link" href="https://www.gov.uk/government/organisations/office-of-the-public-guardian/about/personal-information-charter">
+                        OPG’s personal information charter
+                    </a>
+                    explains how we process personal data.
+                </p>
+                <p class="govuk-body">You can find more information about using the View a lasting power of attorney service in our
+                    <a class="govuk-link" href="{{ path('lpa.terms-of-use') }}">terms of use</a> and <a class="govuk-link" href="#">cookies policy.</a>
+                </p>
+                <h2 class="govuk-heading-m"> Why we collect personal data and how we use it
+                </h2>
+                <p class="govuk-body">
+                    We only collect the personal data that is relevant for the services we are providing to you.
+                </p>
+                <p class="govuk-body">
+                    In order to use this service, you need to enter some personal data and create an account
+                </p>
+                <p class="govuk-body">
+                    The personal data we collect includes:
+                </p>
+                    <ul class="govuk-list govuk-list--bullet">
+                        <li>your email address</li>
+                        <li>your name and date of birth</li>
+                        <li>your computer’s IP address while you use this service</li>
+                    </ul>
+
+                <p class="govuk-body">
+                    We use the data to find the <abbr title="Lasting power of attorney">LPA</abbr> you’re named on and to create your account.
+                </p>
+                <p class="govuk-body">
+                    The service also keeps a record of the <abbr title="lasting power of attorney">LPA</abbr> access codes you’ve made and which organisations you made them for.
+                </p>
+                <p class="govuk-body">
+                    If other people named on the <abbr title="lasting power of attorney">LPA</abbr> (the donor or attorneys) are also using the service,
+                    they can see which organisations you’ve made access codes for.
+                </p>
+                <h3 class="govuk-heading-s">Cookies and site usage data</h3>
+                <p class="govuk-body">
+                    We collect site usage information from this service. This allows us to see how the service is being used so we can improve it. This information does not contain any personal data and is stored separately from the information you enter when using this service.
+                </p>
+                <p class="govuk-body">
+                    Find out more about <a class="govuk-link" href="https://www.gov.uk/help/cookies">cookies</a>.
+                </p>
+                <h3 class="govuk-heading-s">Legal basis for processing this data</h3>
+                <p class="govuk-body">
+                    Your use of this online service is optional.
+                    If you prefer, you can show the original paper <abbr title="lasting power of attorney">LPA</abbr>, or a certified copy, to people who need to see it.
+                </p>
+                <p class="govuk-body">
+                    We operate the Use an <abbr title="lasting power of attorney">LPA</abbr> service as part of our legal responsibilities under the Mental Capacity Act 2005.
+                </p>
+                <h2 class="govuk-heading-m">Personal data and the online summary</h2>
+                <p class="govuk-body">
+                    The donor or an attorney named on an <abbr title="lasting power of attorney">LPA</abbr> can use this service
+                    to give a third party access to an online summary of the <abbr title="lasting power of attorney">LPA</abbr>.
+                </p>
+                <p class="govuk-body">
+                    This summary includes:
+                </p>
+                <ul class="govuk-list govuk-list--bullet">
+
+                    <li>the name and address of the donor and any active attorneys</li>
+                    <li>the name of any inactive attorneys</li>
+                    <li>whether the <abbr title="lasting power of attorney">LPA</abbr> is currently valid</li>
+                    <li>when the <abbr title="lasting power of attorney">LPA</abbr> can be used (property and finance <abbr title="lasting powers of attorney">LPAs</abbr> only)</li>
+                    <li>whether the donor chose to allow their attorneys to make decisions on life-sustaining treatment
+                        (health and welfare <abbr title="lasting powers of attorney">LPAs</abbr> only)
+                    </li>
+                </ul>
+                <p class="govuk-body">
+                    Third parties can download and keep a copy of the summary.
+                </p>
+                <p class="govuk-body">
+                    We’re not responsible for how personal data, accessed by a third party using a code created by a donor or attorney, is used, shared, or held.
+                </p>
+                <h2 class="govuk-heading-m">How we store data</h2>
+                <p class="govuk-body">
+                    Information you enter into the service is stored in a secure database within the European Economic Area (EEA).
+                    However, due to the global nature of the internet, the data sent to and from the database may transit through countries outside of the EEA.
+                    Data is not stored in a non-EEA country.
+                </p>
+                <p class="govuk-body">
+                    It may sometimes be necessary to transfer personal information overseas.
+                    Any transfers will fully comply with all aspects of data protection law.
+                </p>
+                <h3 class="govuk-heading-s">Who has access to data in the service</h3>
+                <p class="govuk-body">
+                    MOJ staff are responsible for supporting the service and have access to the secure database.
+                </p>
+                <p class="govuk-body">
+                    All OPG staff who have access to the database have MOJ security clearance.
+                </p>
+                <p class="govuk-body">
+                    Our hosting provider (Amazon Web Services) is not allowed to routinely access the secure data.
+                    If they need to do so for operational purposes, their access is strictly controlled and approved by OPG.
+                </p>
+                <p class="govuk-body">
+                    You can find out more about how we store and use this data in our
+                    <a class="govuk-link" href="https://www.gov.uk/government/organisations/office-of-the-public-guardian/about/personal-information-charter">
+                        personal information charter
+                    </a>.
+                </p>
+                <p class="govuk-body">
+                    We do not use personal data when testing the service.
+                </p>
+                <h3 class="govuk-heading-s">How long we keep data</h3>
+                <p class="govuk-body">
+                    We’ll keep your personal data in line with our
+                    <a class="govuk-link" href="https://www.gov.uk/government/organisations/office-of-the-public-guardian/about/personal-information-charter">
+                        retention policy
+                    </a>.
+                </p>
+                <h3 class="govuk-heading-s">Change your personal data</h3>
+                <p class="govuk-body">
+                    Contact us if you want to change your personal data.
+                </p>
+                <h2 class="govuk-heading-m">How to get a copy of your information</h2>
+                <p class="govuk-body">
+                    You can find out what personal data we hold about you in the service by making a subject access request.
+                </p>
+                <p class="govuk-body">
+                    <a class="govuk-link" href="https://www.gov.uk/government/organisations/office-of-the-public-guardian/about/personal-information-charter">
+                        Find out more about subject access requests
+                    </a>.
+                </p>
+                <h2 class="govuk-heading-m">Sharing personal data</h2>
+                <p class="govuk-body">We’ll only share the information you give us when the law says we can.
+                    For example, we may share information with the police to help them prevent or investigate crime.
+                </p>
+                <p class="govuk-body">We’ll never:</p>
+                    <ul class="govuk-list govuk-list--bullet">
+                        <li>share your information with other organisations for marketing, market research or commercial purposes</li>
+                        <li>sell or rent your data to third parties</li>
+                    </ul>
+
+                <h2 class="govuk-heading-m">Getting more information</h2>
+                <p class="govuk-body">
+                    You can get more details on:
+                </p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>agreements we have with other organisations for sharing information</li>
+                    <li>when we can pass on personal information without telling you, for example,
+                        to help with the prevention or detection of crime or to produce anonymised statistics</li>
+                    <li>instructions we give to staff on how to collect, use or delete your personal data</li>
+                    <li>how we check that the information we hold is accurate and up-to-date</li>
+                    <li>how to make a complaint</li>
+                    <li>anything in this privacy notice</li>
+                    <li>what to do if you think that your personal data has been misused or mishandled</li>
+                </ul>
+                <p class="govuk-body">
+                    For more information, please contact:
+                </p>
+                <p class="govuk-body">
+                    MOJ Data Protection Officer <br>
+                    Post point 10.38 <br>
+                    102 Petty France <br>
+                    London <br>
+                    SW1H 9AJ <br>
+                </p>
+                <h2 class="govuk-heading-m">Changes to this notice</h2>
+                <p class="govuk-body">
+                    We may change this privacy notice from time to time. When we do, we’ll update the ‘last updated’ date at the bottom of this page.
+                </p>
+                <p class="govuk-body">
+                    If these changes affect how your personal data is processed, we’ll take reasonable steps to let you know.
+                </p>
+                <p class="govuk-body">
+                    Any changes to this privacy notice will apply to you and your data immediately.
+                </p>
+                <h2 class="govuk-heading-m">Making a complaint</h2>
+                <p class="govuk-body">
+                    When we ask for personal data, we’ll keep to the law.
+                    If you think that your information has not been handled correctly,
+                    in addition to contacting the MOJ Data Protection Officer,
+                    you can contact the Information Commissioner for independent advice about data protection at the address below:
+                </p>
+                <p class="govuk-body">
+                    Information Commissioner's Office <br>
+                    Wycliffe House <br>
+                    Water Lane <br>
+                    Wilmslow <br>
+                    Cheshire <br>
+                    SK9 5AF <br>
+                </p>
+                <p class="govuk-body">
+                    Phone: 0303 123 1113<br>
+                    Textphone: 01625 545860<br>
+                    Monday to Friday, 9am to 4:30pm<br>
+                </p>
+                <p class="govuk-body">
+                    <a class="govuk-link" href="http://www.ico.org.uk/">www.ico.org.uk</a>
+                </p>
+                <p class="govuk-body">
+                    Last updated: 30 March 2020
+                </p>
+            </div>
+        </div>
+    </main>
+</div>
+
+{% endblock %}

--- a/service-front/app/src/Actor/templates/actor/actor-terms-of-use.html.twig
+++ b/service-front/app/src/Actor/templates/actor/actor-terms-of-use.html.twig
@@ -70,7 +70,7 @@
 
                     <h2 class="govuk-heading-m">Keeping your information safe</h2>
 
-                    <p class="govuk-body">Any information you submit will be stored securely and used inline with our <a class="govuk-link" href="#">privacy notice</a> and <a class="govuk-link" href="#">cookie policy</a>.</p>
+                    <p class="govuk-body">Any information you submit will be stored securely and used inline with our <a class="govuk-link" href="{{ path('lpa.privacy-notice') }}">privacy notice</a> and <a class="govuk-link" href="#">cookie policy</a>.</p>
 
                     <h2 class="govuk-heading-m">Let us know if you want us to change the LPA</h2>
 


### PR DESCRIPTION
## Purpose
Add a privacy notice to the Actor page.

Fixes UML-779

## Approach

- new handler
- twig file with a privacy notice 
- routing
- behat tests

## Learning
GDS styling: https://design-system.service.gov.uk/styles/

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [X] The product team have tested these changes

