### PR TITLE
Added performance metric collection to send to GA (DO NOT MERGE)

### DIFF
--- a/service-front/web/package-lock.json
+++ b/service-front/web/package-lock.json
@@ -3641,6 +3641,14 @@
         "moment": "^2.22.2"
       }
     },
+    "@ministryofjustice/opg-performance-analytics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/opg-performance-analytics/-/opg-performance-analytics-1.1.0.tgz",
+      "integrity": "sha512-rHeRcOLROQfOcNQ7Oo97cgVgM7SgjOZjRvepezaI51AQ2ObZYdKG8bSJRE72s2r5B2HfNIQzx2r2YtRkf8xVXQ==",
+      "requires": {
+        "perfume.js": "^5.0.0-rc.15"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -13117,6 +13125,11 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
+    },
+    "perfume.js": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/perfume.js/-/perfume.js-5.1.0.tgz",
+      "integrity": "sha512-ICZ54+V/6v7Qa40oQw7JtA0wcczYJb3azx+g8FP5u1ZawIEjnzAIVeBBkclkfqN1y25p9qjKjhJqvdzk9kugQg=="
     },
     "picomatch": {
       "version": "2.2.2",

--- a/service-front/web/package.json
+++ b/service-front/web/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@ministryofjustice/frontend": "0.0.18-alpha",
+    "@ministryofjustice/opg-performance-analytics": "^1.1.0",
     "govuk-frontend": "^3.6.0"
   },
   "jest-junit": {

--- a/service-front/web/src/javascript/googleAnalytics.js
+++ b/service-front/web/src/javascript/googleAnalytics.js
@@ -1,3 +1,7 @@
+import {
+    PerformanceAnalytics,
+    ErrorAnalytics,
+} from "@ministryofjustice/opg-performance-analytics";
 
 export default class GoogleAnalytics {
     constructor(analyticsId) {
@@ -25,6 +29,9 @@ export default class GoogleAnalytics {
             'allow_ad_personalization_signals': false // https://developers.google.com/analytics/devguides/collection/gtagjs/display-features
         });
         this._trackExternalLinks();
+
+        PerformanceAnalytics();
+        ErrorAnalytics();
     }
 
     trackEvent(action, category, label, value = "") {


### PR DESCRIPTION
## Purpose
Experiment in integrating the @ministryofjustice/opg-performance-analytics library for sending performance metrics to GA.

Going to test on a PR environment to see data collected.

Fixes UML-####

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Refunds service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

