### PR TITLE
Link cookies page to terms of use and privacy policy

### DIFF
--- a/service-front/app/config/routes.php
+++ b/service-front/app/config/routes.php
@@ -83,12 +83,12 @@ $actorRoutes = function (Application $app, MiddlewareFactory $factory, Container
         Mezzio\Authentication\AuthenticationMiddleware::class,
         Actor\Handler\YourDetailsHandler::class,
     ], 'your-details');
-    $app->get('/lpa/terms-of-use', [
+    $app->get('/terms-of-use', [
         Actor\Handler\ActorTermsOfUseHandler::class
-    ], 'lpa.terms-of-use');
-    $app->get('/lpa/privacy-notice', [
+    ], 'actor-terms-of-use');
+    $app->get('/privacy-notice', [
         Actor\Handler\ActorPrivacyNoticeHandler::class
-    ], 'lpa.privacy-notice');
+    ], 'actor-privacy-notice');
     $app->route('/change-password', [
         Mezzio\Authentication\AuthenticationMiddleware::class,
         Actor\Handler\ChangePasswordHandler::class

--- a/service-front/app/features/actor-privacy-notice.feature
+++ b/service-front/app/features/actor-privacy-notice.feature
@@ -20,5 +20,5 @@ Feature: View privacy notice from the terms of use page
   @ui
   Scenario: Actor can access the actor cookies page from the actor privacy notice page
     Given I am on the actor privacy notice page
-    When I click the actor cookies policy link
+    When I navigate to the actor cookies page
     Then I am taken to the actor cookies page

--- a/service-front/app/features/actor-privacy-notice.feature
+++ b/service-front/app/features/actor-privacy-notice.feature
@@ -16,3 +16,9 @@ Feature: View privacy notice from the terms of use page
     Given I am on the actor privacy notice page
     When I request to go back to the terms of use page
     Then I am taken back to the terms of use page
+
+  @ui
+  Scenario: Actor can access the actor cookies page from the actor privacy notice page
+    Given I am on the actor privacy notice page
+    When I click the actor cookies policy link
+    Then I am taken to the actor cookies page

--- a/service-front/app/features/actor-terms-of-use.feature
+++ b/service-front/app/features/actor-terms-of-use.feature
@@ -19,5 +19,5 @@ Feature: View terms of use from create account page
   @ui
   Scenario: Actor can access the actor cookies page from the actor terms of use page
     Given I am on the actor terms of use page
-    When I click the actor cookies policy link
+    When I navigate to the actor cookies page
     Then I am taken to the actor cookies page

--- a/service-front/app/features/actor-terms-of-use.feature
+++ b/service-front/app/features/actor-terms-of-use.feature
@@ -15,3 +15,9 @@ Feature: View terms of use from create account page
     Given I am on the actor terms of use page
     When I request to go back to the create account page
     Then I am taken back to the create account page
+
+  @ui
+  Scenario: Actor can access the actor cookies page from the actor terms of use page
+    Given I am on the actor terms of use page
+    When I click the actor cookies policy link
+    Then I am taken to the actor cookies page

--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -3378,8 +3378,23 @@ class AccountContext implements Context
     }
 
     /**
-<<<<<<< HEAD
-<<<<<<< HEAD
+     * @When /^I navigate to the actor cookies page$/
+     */
+    public function iNavigateToTheActorCookiesPage()
+    {
+        $this->ui->clickLink('cookie policy');
+    }
+
+    /**
+     * @Then /^I am taken to the actor cookies page$/
+     */
+    public function iAmTakenToTheActorCookiesPage()
+    {
+        $this->ui->assertPageAddress('/cookies');
+        $this->ui->assertPageContainsText('Use a lasting power of attorney service');
+    }
+
+    /**
      * @When /^I select the option to sign in to my existing account$/
      */
     public function iSelectTheOptionToSignInToMyExistingAccount()
@@ -3443,23 +3458,6 @@ class AccountContext implements Context
     public function iWantToCreateANewAccount()
     {
          // Not needed for this context
-    }
-
-    /**
-     * @When /^I navigate to the actor cookies page$/
-     */
-    public function iNavigateToTheActorCookiesPage()
-    {
-        $this->ui->clickLink('cookie policy');
-    }
-
-    /**
-     * @Then /^I am taken to the actor cookies page$/
-     */
-    public function iAmTakenToTheActorCookiesPage()
-    {
-        $this->ui->assertPageAddress('/cookies');
-        $this->ui->assertPageContainsText('Use a lasting power of attorney service');
     }
 
 }

--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -3378,6 +3378,7 @@ class AccountContext implements Context
     }
 
     /**
+<<<<<<< HEAD
      * @When /^I select the option to sign in to my existing account$/
      */
     public function iSelectTheOptionToSignInToMyExistingAccount()
