### PR TITLE
Session expiry page

### DIFF
--- a/service-front/app/config/pipeline.php
+++ b/service-front/app/config/pipeline.php
@@ -53,6 +53,7 @@ return function (Application $app, MiddlewareFactory $factory, ContainerInterfac
 
     // Clean out the session if expired
     $app->pipe(\Common\Middleware\Session\SessionExpiredAttributeAllowlistMiddleware::class);
+    $app->pipe(\Common\Middleware\Session\SessionExpiredRedirectMiddleware::class);
 
     $app->pipe(\Mezzio\Csrf\CsrfMiddleware::class);
 

--- a/service-front/app/config/routes.php
+++ b/service-front/app/config/routes.php
@@ -64,6 +64,7 @@ $actorRoutes = function (Application $app, MiddlewareFactory $factory, Container
     // User auth
     $app->route('/login', Actor\Handler\LoginPageHandler::class, ['GET', 'POST'], 'login');
     $app->get('/logout', Actor\Handler\LogoutPageHandler::class, 'logout');
+    $app->get('/session-expired', Actor\Handler\ActorSessionExpiredHandler::class, 'session-expired');
 
     // User management
     $app->route('/forgot-password', Actor\Handler\PasswordResetRequestPageHandler::class, ['GET', 'POST'], 'password-reset');

--- a/service-front/app/features/common-session.feature
+++ b/service-front/app/features/common-session.feature
@@ -15,4 +15,4 @@ Feature: Session length is independent of cookie lifetime
     And I am currently signed in
     When my session expires
     And I view my dashboard
-    Then I am taken to the login page
+    Then I am taken to the session expired page

--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -2334,6 +2334,15 @@ class AccountContext implements Context
     }
 
     /**
+     * @Then /^I am taken to the session expired page$/
+     */
+    public function iAmTakenToTheSessionExpiredPage()
+    {
+        $this->ui->assertPageAddress('/session-expired');
+        $this->ui->assertPageContainsText('We\'ve signed you out');
+    }
+
+    /**
      * @Given /^I have added a (.*) LPA$/
      */
     public function iHaveAddedALPA($lpaType)

--- a/service-front/app/src/Actor/src/Handler/ActorSessionExpiredHandler.php
+++ b/service-front/app/src/Actor/src/Handler/ActorSessionExpiredHandler.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Actor\Handler;
 
 use Common\Handler\AbstractHandler;
+use Laminas\Diactoros\Response\HtmlResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Laminas\Diactoros\Response\HtmlResponse;
 
-class ActorTermsOfUseHandler extends AbstractHandler
+class ActorSessionExpiredHandler extends AbstractHandler
 {
     /**
      * @param ServerRequestInterface $request
@@ -17,6 +17,6 @@ class ActorTermsOfUseHandler extends AbstractHandler
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        return new HtmlResponse($this->renderer->render('actor::actor-terms-of-use'));
+        return new HtmlResponse($this->renderer->render('actor::actor-session-expired'));
     }
 }

--- a/service-front/app/src/Actor/templates/actor/actor-session-expired.html.twig
+++ b/service-front/app/src/Actor/templates/actor/actor-session-expired.html.twig
@@ -1,0 +1,22 @@
+{% extends '@actor/layout.html.twig' %}
+
+{% block html_title %}Your session has expired - {{ parent() }} {% endblock %}
+
+{% block content %}
+    <div class="govuk-width-container">
+        {{ include('@actor/partials/new-use-service.html.twig') }}
+
+        <main class="govuk-main-wrapper" id="main-content" role="main">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds">
+                    <h1 class="govuk-heading-xl">We've signed you out</h1>
+
+                    <p class="govuk-body">For your security, we've signed you out of this service because you did not use it for 20 minutes.</p>
+
+                    <a href="{{ path('login') }}" draggable="false" class="govuk-button">Log back in</a>
+                </div>
+
+            </div>
+        </main>
+    </div>
+{% endblock %}

--- a/service-front/app/src/Common/src/Middleware/Session/SessionExpiredAttributeAllowlistMiddleware.php
+++ b/service-front/app/src/Common/src/Middleware/Session/SessionExpiredAttributeAllowlistMiddleware.php
@@ -28,6 +28,7 @@ class SessionExpiredAttributeAllowlistMiddleware implements MiddlewareInterface
     protected const ALLOWLIST = [
         UserIdentificationMiddleware::IDENTIFY_ATTRIBUTE,
         EncryptedCookiePersistence::SESSION_TIME_KEY,
+        EncryptedCookiePersistence::SESSION_EXPIRED_KEY
     ];
 
     private LoggerInterface $logger;

--- a/service-front/app/src/Common/src/Middleware/Session/SessionExpiredRedirectMiddleware.php
+++ b/service-front/app/src/Common/src/Middleware/Session/SessionExpiredRedirectMiddleware.php
@@ -13,6 +13,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Laminas\Diactoros\Response\RedirectResponse;
 
 class SessionExpiredRedirectMiddleware implements MiddlewareInterface
 {
@@ -34,7 +35,7 @@ class SessionExpiredRedirectMiddleware implements MiddlewareInterface
             $session->unset(EncryptedCookiePersistence::SESSION_EXPIRED_KEY);
             $uri = new Uri($this->helper->generate('/session-expired'));
 
-            return $handler->handle($request->withUri($uri));
+            return new RedirectResponse($uri);
         } else {
             return $handler->handle($request);
         }

--- a/service-front/app/src/Common/src/Middleware/Session/SessionExpiredRedirectMiddleware.php
+++ b/service-front/app/src/Common/src/Middleware/Session/SessionExpiredRedirectMiddleware.php
@@ -7,12 +7,10 @@ namespace Common\Middleware\Session;
 use Common\Service\Session\EncryptedCookiePersistence;
 use Laminas\Diactoros\Uri;
 use Mezzio\Helper\ServerUrlHelper;
-use Mezzio\Router\RouterInterface;
 use Mezzio\Session\SessionInterface;
 use Mezzio\Session\SessionMiddleware;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\UriInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 

--- a/service-front/app/src/Common/src/Middleware/Session/SessionExpiredRedirectMiddleware.php
+++ b/service-front/app/src/Common/src/Middleware/Session/SessionExpiredRedirectMiddleware.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Middleware\Session;
+
+use Common\Service\Session\EncryptedCookiePersistence;
+use Laminas\Diactoros\Uri;
+use Mezzio\Helper\ServerUrlHelper;
+use Mezzio\Router\RouterInterface;
+use Mezzio\Session\SessionInterface;
+use Mezzio\Session\SessionMiddleware;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class SessionExpiredRedirectMiddleware implements MiddlewareInterface
+{
+    /**
+     * @var ServerUrlHelper
+     */
+    private $helper;
+
+    public function __construct(ServerUrlHelper $helper)
+    {
+        $this->helper = $helper;
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        /** @var SessionInterface $session */
+        $session = $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE);
+        if ($session !== null && $session->get(EncryptedCookiePersistence::SESSION_EXPIRED_KEY) !== null) {
+            $session->unset(EncryptedCookiePersistence::SESSION_EXPIRED_KEY);
+            $uri = new Uri($this->helper->generate('/session-expired'));
+
+            return $handler->handle($request->withUri($uri));
+        } else {
+            return $handler->handle($request);
+        }
+    }
+}

