### PR TITLE
UML-780 Added viewer privacy notice with links to /from ToU. 

### DIFF
--- a/service-front/app/config/routes.php
+++ b/service-front/app/config/routes.php
@@ -42,6 +42,7 @@ $viewerRoutes = function (Application $app, MiddlewareFactory $factory, Containe
     $app->get('/view-lpa', Viewer\Handler\ViewLpaHandler::class, 'view-lpa');
     $app->get('/download-lpa', Viewer\Handler\DownloadLpaHandler::class, 'download-lpa');
     $app->get('/terms-of-use', Viewer\Handler\ViewerTermsOfUseHandler::class, 'viewer-terms-of-use');
+    $app->get('/privacy-notice',Viewer\Handler\ViewerPrivacyNoticeHandler::class,'viewer-privacy-notice');
     $app->get('/stats', Viewer\Handler\StatsPageHandler::class, 'viewer-stats');
 
     $app->route('/cookies', Common\Handler\CookiesPageHandler::class, ['GET', 'POST'], 'cookies');

--- a/service-front/app/features/context/UI/ViewerContext.php
+++ b/service-front/app/features/context/UI/ViewerContext.php
@@ -404,12 +404,28 @@ class ViewerContext implements Context
     }
 
     /**
+     * @When /^I request to see the viewer privacy notice$/
+     */
+    public function iRequestToSeeTheViewerPrivacyNotice()
+    {
+        $this->ui->clickLink("privacy notice");
+    }
+    /**
      * @Then /^I can see the viewer terms of use$/
      */
     public function iCanSeeTheViewerTermsOfUse()
     {
         $this->ui->assertPageAddress('/terms-of-use');
         $this->ui->assertPageContainsText('Terms of use');
+    }
+
+    /**
+     * @Then /^I can see the viewer privacy notice$/
+     */
+    public function iCanSeeTheViewerPrivacyNotice()
+    {
+        $this->ui->assertPageAddress('/privacy-notice');
+        $this->ui->assertPageContainsText('Privacy notice');
     }
 
     /**
@@ -422,9 +438,19 @@ class ViewerContext implements Context
     }
 
     /**
-     * @When /^I request to go back to the enter code page$/
+     * @Given /^I am on the privacy notice page$/
      */
-    public function iRequestToGoBackToTheEnterCodePage()
+    public function iAmOnThePrivacyNoticePage()
+    {
+        $this->ui->visit('/privacy-notice');
+        $this->ui->assertPageAddress('/privacy-notice');
+    }
+
+    /**
+     * @When /^I request to go back to the enter code page$/
+     * @When /^I request to go back to the terms of use page$/
+     */
+    public function iRequestToGoBackToTheRequiredPage()
     {
         $this->ui->clickLink('Back');
     }
@@ -436,6 +462,14 @@ class ViewerContext implements Context
     {
         $this->ui->assertPageAddress('/enter-code');
         $this->ui->assertPageContainsText('Enter the LPA access code');
+    }
+
+    /**
+     * @Then /^I am taken back to the terms of use page$/
+     */
+    public function iAmTakenBackToTheTermsOfUsePage()
+    {
+        $this->iAmOnTheTermsOfUsePage();
     }
 
     /**

--- a/service-front/app/features/viewer-privacy-notice.feature
+++ b/service-front/app/features/viewer-privacy-notice.feature
@@ -1,0 +1,18 @@
+@viewer @privacyNotice
+Feature: View privacy notice from terms of use page
+  As an organisation using the service
+  I want to check the privacy notice
+  So that I can be be sure of the way that the data is processed for an LPA
+
+  @ui
+  Scenario: The user can access the privacy notice from the terms of use page
+    Given I am on the enter code page
+    When I request to see the viewer terms of use
+    And I request to see the viewer privacy notice
+    Then I can see the viewer privacy notice
+
+  @ui
+  Scenario: The user can go back to the terms of use page from the privacy notice page
+    Given I am on the privacy notice page
+    When I request to go back to the terms of use page
+    Then I am taken back to the terms of use page

--- a/service-front/app/src/Viewer/src/Handler/ViewerPrivacyNoticeHandler.php
+++ b/service-front/app/src/Viewer/src/Handler/ViewerPrivacyNoticeHandler.php
@@ -8,6 +8,11 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Laminas\Diactoros\Response\HtmlResponse;
 
+/**
+ * Class ViewerPrivacyNoticeHandler
+ * @package Viewer\Handler
+ * @codeCoverageIgnore
+ */
 class ViewerPrivacyNoticeHandler extends AbstractHandler
 {
     /**
@@ -18,7 +23,4 @@ class ViewerPrivacyNoticeHandler extends AbstractHandler
     {
         return new HtmlResponse($this->renderer->render('viewer::viewer-privacy-notice'));
     }
-}
-{
-
 }

--- a/service-front/app/src/Viewer/src/Handler/ViewerPrivacyNoticeHandler.php
+++ b/service-front/app/src/Viewer/src/Handler/ViewerPrivacyNoticeHandler.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace Viewer\Handler;
+
+use Common\Handler\AbstractHandler;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Laminas\Diactoros\Response\HtmlResponse;
+
+class ViewerPrivacyNoticeHandler extends AbstractHandler
+{
+    /**
+     * @param ServerRequestInterface $request
+     * @return ResponseInterface
+     */
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        return new HtmlResponse($this->renderer->render('viewer::viewer-privacy-notice'));
+    }
+}
+{
+
+}