@@ -3441,6 +3442,23 @@ class AccountContext implements Context
     public function iWantToCreateANewAccount()
     {
          // Not needed for this context
+    }
+
+    /**
+     * @When /^I click the actor cookies policy link$/
+     */
+    public function iClickTheActorCookiesPolicyLink()
+    {
+        $this->ui->clickLink('cookie policy');
+    }
+
+    /**
+     * @Then /^I am taken to the actor cookies page$/
+     */
+    public function iAmTakenToTheActorCookiesPage()
+    {
+        $this->ui->assertPageAddress('/cookies');
+        $this->ui->assertPageContainsText('Use a lasting power of attorney service');
     }
 
 }

--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -2187,7 +2187,7 @@ class AccountContext implements Context
      */
     public function iCanSeeTheActorTermsOfUse()
     {
-        $this->ui->assertPageAddress('/lpa/terms-of-use');
+        $this->ui->assertPageAddress('/terms-of-use');
         $this->ui->assertPageContainsText('Terms of use');
         $this->ui->assertPageContainsText('The service is for donors and attorneys on an LPA.');
     }
@@ -2196,7 +2196,7 @@ class AccountContext implements Context
      */
     public function iCanSeeTheActorPrivacyNotice()
     {
-        $this->ui->assertPageAddress('/lpa/privacy-notice');
+        $this->ui->assertPageAddress('/privacy-notice');
         $this->ui->assertPageContainsText('Privacy notice');
     }
     /**
@@ -2204,16 +2204,16 @@ class AccountContext implements Context
      */
     public function iAmOnTheActorTermsOfUsePage()
     {
-        $this->ui->visit('/lpa/terms-of-use');
-        $this->ui->assertPageAddress('/lpa/terms-of-use');
+        $this->ui->visit('/terms-of-use');
+        $this->ui->assertPageAddress('/terms-of-use');
     }
     /**
      * @Given /^I am on the actor privacy notice page$/
      */
     public function iAmOnTheActorPrivacyNoticePage()
     {
-        $this->ui->visit('/lpa/privacy-notice');
-        $this->ui->assertPageAddress('/lpa/privacy-notice');
+        $this->ui->visit('/privacy-notice');
+        $this->ui->assertPageAddress('/privacy-notice');
     }
 
     /**
@@ -2238,7 +2238,7 @@ class AccountContext implements Context
      */
     public function iAmTakenBackToTheTermsOfUsePage()
     {
-        $this->ui->assertPageAddress('/lpa/terms-of-use');
+        $this->ui->assertPageAddress('/terms-of-use');
     }
 
     /**

--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -3379,6 +3379,7 @@ class AccountContext implements Context
 
     /**
 <<<<<<< HEAD
+<<<<<<< HEAD
      * @When /^I select the option to sign in to my existing account$/
      */
     public function iSelectTheOptionToSignInToMyExistingAccount()
@@ -3445,9 +3446,9 @@ class AccountContext implements Context
     }
 
     /**
-     * @When /^I click the actor cookies policy link$/
+     * @When /^I navigate to the actor cookies page$/
      */
-    public function iClickTheActorCookiesPolicyLink()
+    public function iNavigateToTheActorCookiesPage()
     {
         $this->ui->clickLink('cookie policy');
     }

--- a/service-front/app/features/context/UI/ViewerContext.php
+++ b/service-front/app/features/context/UI/ViewerContext.php
@@ -554,9 +554,9 @@ class ViewerContext implements Context
     }
 
     /**
-     * @When /^I click the viewer cookies policy link$/
+     * @When /^I navigate to the viewer cookies page$/
      */
-    public function iClickTheViewerCookiesPolicyLink()
+    public function iNavigateToTheViewerCookiesPage()
     {
         $this->ui->clickLink('cookie policy');
     }

--- a/service-front/app/features/context/UI/ViewerContext.php
+++ b/service-front/app/features/context/UI/ViewerContext.php
@@ -427,20 +427,12 @@ class ViewerContext implements Context
     }
 
     /**
-     * @Given /^I am on the terms of use page$/
+     * @Given /^I am on the viewer privacy notice page$/
      */
-    public function iAmOnTheTermsOfUsePage()
-    {
-        $this->ui->visit('/terms-of-use');
-        $this->ui->assertPageAddress('/terms-of-use');
-    }
-
-    /**
-     * @Given /^I am on the privacy notice page$/
-     */
-    public function iAmOnThePrivacyNoticePage()
+    public function iAmOnTheViewerPrivacyNoticePage()
     {
         $this->ui->visit('/privacy-notice');
+        $this->ui->assertPageContainsText('View a lasting power of attorney');
         $this->ui->assertPageAddress('/privacy-notice');
     }
 