--- a/service-front/app/test/CommonTest/Middleware/Session/SessionExpiredAttributeAllowlistMiddlewareTest.php
+++ b/service-front/app/test/CommonTest/Middleware/Session/SessionExpiredAttributeAllowlistMiddlewareTest.php
@@ -94,7 +94,7 @@ class SessionExpiredAttributeAllowlistMiddlewareTest extends TestCase
             ->willReturn($sessionData);
         $sessionProphecy
             ->unset(Argument::type('string'))
-            ->shouldBeCalledTimes(4); // SESSION_TIME_KEY is allowed
+            ->shouldBeCalledTimes(3); // SESSION_TIME_KEY is allowed
 
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy

--- a/service-front/app/test/CommonTest/Middleware/Session/SessionExpiredRedirectMiddlewareTest.php
+++ b/service-front/app/test/CommonTest/Middleware/Session/SessionExpiredRedirectMiddlewareTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace CommonTest\Middleware\Session;
+
+use Common\Middleware\Session\SessionExpiredRedirectMiddleware;
+use Common\Service\Session\EncryptedCookiePersistence;
+use Laminas\Diactoros\Response\RedirectResponse;
+use Mezzio\Helper\ServerUrlHelper;
+use Mezzio\Session\Session;
+use Mezzio\Session\SessionMiddleware;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class SessionExpiredRedirectMiddlewareTest extends TestCase
+{
+    /** @test */
+    public function it_correctly_handles_request_with_no_session(): void
+    {
+        $requestProphecy = $this->prophesize(ServerRequestInterface::class);
+        $requestProphecy
+            ->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE)
+            ->shouldBeCalled()
+            ->willReturn(null);
+
+        $delegateProphecy = $this->prophesize(RequestHandlerInterface::class);
+        $delegateProphecy
+            ->handle($requestProphecy->reveal())
+            ->shouldBeCalled()
+            ->willReturn($this->prophesize(ResponseInterface::class)->reveal());
+
+        $request = new SessionExpiredRedirectMiddleware(
+            $this->prophesize(ServerUrlHelper::class)->reveal()
+        );
+
+        $request->process($requestProphecy->reveal(), $delegateProphecy->reveal());
+    }
+
+    /** @test */
+    public function it_correctly_handles_an_non_expired_session(): void
+    {
+        $sessionProphecy = $this->prophesize(Session::class);
+        $sessionProphecy
+            ->get(EncryptedCookiePersistence::SESSION_EXPIRED_KEY)
+            ->shouldBeCalled()
+            ->willReturn(null);
+
+        $requestProphecy = $this->prophesize(ServerRequestInterface::class);
+        $requestProphecy
+            ->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE)
+            ->shouldBeCalled()
+            ->willReturn($sessionProphecy->reveal());
+
+        $delegateProphecy = $this->prophesize(RequestHandlerInterface::class);
+        $delegateProphecy
+            ->handle($requestProphecy->reveal())
+            ->shouldBeCalled()
+            ->willReturn($this->prophesize(ResponseInterface::class)->reveal());
+
+        $request = new SessionExpiredRedirectMiddleware(
+            $this->prophesize(ServerUrlHelper::class)->reveal()
+        );
+
+        $result = $request->process($requestProphecy->reveal(), $delegateProphecy->reveal());
+        $this->assertInstanceOf(ResponseInterface::class, $result);
+    }
+
+    /** @test */
+    public function it_correctly_redirects_when_session_expires(): void
+    {
+        $uri = 'https://localhost:9002/session-expired';
+
+        $sessionProphecy = $this->prophesize(Session::class);
+        $helperProphecy = $this->prophesize(ServerUrlHelper::class);
+        $delegateProphecy = $this->prophesize(RequestHandlerInterface::class);
+        $requestProphecy = $this->prophesize(ServerRequestInterface::class);
+
+        $requestProphecy
+            ->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE)
+            ->shouldBeCalled()
+            ->willReturn($sessionProphecy->reveal());
+
+        $sessionProphecy
+            ->get(EncryptedCookiePersistence::SESSION_EXPIRED_KEY)
+            ->shouldBeCalled()
+            ->willReturn(true);
+
+        $sessionProphecy
+            ->unset(EncryptedCookiePersistence::SESSION_EXPIRED_KEY)
+            ->shouldBeCalled();
+
+        $helperProphecy
+            ->generate('/session-expired')
+            ->willReturn($uri);
+
+        $request = new SessionExpiredRedirectMiddleware(
+            $helperProphecy->reveal()
+        );
+
+        $redirect = $request->process($requestProphecy->reveal(), $delegateProphecy->reveal());
+
+        $this->assertInstanceOf(RedirectResponse::class, $redirect);
+        $this->assertEquals($uri, $redirect->getHeader('location')[0]);
+    }
+}


### PR DESCRIPTION
## Purpose
Takes the user to a page to tell them why they were logged out when their session expires

Fixes UML-886

## Approach

Created a new middleware that checks to see if the session expiry flag is present in the session, and redirects the user to the new page. Added the session expiry to the allow list in the SessionExpiredAttributeAllowlistMiddleware, and gave responsibility to the new SessionExpiredRedirectMiddleware to remove it.

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

