### PR TITLE
UML-947 - Create Certificates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -804,7 +804,7 @@ orbs:
               command: |
                 cd ~/project/terraform/account
                 terraform init -lock-timeout=300s
-                terraform plan -lock-timeout=300s --auto-approve
+                terraform plan -lock-timeout=300s
 
       apply_shared_terraform:
         #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,8 +92,8 @@ workflows:
               ]
 
             # Provision and test development
-        - use-my-lpa/apply_shared_terraform:
-            name: dev_apply_shared_terraform
+        - use-my-lpa/plan_shared_terraform:
+            name: dev_plan_shared_terraform
             filters: { branches: { ignore: [master] } }
             requires: [lint_terraform_pr_build]
 
@@ -102,7 +102,7 @@ workflows:
             filters: { branches: { ignore: [master] } }
             requires:
               [
-                dev_apply_shared_terraform,
+                dev_plan_shared_terraform,
                 app_front_build_pr_build,
                 web_front_build_pr_build,
                 web_api_build_pr_build,
@@ -197,9 +197,18 @@ workflows:
 
         # Provision and test preproduction
         - use-my-lpa/apply_shared_terraform:
+            name: dev_apply_shared_terraform
+            workspace: development
+            filters: { branches: { only: [master] } }
+
+        - use-my-lpa/apply_shared_terraform:
             name: preprod_apply_shared_terraform
             workspace: preproduction
             filters: { branches: { only: [master] } }
+            requires:
+              [
+                dev_apply_shared_terraform,
+              ]
 
         - use-my-lpa/apply_environment_terraform:
             name: preprod_apply_environment_terraform
@@ -774,6 +783,28 @@ orbs:
                 export IMAGE_TAG=$(~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
                 echo $IMAGE_TAG
                 terraform validate -var container_version=${IMAGE_TAG}
+
+      plan_shared_terraform:
+        #
+        # Plan the shared terraform configuration. This:
+        #   - Updates the shared infrastructure;
+        #
+        executor: terraform
+        parameters:
+          workspace:
+            description: Terraform workspace name
+            type: string
+            default: development
+        environment:
+          TF_WORKSPACE: "<<parameters.workspace>>"
+        steps:
+          - checkout
+          - run:
+              name: Plan Shared Terraform
+              command: |
+                cd ~/project/terraform/account
+                terraform init -lock-timeout=300s
+                terraform plan -lock-timeout=300s --auto-approve
 
       apply_shared_terraform:
         #

--- a/terraform/account/certificate.tf
+++ b/terraform/account/certificate.tf
@@ -3,6 +3,16 @@ data "aws_route53_zone" "opg_service_justice_gov_uk" {
   name     = "opg.service.justice.gov.uk"
 }
 
+data "aws_route53_zone" "live_service_use_lasting_power_of_attorney" {
+  provider = aws.management
+  name     = "use-lasting-power-of-attorney.service.gov.uk"
+}
+
+data "aws_route53_zone" "live_service_view_lasting_power_of_attorney" {
+  provider = aws.management
+  name     = "view-lasting-power-of-attorney.service.gov.uk"
+}
+
 //------------------------
 // View Certificates
 
@@ -25,6 +35,25 @@ resource "aws_acm_certificate" "certificate_view" {
   validation_method = "DNS"
 }
 
+resource "aws_route53_record" "certificate_validation_public_facing_view" {
+  provider = aws.management
+  name     = aws_acm_certificate.certificate_public_facing_view.domain_validation_options[0].resource_record_name
+  type     = aws_acm_certificate.certificate_public_facing_view.domain_validation_options[0].resource_record_type
+  zone_id  = data.aws_route53_zone.live_service_view_lasting_power_of_attorney.zone_id
+  records  = [aws_acm_certificate.certificate_public_facing_view.domain_validation_options[0].resource_record_value]
+  ttl      = 60
+}
+
+resource "aws_acm_certificate_validation" "certificate_public_facing_view" {
+  certificate_arn         = aws_acm_certificate.certificate_public_facing_view.arn
+  validation_record_fqdns = [aws_route53_record.certificate_validation_public_facing_view.fqdn]
+}
+
+resource "aws_acm_certificate" "certificate_public_facing_view" {
+  domain_name       = "${local.dev_wildcard}${data.aws_route53_zone.live_service_view_lasting_power_of_attorney.name}"
+  validation_method = "DNS"
+}
+
 //------------------------
 // Use Certificates
 
@@ -44,5 +73,24 @@ resource "aws_acm_certificate_validation" "certificate_use" {
 
 resource "aws_acm_certificate" "certificate_use" {
   domain_name       = "${local.dev_wildcard}use.lastingpowerofattorney.opg.service.justice.gov.uk"
+  validation_method = "DNS"
+}
+
+resource "aws_route53_record" "certificate_validation_public_facing_use" {
+  provider = aws.management
+  name     = aws_acm_certificate.certificate_public_facing_use.domain_validation_options[0].resource_record_name
+  type     = aws_acm_certificate.certificate_public_facing_use.domain_validation_options[0].resource_record_type
+  zone_id  = data.aws_route53_zone.live_service_use_lasting_power_of_attorney.zone_id
+  records  = [aws_acm_certificate.certificate_public_facing_use.domain_validation_options[0].resource_record_value]
+  ttl      = 60
+}
+
+resource "aws_acm_certificate_validation" "certificate_public_facing_use" {
+  certificate_arn         = aws_acm_certificate.certificate_public_facing_use.arn
+  validation_record_fqdns = [aws_route53_record.certificate_validation_public_facing_use.fqdn]
+}
+
+resource "aws_acm_certificate" "certificate_public_facing_use" {
+  domain_name       = "${local.dev_wildcard}${data.aws_route53_zone.live_service_use_lasting_power_of_attorney.name}"
   validation_method = "DNS"
 }


### PR DESCRIPTION
## Purpose
Make it safer to create account-level resources in dev
Secure communications between users and our service.

Fixes UML-947

## Approach

Only show the plan of account-level resources in dev during the pr-build workflow, and apply on path-to-live only.
Create a new set of certificates for the public-facing URLs.

## Learning



## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