@@ -467,7 +459,7 @@ class ViewerContext implements Context
      */
     public function iAmTakenBackToTheTermsOfUsePage()
     {
-        $this->iAmOnTheTermsOfUsePage();
+        $this->iAmOnTheViewerTermsOfUsePage();
     }
 
     /**
@@ -550,5 +542,31 @@ class ViewerContext implements Context
     public function iAmOnTheTriagePage()
     {
         $this->ui->visit('/home');
+    }
+
+    /**
+     * @Given /^I am on the viewer terms of use page$/
+     */
+    public function iAmOnTheViewerTermsOfUsePage()
+    {
+        $this->ui->visit('/terms-of-use');
+        $this->ui->assertPageAddress('/terms-of-use');
+    }
+
+    /**
+     * @When /^I click the viewer cookies policy link$/
+     */
+    public function iClickTheViewerCookiesPolicyLink()
+    {
+        $this->ui->clickLink('cookie policy');
+    }
+
+    /**
+     * @Then /^I am taken to the viewer cookies page$/
+     */
+    public function iAmTakenToTheViewerCookiesPage()
+    {
+        $this->ui->assertPageAddress('/cookies');
+        $this->ui->assertPageContainsText('View a lasting power of attorney service');
     }
 }

--- a/service-front/app/features/context/UI/ViewerContext.php
+++ b/service-front/app/features/context/UI/ViewerContext.php
@@ -537,14 +537,6 @@ class ViewerContext implements Context
     }
 
     /**
-     * @Given /^I am on the triage page$/
-     */
-    public function iAmOnTheTriagePage()
-    {
-        $this->ui->visit('/home');
-    }
-
-    /**
      * @Given /^I am on the viewer terms of use page$/
      */
     public function iAmOnTheViewerTermsOfUsePage()
@@ -568,5 +560,13 @@ class ViewerContext implements Context
     {
         $this->ui->assertPageAddress('/cookies');
         $this->ui->assertPageContainsText('View a lasting power of attorney service');
+    }
+  
+    /**
+     * @Given /^I am on the triage page$/
+     */
+    public function iAmOnTheTriagePage()
+    {
+        $this->ui->visit('/home');
     }
 }

--- a/service-front/app/features/viewer-cookie-banner.feature
+++ b/service-front/app/features/viewer-cookie-banner.feature
@@ -36,7 +36,7 @@ Feature: Cookie consent
     And I click on Set cookie preferences button
     When I am on the cookie preferences page
     Then I see options to Use cookies that measure my website use and Do not use cookies that measure my website use
-    And And I choose an <option> and save my choice
+    And I choose an <option> and save my choice
     Then I should be on the home page of the service
     And I should not see a cookie banner
 

--- a/service-front/app/features/viewer-privacy-notice.feature
+++ b/service-front/app/features/viewer-privacy-notice.feature
@@ -20,5 +20,5 @@ Feature: View privacy notice from terms of use page
   @ui
   Scenario: Viewer can access the cookies page from the privacy notice page
     Given I am on the viewer privacy notice page
-    When I click the viewer cookies policy link
+    When I navigate to the viewer cookies page
     Then I am taken to the viewer cookies page

--- a/service-front/app/features/viewer-privacy-notice.feature
+++ b/service-front/app/features/viewer-privacy-notice.feature
@@ -13,6 +13,12 @@ Feature: View privacy notice from terms of use page
 
   @ui
   Scenario: The user can go back to the terms of use page from the privacy notice page
-    Given I am on the privacy notice page
+    Given I am on the viewer privacy notice page
     When I request to go back to the terms of use page
     Then I am taken back to the terms of use page
+
+  @ui
+  Scenario: Viewer can access the cookies page from the privacy notice page
+    Given I am on the viewer privacy notice page
+    When I click the viewer cookies policy link
+    Then I am taken to the viewer cookies page

--- a/service-front/app/features/viewer-terms-of-use.feature
+++ b/service-front/app/features/viewer-terms-of-use.feature
@@ -19,5 +19,5 @@ Feature: View terms of use from enter code page
   @ui
   Scenario: Viewer can access the cookies page from the terms of use page
     Given I am on the viewer terms of use page
-    When I click the viewer cookies policy link
+    When I navigate to the viewer cookies page
     Then I am taken to the viewer cookies page

--- a/service-front/app/features/viewer-terms-of-use.feature
+++ b/service-front/app/features/viewer-terms-of-use.feature
@@ -12,6 +12,12 @@ Feature: View terms of use from enter code page
 
   @ui
   Scenario: The user can go back to the enter code page from the terms of use page
-    Given I am on the terms of use page
+    Given I am on the viewer terms of use page
     When I request to go back to the enter code page
     Then I am taken back to the enter code page
+
+  @ui
+  Scenario: Viewer can access the cookies page from the terms of use page
+    Given I am on the viewer terms of use page
+    When I click the viewer cookies policy link
+    Then I am taken to the viewer cookies page

--- a/service-front/app/src/Actor/templates/actor/actor-privacy-notice.html.twig
+++ b/service-front/app/src/Actor/templates/actor/actor-privacy-notice.html.twig
@@ -6,7 +6,7 @@
 <div class="govuk-width-container">
 {{ include('@partials/new-service.html.twig') }}
 
