### PR TITLE
Strips querystrings from page views in GA

### DIFF
--- a/service-front/web/src/javascript/googleAnalytics.js
+++ b/service-front/web/src/javascript/googleAnalytics.js
@@ -28,7 +28,9 @@ export default class GoogleAnalytics {
             'transport_type': 'beacon',
             'anonymize_ip': true, // https://developers.google.com/analytics/devguides/collection/gtagjs/ip-anonymization
             'allow_google_signals': false, // https://developers.google.com/analytics/devguides/collection/gtagjs/display-features
-            'allow_ad_personalization_signals': false // https://developers.google.com/analytics/devguides/collection/gtagjs/display-features
+            'allow_ad_personalization_signals': false, // https://developers.google.com/analytics/devguides/collection/gtagjs/display-features
+            'page_title' : document.title,
+            'page_path': `${location.protocol}//${location.host}${location.pathname}`
         });
         this._trackExternalLinks();
 

--- a/service-front/web/src/javascript/googleAnalytics.test.js
+++ b/service-front/web/src/javascript/googleAnalytics.test.js
@@ -45,56 +45,67 @@ describe('given Google Analytics datalayer is not setup', () => {
     });
 });
 
-    describe('given Google Analytics is enabled', () => {
-        let useAnalytics;
-        beforeEach(() => {
-            document.body.innerHTML = linkList;
-            global.dataLayer = [];
-            useAnalytics = new googleAnalytics('UA-12345');
-        });
+describe('given Google Analytics is enabled', () => {
+    let useAnalytics;
+    beforeEach(() => {
+        document.body.innerHTML = linkList;
+        document.title = 'Test Page Title';
+        delete global.window.location;
+        global.window = Object.create(window);
+        global.window.location = {
+            port: '80',
+            protocol: 'https:',
+            host: 'localhost',
+            hostname: 'localhost',
+            pathname: '/use-lpa',
+            search: "?v=email@test.com"
+        };
+        global.dataLayer = [];
+        useAnalytics = new googleAnalytics('UA-12345');
+    });
 
-        /**
-         * Description of data layer 2 and 3 in gtag
-         * [Arguments] {
-          '0': 'event',
-          '1': 'event',
-          '2': {
-                event_category: 'event_category',
-                event_label: 'event_label',
-                value: 'value'
-             }
-            }
-         */
-        test('it fires click events on the 2 external links', () => {
-            const linkSelector = document.querySelectorAll('a');
-            for (let i = 0; i < linkSelector.length; i++) {
-                linkSelector[i].click();
-            }
+    /**
+     * Description of data layer 2 and 3 in gtag
+     * [Arguments] {
+      '0': 'event',
+      '1': 'event',
+      '2': {
+            event_category: 'event_category',
+            event_label: 'event_label',
+            value: 'value'
+         }
+        }
+     */
+    test('it fires click events on the 2 external links', () => {
+        const linkSelector = document.querySelectorAll('a');
+        for (let i = 0; i < linkSelector.length; i++) {
+            linkSelector[i].click();
+        }
 
-            expect(global.dataLayer[2][0]).toBe('event');
-            expect(global.dataLayer[2][1]).toBe('click');
-            expect(global.dataLayer[2][2].event_category).toBe('outbound');
-            expect(global.dataLayer[2][2].event_label).toBe('http://localhost/');
-            expect(global.dataLayer[3][0]).toBe('event');
-            expect(global.dataLayer[3][1]).toBe('click');
-            expect(global.dataLayer[3][2].event_category).toBe('outbound');
-            expect(global.dataLayer[3][2].event_label).toBe('https://localhost/');
-            expect(global.dataLayer.length).toEqual(4);
-        });
+        expect(global.dataLayer[2][0]).toBe('event');
+        expect(global.dataLayer[2][1]).toBe('click');
+        expect(global.dataLayer[2][2].event_category).toBe('outbound');
+        expect(global.dataLayer[2][2].event_label).toBe('http://localhost/');
+        expect(global.dataLayer[3][0]).toBe('event');
+        expect(global.dataLayer[3][1]).toBe('click');
+        expect(global.dataLayer[3][2].event_category).toBe('outbound');
+        expect(global.dataLayer[3][2].event_label).toBe('https://localhost/');
+        expect(global.dataLayer.length).toEqual(4);
+    });
 
-        /**
-         * Description of data layer 1 in gtag
-         *  'config',
-         *  this.analyticsId, {
-                'linker': {
-                    'domains': ['www.gov.uk']
-            },
-            'transport_type': 'beacon',
-            'anonymize_ip': true,
-            'allow_google_signals': false, //display-features
-            'allow_ad_personalization_signals': false //display-features
-         *
-         */
+    /**
+     * Description of data layer 1 in gtag
+     *  'config',
+     *  this.analyticsId, {
+            'linker': {
+                'domains': ['www.gov.uk']
+        },
+        'transport_type': 'beacon',
+        'anonymize_ip': true,
+        'allow_google_signals': false, //display-features
+        'allow_ad_personalization_signals': false //display-features
+     *
+     */
     test('it should have the correct config setup', () => {
         expect(global.dataLayer.length).toEqual(2);
         expect(global.dataLayer[1][0]).toBe('config');
@@ -174,5 +185,11 @@ describe('given Google Analytics datalayer is not setup', () => {
 
         expect(global.dataLayer[2][2].value).not.toBeUndefined();
         expect(global.dataLayer[2][2].value).toBe('[sanitised]');
+    });
+
+    test('it should strip querystrings out of the pageview', () => {
+        console.log(global.dataLayer)
+        expect(global.dataLayer[1][2].page_title).toBe('Test Page Title');
+        expect(global.dataLayer[1][2].page_path).toBe('https://localhost/use-lpa');
     });
 });


### PR DESCRIPTION
## Purpose
Fixes GA from sending PID in querystrings

Fixes UML-950

## Approach

Manually override the url details to send on initial tracking of the page to strip the querystring out.

## Learning

Ideally we want to not include PID in our urls but understand this is sometimes unpreventable.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes

