### PR TITLE
UML-875 Add a trim filter and php unit tests - also minor tidy up

### DIFF
--- a/service-front/app/src/Actor/src/Form/LpaAdd.php
+++ b/service-front/app/src/Actor/src/Form/LpaAdd.php
@@ -7,6 +7,7 @@ namespace Actor\Form;
 use Common\Form\AbstractForm;
 use Common\Form\Fieldset\Date;
 use Common\Form\Fieldset\DatePrefixFilter;
+use Common\Form\Fieldset\DateTrimFilter;
 use Common\Validator\DobValidator;
 use Laminas\Filter\StringToUpper;
 use Mezzio\Csrf\CsrfGuardInterface;
@@ -114,9 +115,8 @@ class LpaAdd extends AbstractForm implements InputFilterProviderInterface
             ],
             'dob' => [
                 'filters'  => [
-                    [
-                        'name' => DatePrefixFilter::class
-                    ],
+                    ['name' => DateTrimFilter::class],
+                    ['name' => DatePrefixFilter::class],
                 ],
                 'validators' => [
                     [

--- a/service-front/app/src/Common/src/Form/Fieldset/DateTrimFilter.php
+++ b/service-front/app/src/Common/src/Form/Fieldset/DateTrimFilter.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Common\Form\Fieldset;
+
+use Laminas\Filter\AbstractFilter;
+
+class DateTrimFilter extends AbstractFilter
+{
+
+    /**
+     * Defined by Laminas\Filter\FilterInterface
+     *
+     * Returns the array $value with  the values trimmed for day month and year
+     *
+     * @param  array $value
+     * @return array
+     */
+    public function filter($value): array
+    {
+        $value['day'] = trim($value['day']);
+        $value['month'] = trim($value['month']);
+        $value['year'] = trim($value['year']);
+        return $value;
+    }
+}

--- a/service-front/app/test/CommonTest/Form/Fieldset/DobTrimFilterTest.php
+++ b/service-front/app/test/CommonTest/Form/Fieldset/DobTrimFilterTest.php
@@ -4,23 +4,25 @@ declare(strict_types=1);
 
 namespace CommonTest\Form\Fieldset;
 
-use Common\Form\Fieldset\DatePrefixFilter;
+use Common\Form\Fieldset\DateTrimFilter;
 use PHPUnit\Framework\TestCase;
 
-class DobPrefixFilterTest extends TestCase
+class DobTrimFilterTest extends TestCase
 {
     /**
-     * @var DatePrefixFilter
+     * @var DateTrimFilter
      */
-    private DatePrefixFilter $filter;
+    private DateTrimFilter $filter;
 
     public function setUp()
     {
-        $this->filter = new DatePrefixFilter();
+        $this->filter = new DateTrimFilter();
     }
 
     /**
      * @dataProvider validFormatProvider
+     * @param array $expected
+     * @param array $dob
      */
     public function testIsDobFormattedWithLeadingZeroes(array $expected, array $dob)
     {
@@ -28,48 +30,48 @@ class DobPrefixFilterTest extends TestCase
         $this->assertEquals($formattedDate, $dob);
     }
 
-    public function validFormatProvider() : array
+    public function validFormatProvider(): array
     {
         return [
             [
                 [
-                    'day' => '1',
-                    'month' => '10',
-                    'year' => '1980',
+                    'day' => ' 1',
+                    'month' => ' 10',
+                    'year' => ' 1980',
                 ],
                 [
-                    'day' => '01',
+                    'day' => '1',
                     'month' => '10',
                     'year' => '1980',
                 ]
             ],
             [
+                [
+                    'day' => '11 ',
+                    'month' => '8 ',
+                    'year' => '1980 ',
+                ],
                 [
                     'day' => '11',
                     'month' => '8',
                     'year' => '1980',
-                ],
-                [
-                    'day' => '11',
-                    'month' => '08',
-                    'year' => '1980',
                 ]
             ],
             [
+                [
+                    'day' => ' 1 ',
+                    'month' => ' 1 ',
+                    'year' => ' 1980 ',
+                ],
                 [
                     'day' => '1',
                     'month' => '1',
                     'year' => '1980',
-                ],
-                [
-                    'day' => '01',
-                    'month' => '01',
-                    'year' => '1980',
                 ]
             ],
             [
                 [
-                    'day' => '11',
+                    'day' => ' 11',
                     'month' => '10',
                     'year' => '1980',
                 ],

--- a/service-front/app/test/CommonTest/Form/Fieldset/DobTrimFilterTest.php
+++ b/service-front/app/test/CommonTest/Form/Fieldset/DobTrimFilterTest.php
@@ -24,7 +24,7 @@ class DobTrimFilterTest extends TestCase
      * @param array $expected
      * @param array $dob
      */
-    public function testIsDobFormattedWithLeadingZeroes(array $expected, array $dob)
+    public function testIsDobTrimmed(array $expected, array $dob)
     {
         $formattedDate = $this->filter->filter($expected);
         $this->assertEquals($formattedDate, $dob);


### PR DESCRIPTION
## Purpose
Fixes the issue of leading and trailing spaces entered into the date of birth fieldset

Fixes UML-875

## Approach
 
- Add a custom filter in the same style as DatePrefixFilter
- Add PHPUnit Tests and cases for new filter

## Learning

- data driven tests in PHP Unit using a dataProvider method

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [x] The product team have tested these changes