-    <a class="govuk-link govuk-back-link" href="{{ path('lpa.terms-of-use') }}">Back</a>
+    <a class="govuk-link govuk-back-link" href="{{ path('actor-terms-of-use') }}">Back</a>
     <main class="govuk-main-wrapper" id="main-content" role="main">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
@@ -61,7 +61,7 @@
                     explains how we process personal data.
                 </p>
                 <p class="govuk-body">You can find more information about using the View a lasting power of attorney service in our
-                    <a class="govuk-link" href="{{ path('lpa.terms-of-use') }}">terms of use</a> and <a class="govuk-link" href="#">cookies policy.</a>
+                    <a class="govuk-link" href="{{ path('actor-terms-of-use') }}">terms of use</a> and <a class="govuk-link" href="#">cookies policy.</a>
                 </p>
                 <h2 class="govuk-heading-m"> Why we collect personal data and how we use it
                 </h2>

--- a/service-front/app/src/Actor/templates/actor/actor-privacy-notice.html.twig
+++ b/service-front/app/src/Actor/templates/actor/actor-privacy-notice.html.twig
@@ -60,8 +60,8 @@
                     </a>
                     explains how we process personal data.
                 </p>
-                <p class="govuk-body">You can find more information about using the View a lasting power of attorney service in our
-                    <a class="govuk-link" href="{{ path('actor-terms-of-use') }}">terms of use</a> and <a class="govuk-link" href="#">cookies policy.</a>
+                <p class="govuk-body">You can find more information about using the View a lasting power of attorney service in ou
+                    <a class="govuk-link" href="{{ path('actor-terms-of-use') }}">terms of use</a> and <a class="govuk-link" href="{{ path('actor-cookies')}}">cookies policy.</a>
                 </p>
                 <h2 class="govuk-heading-m"> Why we collect personal data and how we use it
                 </h2>

--- a/service-front/app/src/Actor/templates/actor/actor-privacy-notice.html.twig
+++ b/service-front/app/src/Actor/templates/actor/actor-privacy-notice.html.twig
@@ -60,8 +60,9 @@
                     </a>
                     explains how we process personal data.
                 </p>
-                <p class="govuk-body">You can find more information about using the View a lasting power of attorney service in ou
-                    <a class="govuk-link" href="{{ path('actor-terms-of-use') }}">terms of use</a> and <a class="govuk-link" href="{{ path('actor-cookies')}}">cookies policy.</a>
+
+                <p class="govuk-body">You can find more information about using the Use a lasting power of attorney service in our
+                    <a class="govuk-link" href="{{ path('actor-terms-of-use') }}">terms of use</a> and <a class="govuk-link" href="{{ path('actor-cookies')}}">cookie policy.</a>
                 </p>
                 <h2 class="govuk-heading-m"> Why we collect personal data and how we use it
                 </h2>
@@ -103,7 +104,7 @@
                     If you prefer, you can show the original paper <abbr title="lasting power of attorney">LPA</abbr>, or a certified copy, to people who need to see it.
                 </p>
                 <p class="govuk-body">
-                    We operate the Use an <abbr title="lasting power of attorney">LPA</abbr> service as part of our legal responsibilities under the Mental Capacity Act 2005.
+                    We operate the Use a lasting power of attorney service as part of our legal responsibilities under the Mental Capacity Act 2005.
                 </p>
                 <h2 class="govuk-heading-m">Personal data and the online summary</h2>
                 <p class="govuk-body">

--- a/service-front/app/src/Actor/templates/actor/actor-terms-of-use.html.twig
+++ b/service-front/app/src/Actor/templates/actor/actor-terms-of-use.html.twig
@@ -70,7 +70,7 @@
 
                     <h2 class="govuk-heading-m">Keeping your information safe</h2>
 
-                    <p class="govuk-body">Any information you submit will be stored securely and used inline with our <a class="govuk-link" href="{{ path('actor-privacy-notice') }}">privacy notice</a> and <a class="govuk-link" href="#">cookie policy</a>.</p>
+                    <p class="govuk-body">Any information you submit will be stored securely and used inline with our <a class="govuk-link" href="{{ path('actor-privacy-notice') }}">privacy notice</a> and <a class="govuk-link" href="{{ path('actor-cookies') }}">cookie policy</a>.</p>
 
                     <h2 class="govuk-heading-m">Let us know if you want us to change the LPA</h2>
 

--- a/service-front/app/src/Actor/templates/actor/actor-terms-of-use.html.twig
+++ b/service-front/app/src/Actor/templates/actor/actor-terms-of-use.html.twig
@@ -70,7 +70,7 @@
 
                     <h2 class="govuk-heading-m">Keeping your information safe</h2>
 
