### PR TITLE
UML-805 remove old brute force cache cluster

### DIFF
--- a/terraform/account/elasticache.tf
+++ b/terraform/account/elasticache.tf
@@ -10,20 +10,6 @@ resource "aws_elasticache_subnet_group" "private_subnets" {
 }
 
 
-resource "aws_elasticache_cluster" "brute_force_cache" {
-  cluster_id           = "brute-force-cache"
-  engine               = "redis"
-  node_type            = "cache.t2.micro"
-  num_cache_nodes      = 1
-  parameter_group_name = "default.redis5.0"
-  engine_version       = "5.0.6"
-
-  subnet_group_name  = aws_elasticache_subnet_group.private_subnets.name
-  security_group_ids = [aws_security_group.brute_force_cache_service.id]
-
-  tags = local.default_tags
-}
-
 resource "aws_elasticache_replication_group" "brute_force_cache_replication_group" {
   automatic_failover_enabled    = true
   replication_group_id          = "brute-force-cache-replication-group"


### PR DESCRIPTION
## Purpose
***Part 3 of 3***:
Remove old brute force cache resource - covered by subtask UML-921

Fixes UML-804

## Approach
- remove the terraform for the old brute force cache.

## Learning
- more Terraform 

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work/ Planned the terraform work.
* [ ] The product team have tested these changes