--- a/service-front/app/src/Viewer/src/Handler/ViewerTermsOfUseHandler.php
+++ b/service-front/app/src/Viewer/src/Handler/ViewerTermsOfUseHandler.php
@@ -12,6 +12,7 @@ use Laminas\Diactoros\Response\HtmlResponse;
 /**
  * Class ViewerTermsOfUseHandler
  * @package Viewer\Handler
+ * @codeCoverageIgnore
  */
 class ViewerTermsOfUseHandler extends AbstractHandler
 {

--- a/service-front/app/src/Viewer/templates/viewer/viewer-privacy-notice.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/viewer-privacy-notice.html.twig
@@ -1,0 +1,222 @@
+{% extends '@viewer/layout.html.twig' %}
+
+{% block html_title %}Privacy Notice - {{ parent() }} {% endblock %}
+
+{% block content %}
+<div class="govuk-width-container">
+{{ include('@partials/new-service.html.twig') }}
+
+    <a href="{{ path('viewer-terms-of-use') }}" class="govuk-back-link">Back</a>
+    <main class="govuk-main-wrapper" id="main-content" role="main">
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <h1 class="govuk-heading-xl">Privacy notice</h1>
+
+
+                <p class="govuk-body-l">
+                    This privacy notice explains why the Office of the Public Guardian (OPG)
+                    collects personal data when you use the ‘View a lasting power of attorney’ (LPA) service.
+                </p>
+                <p class="govuk-body">
+                    This privacy notice also explains:
+                </p>
+                <ul class="govuk-list govuk-list--bullet">
+
+                    <li>how we store your data</li>
+
+                    <li>what we do with your data</li>
+
+                    <li>how you can get a copy of the data we have about you</li>
+
+                    <li>how you can complain if you think we’ve done something wrong</li>
+                </ul>
+                <p class="govuk-body">
+                    You should read this privacy notice alongside <a class="govuk-link" href="https://www.gov.uk/government/organisations/office-of-the-public-guardian/about/personal-information-charter"> <abbr title="Office of the Public Guardian">OPG</abbr>’s personal information charter</a>, which sets out the standards you can expect when we ask for, use or share your personal information.
+                </p>
+                <h2 class="govuk-heading-m">Who manages the View a lasting power of attorney service</h2>
+
+
+                <p class="govuk-body">
+                    This service is managed by  <abbr title="Office of the Public Guardian">OPG</abbr>, which is an executive agency sponsored by the Ministry of Justice (MOJ).
+                </p>
+                <p class="govuk-body">
+                    MOJ is the data controller for the personal data we store. <a class="govuk-link" href="https://www.gov.uk/government/organisations/office-of-the-public-guardian/about/personal-information-charter"> <abbr title="Office of the Public Guardian">OPG</abbr>’s personal information charter</a> explains how we process personal data.
+                </p>
+                <p class="govuk-body">
+                    You can find more information about using the View a lasting power of attorney service in our <a class="govuk-link" href="{{ path('viewer-terms-of-use') }}">terms of use</a> and <a class="govuk-link" class="govuk-link"  href="#">cookies policy</a>.
+                </p>
+                <h2 class="govuk-heading-m">What data we collect and how we use it</h2>
+
+
+                <p class="govuk-body">
+                    The donor or an attorney on an
+                    <abbr title="lasting power of attorney">LPA</abbr>
+                    can use the <span style="text-decoration:underline;">Use a lasting power of attorney service</span> to create an ‘access code’ to give to a named organisation and professional. They should create a unique code for each organisation or professional.
+                </p>
+                <p class="govuk-body">
+                    In order to use the View a lasting power of attorney service,
+                    you need to enter the unique ‘access code’ given to you by the donor or an attorney on the
+                    <abbr title="lasting power of attorney">LPA</abbr> you want to view.
+                </p>
+                <p class="govuk-body">
+                    We keep a record of:
+                </p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>when the access code is used to view an  <abbr title="lasting power of attorney">LPA</abbr></li>
+                    <li>the name of the organisation or individual the donor or attorney said they were giving that code to</li>
+                    <li>your computer’s IP address while you use this service</li>
+                    </li>
+                </ul>
+                <p class="govuk-body">
+                    This information will be shared with the donor and attorneys on the
+                    <abbr title="lasting power of attorney">LPA</abbr>,
+                    if they’re using the Use a lasting power of attorney service.
+                    This is to help prevent and detect unauthorised access.
+                </p>
+                <h3 class="govuk-heading-s">Cookies and site usage data</h3>
+
+
+                <p class="govuk-body">
+                    We collect site usage information from this service. This allows us to see how the service is being used so we can improve it. This information does not contain any personal data and is stored separately from the information you enter when using this service.
+                </p>
+                <p class="govuk-body">
+                    Find out more about <a class="govuk-link"  href="https://www.gov.uk/help/cookies">cookies</a>.
+                </p>
+                <h3 class="govuk-heading-s">Legal basis for processing this data</h3>
+
+
+                <p class="govuk-body">
+                    Your use of this online service is optional. If you prefer, you can ask the donor or an attorney to show you the original paper  <abbr title="lasting power of attorney">LPA</abbr> or a certified copy.
+                </p>
+                <p class="govuk-body">
+                    We operate the View a lasting power of attorney service as part of our legal functions under the Mental Capacity Act 2005.
+                </p>
+                <h2 class="govuk-heading-m">How we store data</h2>
+
+
+                <p class="govuk-body">
+                    Information you enter into the service is stored in a secure database within the European Economic Area (EEA). However, due to the global nature of the internet, the data sent to and from the database may transit through countries outside of the EEA. Data is not stored in a non-EEA country.
+                </p>
+                <p class="govuk-body">
+                    It may sometimes be necessary to transfer personal information overseas. Any transfers made will fully comply with all aspects of data protection law.
+                </p>
+                <h3 class="govuk-heading-s">Who has access to data in the service</h3>
+                <p class="govuk-body">
+                    MOJ staff are responsible for supporting the service and have access to the secure database.
+                </p>
+                <p class="govuk-body">
+                    All  <abbr title="Office of the Public Guardian">OPG</abbr>
+                    staff who have access to the database have MOJ security clearance.
+                </p>
+                <p class="govuk-body">
+                    Our hosting provider (Amazon Web Services) is not allowed to routinely access the secure data.
+                    If they need to do so for operational purposes, their access is strictly controlled and approved by
+                    <abbr title="Office of the Public Guardian">OPG</abbr>.
+                </p>
+                <p class="govuk-body">
+                    You can find out more about how we store and use this data in
+                    <abbr title="Office of the Public Guardian">OPG</abbr>’s
+                    <a class="govuk-link"  href="https://www.gov.uk/government/organisations/office-of-the-public-guardian/about/personal-information-charter">
+                        personal information charter
+                    </a>.
+                </p>
+                <p class="govuk-body">
+                    We do not use personal data when testing the service.
+                </p>
+                <h3 class="govuk-heading-s">How long we keep data</h3>
+
+
+                <p class="govuk-body">
+                    We will keep your personal data inline with our <a class="govuk-link"  href="https://www.gov.uk/government/organisations/office-of-the-public-guardian/about/personal-information-charter">retention policy</a>.
+                </p>
+                <h2 class="govuk-heading-m">How to get a copy of your information</h2>
+
+
+                <p class="govuk-body">
+                    You can find out what personal data we hold about you in the service by making a subject access request.
+                </p>
+                <p class="govuk-body">
+                    <a class="govuk-link"  href="https://www.gov.uk/government/organisations/office-of-the-public-guardian/about/personal-information-charter">Find out more about subject access requests</a>.
+                </p>
+                <h2 class="govuk-heading-m">Sharing personal data</h2>
+
+
+                <p class="govuk-body">We’ll only share the information you give us when the law says we can. For example, we may share information with the police to help them prevent or investigate crime.</p>
+
+
+                <p class="govuk-body">We’ll never:</p>
+
+
+                <ul class="govuk-list govuk-list--bullet">
+
+                    <li>share your information with other organisations for marketing, market research or commercial purposes
+
+                    <li>sell or rent your data to third parties
+                    </li>
+                </ul>
+                <h2 class="govuk-heading-m">Getting more information</h2>
+
+
+                <p class="govuk-body">
+                    You can get more details on:
+                </p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>agreements we have with other organisations for sharing information</li>
+                    <li>when we can pass on personal information without telling you,
+                        for example, to help with the prevention or detection of crime or to produce anonymised statistics
+                    </li>
+                    <li>instructions we give to staff on how to collect, use or delete your personal data</li>
+                    <li>how we check that the information we hold is accurate and up-to-date</li>
+                    <li>how to make a complaint</li>
+                    <li>anything in this privacy notice</li>
+                    <li>what to do if you think that your personal data has been misused or mishandled
+                    </li>
+                </ul>
+                <p class="govuk-body">
+                    For more information, please contact:
+                </p>
+                <p class="govuk-body">
+                    MOJ Data Protection Officer<br>
+                    Post point 10.38<br>
+                    102 Petty France<br>
+                    London<br>
+                    SW1H 9AJ<br>
+                </p>
+                <h2 class="govuk-heading-m">Changes to this notice</h2>
+                <p class="govuk-body">
+                    We may change this privacy notice from time to time. When we do, we’ll update the ‘last updated’ date at the bottom of this page.
+                </p>
+                <p class="govuk-body">
+                    If these changes affect how your personal data is processed, We’ll take reasonable steps to let you know.
+                </p>
+                <p class="govuk-body">
+                    Any changes to this privacy notice will apply to you and your data immediately.
+                </p>
+                <h2 class="govuk-heading-m">Making a complaint</h2>
+                <p class="govuk-body">
+                    When we ask for personal data, we’ll keep to the law. If you think that your information has not been handled correctly, in addition to contacting the MOJ Data Protection Officer, you can contact the Information Commissioner for independent advice about data protection at the address below:
+                </p>
+                <p class="govuk-body">
+                    Information Commissioner's Office <br>
+                    Wycliffe House <br>
+                    Water Lane <br>
+                    Wilmslow <br>
+                    Cheshire <br>
+                    SK9 5AF <br>
+                </p>
+                <p class="govuk-body">
+                    Phone: 0303 123 1113 <br>
+                    Textphone: 01625 545860 <br>
+                    Monday to Friday, 9am to 4:30pm <br>
+                </p>
+                <p class="govuk-body">
+                    <a class="govuk-link"  href="http://www.ico.org.uk/">www.ico.org.uk</a>
+                </p>
+                <p class="govuk-body">
+                    Last updated: 24 May 2019
+                </p>
+            </div>
+        </div>
+    </main>
+</div>
+{% endblock %}

--- a/service-front/app/src/Viewer/templates/viewer/viewer-terms-of-use.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/viewer-terms-of-use.html.twig
@@ -59,7 +59,7 @@
                 <h2 class="govuk-heading-m">Tracking use of the service</h2>
 
                 <p class="govuk-body">We keep a record of when an access code has been used to view an <abbr title="lasting power of attorney">LPA</abbr>. This information is available to the donor and attorneys.</p>
-                <p class="govuk-body">The information will be stored securely and used in line with our <a class="govuk-link" href="https://www.lastingpowerofattorney.service.gov.uk/privacy-notice">privacy notice</a> and cookie policy.</p>
+                <p class="govuk-body">The information will be stored securely and used in line with our <a class="govuk-link" href="{{  path('viewer-privacy-notice') }}">privacy notice</a> and cookie policy.</p>
 
                 <h2 class="govuk-heading-m">If you suspect fraud or abuse</h2>
 


### PR DESCRIPTION
## Purpose
To Add Viewer Privacy notice

Fixes UML-780

## Approach
- new handler
- twig file with a privacy notice 
- routing
- behat tests

## Learning
GDS styling: https://design-system.service.gov.uk/styles/

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [ ] The product team have tested these changes