-                    <p class="govuk-body">Any information you submit will be stored securely and used inline with our <a class="govuk-link" href="{{ path('lpa.privacy-notice') }}">privacy notice</a> and <a class="govuk-link" href="#">cookie policy</a>.</p>
+                    <p class="govuk-body">Any information you submit will be stored securely and used inline with our <a class="govuk-link" href="{{ path('actor-privacy-notice') }}">privacy notice</a> and <a class="govuk-link" href="#">cookie policy</a>.</p>
 
                     <h2 class="govuk-heading-m">Let us know if you want us to change the LPA</h2>
 

--- a/service-front/app/src/Actor/templates/actor/check-access-codes.html.twig
+++ b/service-front/app/src/Actor/templates/actor/check-access-codes.html.twig
@@ -61,13 +61,7 @@
 
                             <h2 class="govuk-heading-m">Active codes</h2>
 
-                            <p class="govuk-body">Give an organisation their access code so they can view this <abbr title="lasting power of attorney">LPA</abbr>.</p>
-
-                            <div class="govuk-inset-text">
-                                <p class="govuk-body-s">
-                                    They should then go to https://view.lastingpowerofattorney.opg.service.justice.gov.uk to use it.
-                                </p>
-                            </div>
+                            <p class="govuk-body">Give an organisation their access code so they can view this LPA. They should go to www.gov.uk/view-lpa to use the code.</p>
 
                             <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
 

--- a/service-front/app/src/Actor/templates/actor/create-account.html.twig
+++ b/service-front/app/src/Actor/templates/actor/create-account.html.twig
@@ -48,7 +48,7 @@
                                   </strong>
                                 </div>
 
-                                {{ govuk_form_element(form.get('terms'), { 'label': 'I agree to the <a href="/lpa/terms-of-use" class="govuk-link">terms of use</a>' }) }}
+                                {{ govuk_form_element(form.get('terms'), { 'label': 'I agree to the <a href="/terms-of-use" class="govuk-link">terms of use</a>' }) }}
 
                                 <button data-prevent-double-click="true" type="submit" class="govuk-button">Create account</button>
 

--- a/service-front/app/src/Actor/templates/actor/lpa-show-viewercode.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-show-viewercode.html.twig
@@ -45,15 +45,11 @@
 
                 <div class="govuk-grid-row">
                     <div class="govuk-grid-column-two-thirds">
-                        <p class="govuk-body-l">Ask {{ organisation }} how they want you to give them the code.</p>
+                        <p class="govuk-body-l govuk-!-font-weight-bold">What happens next?</p>
 
-                        <div class="govuk-inset-text">
-                            <p class="govuk-body-s">
-                                They should then go to https://view.lastingpowerofattorney.opg.service.justice.gov.uk to use it.
-                            </p>
-                        </div>
+                        <p class="govuk-body">You’ll need to give {{ organisation }} this access code - ask them how they want to receive it so it gets to the right person.</p>
 
-                        <p class="govuk-body">To find out if an organisation is taking part in our trial, email <a href="mailto:lpa.research@digital.justice.gov.uk">lpa.research@digital.justice.gov.uk</a>. If you need to show the <abbr title="lasting power of attorney">LPA</abbr> to more than one organisation, list the organisations in one email.</p>
+                        <p class="govuk-body">When {{ organisation }} have the access code, they should go to <br> www.gov.uk/view-lpa to see a summary of the LPA.</p>
 
                         <a href="{{ path('lpa.create-code', {}, {'lpa': actorToken }) }}" role="button" draggable="false" class="govuk-button govuk-button">
                             Give another organisation access

--- a/service-front/app/src/Common/src/Handler/CookiesPageHandler.php
+++ b/service-front/app/src/Common/src/Handler/CookiesPageHandler.php
@@ -46,8 +46,7 @@ class CookiesPageHandler extends AbstractHandler implements UserAware, CsrfGuard
         TemplateRendererInterface $renderer,
         UrlHelper $urlHelper,
         UrlValidityCheckService $urlValidityCheckService
-    )
-    {
+    ) {
         parent::__construct($renderer, $urlHelper);
         $this->urlValidityCheckService = $urlValidityCheckService;
     }
@@ -88,7 +87,9 @@ class CookiesPageHandler extends AbstractHandler implements UserAware, CsrfGuard
         $cookies = $request->getCookieParams();
         $form->setData($request->getParsedBody());
 
-        $response = new RedirectResponse($form->get('referer')->getValue());
+        $response = new RedirectResponse(
+            $this->urlValidityCheckService->setValidReferer($form->get('referer')->getValue())
+        );
 
         if (array_key_exists(self::COOKIE_POLICY_NAME, $cookies)) {
             try {
@@ -98,14 +99,16 @@ class CookiesPageHandler extends AbstractHandler implements UserAware, CsrfGuard
             }
 
             $cookiePolicy['usage'] = $form->get('usageCookies')->getValue() === 'yes' ? true : false;
-            $response = FigResponseCookies::set($response,
+            $response = FigResponseCookies::set(
+                $response,
                 SetCookie::create(self::COOKIE_POLICY_NAME, json_encode($cookiePolicy))
                     ->withHttpOnly(false)
                     ->withExpires(new \DateTime('+365 days'))
                     ->withPath('/')
             );
 
-            $response = FigResponseCookies::set($response,
+            $response = FigResponseCookies::set(
+                $response,
                 SetCookie::create(self::SEEN_COOKIE_NAME, "true")
                     ->withHttpOnly(false)
                     ->withExpires(new \DateTime('+30 days'))

--- a/service-front/app/src/Common/src/Service/Url/UrlValidityCheckService.php
+++ b/service-front/app/src/Common/src/Service/Url/UrlValidityCheckService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Common\Service\Url;
 
 use Laminas\Diactoros\ServerRequestFactory;
+use Mezzio\Helper\UrlHelper;
 use Mezzio\Router\RouterInterface;
 
 /**
@@ -23,10 +24,19 @@ class UrlValidityCheckService
      */
     protected $router;
 
-    public function __construct(ServerRequestFactory $serverRequestFactory, RouterInterface $router)
-    {
+    /**
+     * @var UrlHelper
+     */
+    private UrlHelper $urlHelper;
+
+    public function __construct(
+        ServerRequestFactory $serverRequestFactory,
+        RouterInterface $router,
+        UrlHelper $urlHelper
+    ) {
         $this->serverRequestFactory = $serverRequestFactory;
-        $this->router = $router;
+        $this->router               = $router;
+        $this->urlHelper            = $urlHelper;
     }
 
     /**
@@ -46,7 +56,7 @@ class UrlValidityCheckService
         }
     }
 
-    public function checkRefererRouteValid(?string $refererUrl): bool
+    public function checkRefererRouteValid(string $refererUrl): bool
     {
         if ($refererUrl !== null) {
             $request = $this->serverRequestFactory->createServerRequest('GET', $refererUrl);
@@ -57,5 +67,18 @@ class UrlValidityCheckService
             }
         }
         return false;
+    }
+
+    public function setValidReferer(string $referer): string
+    {
+        if (!empty($referer)) {
+            $validUrl = $this->isValid($referer);
+
+            $isValidRefererRoute = $this->checkRefererRouteValid($referer);
+
+            return ($validUrl && $isValidRefererRoute ? $referer : $this->urlHelper->generate('home'));
+        }
+
+        return $this->urlHelper->generate('home');
     }
 }

--- a/service-front/app/src/Common/src/Service/Url/UrlValidityCheckService.php
+++ b/service-front/app/src/Common/src/Service/Url/UrlValidityCheckService.php
@@ -62,7 +62,7 @@ class UrlValidityCheckService
             $request = $this->serverRequestFactory->createServerRequest('GET', $refererUrl);
             $result = $this->router->match($request);
 
-            if ($result) {
+            if ($result->isSuccess()) {
                 return true;
             }
         }

--- a/service-front/app/src/Common/src/Service/Url/UrlValidityCheckService.php
+++ b/service-front/app/src/Common/src/Service/Url/UrlValidityCheckService.php
@@ -46,7 +46,7 @@ class UrlValidityCheckService
         }
     }
 
-    public function checkRefererRouteValid(string $refererUrl): bool
+    public function checkRefererRouteValid(?string $refererUrl): bool
     {
         if ($refererUrl !== null) {
             $request = $this->serverRequestFactory->createServerRequest('GET', $refererUrl);

--- a/service-front/app/src/Common/src/Service/Url/UrlValidityCheckService.php
+++ b/service-front/app/src/Common/src/Service/Url/UrlValidityCheckService.php
@@ -69,7 +69,7 @@ class UrlValidityCheckService
         return false;
     }
 
-    public function setValidReferer(string $referer): string
+    public function setValidReferer(?string $referer): string
     {
         if (!empty($referer)) {
             $validUrl = $this->isValid($referer);

--- a/service-front/app/src/Common/templates/partials/cookies.html.twig
+++ b/service-front/app/src/Common/templates/partials/cookies.html.twig
@@ -10,6 +10,8 @@
 {% block content %}
     <div class="govuk-width-container">
 
+        <a class="govuk-link govuk-back-link" href="{{ routeReferer }}">Back</a>
+
         <main class="govuk-main-wrapper" id="main-content" role="main">
 
             <h1 class="govuk-heading-xl">Cookies</h1>

--- a/service-front/app/src/Common/templates/partials/cookies.html.twig
+++ b/service-front/app/src/Common/templates/partials/cookies.html.twig
@@ -10,7 +10,7 @@
 {% block content %}
     <div class="govuk-width-container">
 
-        <a class="govuk-link govuk-back-link" href="{{ routeReferer }}">Back</a>
+        <a class="govuk-link govuk-back-link" href="{{ form.get('referer').getValue() }}">Back</a>
 
         <main class="govuk-main-wrapper" id="main-content" role="main">
 

--- a/service-front/app/src/Viewer/templates/viewer/viewer-privacy-notice.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/viewer-privacy-notice.html.twig
@@ -43,7 +43,7 @@
                     MOJ is the data controller for the personal data we store. <a class="govuk-link" href="https://www.gov.uk/government/organisations/office-of-the-public-guardian/about/personal-information-charter"> <abbr title="Office of the Public Guardian">OPG</abbr>’s personal information charter</a> explains how we process personal data.
                 </p>
                 <p class="govuk-body">
-                    You can find more information about using the View a lasting power of attorney service in our <a class="govuk-link" href="{{ path('viewer-terms-of-use') }}">terms of use</a> and <a class="govuk-link" class="govuk-link"  href="#">cookies policy</a>.
+                    You can find more information about using the View a lasting power of attorney service in our <a class="govuk-link" href="{{ path('viewer-terms-of-use') }}">terms of use</a> and <a class="govuk-link" class="govuk-link"  href="{{ path('viewer-cookies')}}">cookies policy</a>.
                 </p>
                 <h2 class="govuk-heading-m">What data we collect and how we use it</h2>
 

--- a/service-front/app/src/Viewer/templates/viewer/viewer-privacy-notice.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/viewer-privacy-notice.html.twig
@@ -43,7 +43,7 @@
                     MOJ is the data controller for the personal data we store. <a class="govuk-link" href="https://www.gov.uk/government/organisations/office-of-the-public-guardian/about/personal-information-charter"> <abbr title="Office of the Public Guardian">OPG</abbr>’s personal information charter</a> explains how we process personal data.
                 </p>
                 <p class="govuk-body">
-                    You can find more information about using the View a lasting power of attorney service in our <a class="govuk-link" href="{{ path('viewer-terms-of-use') }}">terms of use</a> and <a class="govuk-link" class="govuk-link"  href="{{ path('viewer-cookies')}}">cookies policy</a>.
+                    You can find more information about using the View a lasting power of attorney service in our <a class="govuk-link" href="{{ path('viewer-terms-of-use') }}">terms of use</a> and <a class="govuk-link" class="govuk-link"  href="{{ path('viewer-cookies')}}">cookie policy</a>.
                 </p>
                 <h2 class="govuk-heading-m">What data we collect and how we use it</h2>
 

--- a/service-front/app/src/Viewer/templates/viewer/viewer-terms-of-use.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/viewer-terms-of-use.html.twig
@@ -59,7 +59,7 @@
                 <h2 class="govuk-heading-m">Tracking use of the service</h2>
 
                 <p class="govuk-body">We keep a record of when an access code has been used to view an <abbr title="lasting power of attorney">LPA</abbr>. This information is available to the donor and attorneys.</p>
-                <p class="govuk-body">The information will be stored securely and used in line with our <a class="govuk-link" href="{{  path('viewer-privacy-notice') }}">privacy notice</a> and cookie policy.</p>
+                <p class="govuk-body">The information will be stored securely and used in line with our <a class="govuk-link" href="{{  path('viewer-privacy-notice') }}">privacy notice</a> and <a class="govuk-link" href="{{ path('viewer-cookies') }}">cookie policy</a>.</p>
 
                 <h2 class="govuk-heading-m">If you suspect fraud or abuse</h2>
 

--- a/service-front/app/test/CommonTest/Service/Url/UrlValidityCheckServiceTest.php
+++ b/service-front/app/test/CommonTest/Service/Url/UrlValidityCheckServiceTest.php
@@ -100,6 +100,8 @@ class UrlValidityCheckServiceTest extends TestCase
         $router = $this->prophesize(RouterInterface::class);
         $router->match($requestReturn)->willReturn($routeResult->reveal());
 
+        $routeResult->isSuccess()->willReturn(true);
+
         $service = new UrlValidityCheckService(
             $serverRequestFactory->reveal(),
             $router->reveal(),
@@ -130,6 +132,8 @@ class UrlValidityCheckServiceTest extends TestCase
 
         $this->routerProphecy->match($requestReturn)->willReturn($routeResult->reveal());
 
+        $routeResult->isSuccess()->willReturn(true);
+
         $service = new UrlValidityCheckService(
             $this->serverRequestFactoryProphecy->reveal(),
             $this->routerProphecy->reveal(),
@@ -138,6 +142,40 @@ class UrlValidityCheckServiceTest extends TestCase
 
         $resultReferer = $service->setValidReferer($refererUrl);
         $this->assertEquals($refererUrl, $resultReferer);
+    }
+
+    /** @test */
+    public function it_returns_a_url_for_home_if_referer_is_invalid()
+    {
+        $homeUrl = 'https://localhost:9002/';
+        $refererUrl = 'https://www.invalid/url';
+
+        $routeResult = $this->prophesize(RouteResult::class);
+        $requestReturn =  new ServerRequest(
+            [],
+            [],
+            $refererUrl,
+            "method",
+            'php://temp'
+        );
+
+        $this->serverRequestFactoryProphecy->createServerRequest('GET', $refererUrl)->willReturn($requestReturn);
+
+        $this->routerProphecy->match($requestReturn)->willReturn($routeResult->reveal());
+
+        $routeResult->isSuccess()->willReturn(false);
+
+        $service = new UrlValidityCheckService(
+            $this->serverRequestFactoryProphecy->reveal(),
+            $this->routerProphecy->reveal(),
+            $this->urlHelperProphecy->reveal()
+        );
+
+        $this->urlHelperProphecy->generate('home')->willReturn($homeUrl);
+
+        $resultReferer = $service->setValidReferer($refererUrl);
+
+        $this->assertEquals($homeUrl, $resultReferer);
     }
 
     /** @test */

--- a/service-front/app/test/CommonTest/Service/Url/UrlValidityCheckServiceTest.php
+++ b/service-front/app/test/CommonTest/Service/Url/UrlValidityCheckServiceTest.php
@@ -12,6 +12,7 @@ use Mezzio\Router\RouterInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Mezzio\Helper\UrlHelper;
 
 class UrlValidityCheckServiceTest extends TestCase
 {
@@ -30,11 +31,17 @@ class UrlValidityCheckServiceTest extends TestCase
      */
     protected $serverRequestInterfaceProphecy;
 
+    /**
+     * @var UrlHelper
+     */
+    private $urlHelperProphecy;
+
     public function setUp()
     {
         $this->serverRequestFactoryProphecy = $this->prophesize(ServerRequestFactory::class);
         $this->routerProphecy = $this->prophesize(RouterInterface::class);
         $this->serverRequestInterfaceProphecy = $this->prophesize(ServerRequestInterface::class);
+        $this->urlHelperProphecy = $this->prophesize(UrlHelper::class);
     }
 
     /** @test */
@@ -44,7 +51,8 @@ class UrlValidityCheckServiceTest extends TestCase
 
         $service = new UrlValidityCheckService(
             $this->serverRequestFactoryProphecy->reveal(),
-            $this->routerProphecy->reveal()
+            $this->routerProphecy->reveal(),
+            $this->urlHelperProphecy->reveal()
         );
 
         $valid = $service->isValid($refererUrl);
@@ -60,7 +68,8 @@ class UrlValidityCheckServiceTest extends TestCase
 
         $service = new UrlValidityCheckService(
             $this->serverRequestFactoryProphecy->reveal(),
-            $this->routerProphecy->reveal()
+            $this->routerProphecy->reveal(),
+            $this->urlHelperProphecy->reveal()
         );
 
         $valid = $service->isValid($refererUrl);
@@ -93,12 +102,59 @@ class UrlValidityCheckServiceTest extends TestCase
 
         $service = new UrlValidityCheckService(
             $serverRequestFactory->reveal(),
-            $router->reveal()
+            $router->reveal(),
+            $this->urlHelperProphecy->reveal()
         );
 
         $valid = $service->checkRefererRouteValid($refererUrl);
 
         $this->assertIsBool($valid);
         $this->assertTrue($valid);
+    }
+
+    /** @test */
+    public function it_returns_a_valid_referer()
+    {
+        $refererUrl = 'https://366uml695cook.use.lastingpowerofattorney.opg.service.justice.gov.uk/lpa/dashboard';
+
+        $routeResult = $this->prophesize(RouteResult::class);
+        $requestReturn =  new ServerRequest(
+            [],
+            [],
+            $refererUrl,
+            "method",
+            'php://temp'
+        );
+
+        $this->serverRequestFactoryProphecy->createServerRequest('GET', $refererUrl)->willReturn($requestReturn);
+
+        $this->routerProphecy->match($requestReturn)->willReturn($routeResult->reveal());
+
+        $service = new UrlValidityCheckService(
+            $this->serverRequestFactoryProphecy->reveal(),
+            $this->routerProphecy->reveal(),
+            $this->urlHelperProphecy->reveal()
+        );
+
+        $resultReferer = $service->setValidReferer($refererUrl);
+        $this->assertEquals($refererUrl, $resultReferer);
+    }
+
+    /** @test */
+    public function it_returns_a_url_for_home_if_referer_is_null()
+    {
+        $homeUrl = 'https://localhost:9002/';
+
+        $service = new UrlValidityCheckService(
+            $this->serverRequestFactoryProphecy->reveal(),
+            $this->routerProphecy->reveal(),
+            $this->urlHelperProphecy->reveal()
+        );
+
+        $this->urlHelperProphecy->generate('home')->willReturn($homeUrl);
+
+        $resultReferer = $service->setValidReferer(null);
+
+        $this->assertEquals($homeUrl, $resultReferer);
     }
 }


### PR DESCRIPTION
## Purpose
The ticket's original purpose was to add content to the cookie preferences pages, however this content already exists. Instead this ticket now add's links to the terms of use and privacy policy pages to take the user to the cookie preferences pages

UPDATE - this ticket now also adds a back button to the cookies page with the functionality to take the user back to the page they were on before they visited the cookies page

Fixes UML-896

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes

