### PR TITLE
UML-932 - Users should start their journey from the gov.uk start page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1014,7 +1014,7 @@ jobs:
       - slack/notify:
           title: "Use a Lasting Power of Attorney Development Environment Ready"
           color: "#9933ff"
-          message: "User: $CIRCLE_USERNAME \nview url: https://$VIEW_DOMAIN \nuse url: https://$USE_DOMAIN \npublic facing view url: https://$PUBLIC_FACING_VIEW_DOMAIN \npublic facing use url: https://$PUBLIC_FACING_USE_DOMAIN"
+          message: "User: $CIRCLE_USERNAME \nview url: https://$VIEW_DOMAIN/home \nuse url: https://$USE_DOMAIN/home \npublic facing view url: https://$PUBLIC_FACING_VIEW_DOMAIN/home \npublic facing use url: https://$PUBLIC_FACING_USE_DOMAIN/home"
           footer: "$CIRCLE_BRANCH - Commit Message: $COMMIT_MESSAGE"
 
   slack_notify_production_release:
@@ -1031,7 +1031,7 @@ jobs:
       - slack/notify:
           title: "Use a Lasting Power of Attorney Production Release Successful"
           color: "#9933ff"
-          message: "User: $CIRCLE_USERNAME \nview url: https://$VIEW_DOMAIN \nuse url: https://$USE_DOMAIN \npublic facing view url: https://$PUBLIC_FACING_VIEW_DOMAIN \npublic facing use url: https://$PUBLIC_FACING_USE_DOMAIN"
+          message: "User: $CIRCLE_USERNAME \nview url: https://$VIEW_DOMAIN/home \nuse url: https://$USE_DOMAIN/home \npublic facing view url: https://$PUBLIC_FACING_VIEW_DOMAIN/home \npublic facing use url: https://$PUBLIC_FACING_USE_DOMAIN/home"
           webhook: ${PROD_RELEASE_SLACK_WEBHOOK}
           footer: "$CIRCLE_BRANCH - Commit Message: $COMMIT_MESSAGE"
 

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -19,7 +19,7 @@ server {
 }
 server {
     listen       80 default_server;
-    server_name *.use-lasting-power-of-attorney.service.gov.uk/ use-lasting-power-of-attorney.service.gov.uk/;
+    server_name *.use-lasting-power-of-attorney.service.gov.uk use-lasting-power-of-attorney.service.gov.uk;
     location = / {
       return 301 https://www.gov.uk/use-lasting-power-of-attorney;
     }

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -66,7 +66,6 @@ server {
 
     # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
     #
-
     location ~ \.php$ {
         fastcgi_pass   {{getv "/app/host" }}:{{getv "/app/port" }};
         fastcgi_split_path_info ^(.+\.php)(/.*)$;

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -10,32 +10,18 @@ map $http_x_amzn_trace_id $trace_id {
 }
 
 # Permanent redirect of root to gov.uk
-# server {
-#     listen       80;
-#     server_name .view-lasting-power-of-attorney.service.gov.uk .view.lastingpowerofattorney.opg.service.justice.gov.uk;
-#     location = / {
-#       return 301 https://www.gov.uk/view-lasting-power-of-attorney;
-#     }
-# }
-# server {
-#     listen       80;
-#     server_name .use-lasting-power-of-attorney.service.gov.uk .use.lastingpowerofattorney.opg.service.justice.gov.uk;
-#     location = / {
-#       return 301 https://www.gov.uk/use-lasting-power-of-attorney;
-#     }
-# }
 server {
     listen       80;
     server_name .view-lasting-power-of-attorney.service.gov.uk .view.lastingpowerofattorney.opg.service.justice.gov.uk;
     location = / {
-      return 302 $scheme://$server_name/home;
+      return 301 https://www.gov.uk/view-lasting-power-of-attorney;
     }
 }
 server {
     listen       80;
     server_name .use-lasting-power-of-attorney.service.gov.uk .use.lastingpowerofattorney.opg.service.justice.gov.uk;
     location = / {
-      return 302 $scheme://$server_name/home;
+      return 301 https://www.gov.uk/use-lasting-power-of-attorney;
     }
 }
 

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -61,8 +61,8 @@ server {
     }
 
     # Permanent redirect of root to gov.uk
-    rewrite ^view-lasting-power-of-attorney.service.gov.uk/ https://www.gov.uk/view-lasting-power-of-attorney permanent;
-    rewrite ^use-lasting-power-of-attorney.service.gov.uk/ https://www.gov.uk/use-lasting-power-of-attorney permanent;
+    rewrite ^view-lasting-power-of-attorney.service.gov.uk/$ https://www.gov.uk/view-lasting-power-of-attorney permanent;
+    rewrite ^use-lasting-power-of-attorney.service.gov.uk/$ https://www.gov.uk/use-lasting-power-of-attorney permanent;
 
     # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
     #

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -13,7 +13,7 @@ map $http_x_amzn_trace_id $trace_id {
 server {
     listen 80;
     listen 443 ssl;
-    server_name *.view-lasting-power-of-attorney.service.gov.uk/ view-lasting-power-of-attorney.service.gov.uk/;
+    server_name *.view-lasting-power-of-attorney.service.gov.uk/home view-lasting-power-of-attorney.service.gov.uk/;
     return 301 https://www.gov.uk/view-lasting-power-of-attorney;
 
     #rewrite ^view-lasting-power-of-attorney.service.gov.uk$ https://www.gov.uk/view-lasting-power-of-attorney permanent;
@@ -60,8 +60,6 @@ server {
     location = /50x.html {
         root   /usr/share/nginx/html;
     }
-
-
 
     # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
     #

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -35,7 +35,7 @@ server {
     listen       80;
     server_name .use-lasting-power-of-attorney.service.gov.uk .use.lastingpowerofattorney.opg.service.justice.gov.uk;
     location = / {
-      return 302 $hostname/home;
+      return 302 $scheme://$server_name/home;
     }
 }
 

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -61,8 +61,8 @@ server {
     }
 
     # Permanent redirect of root to gov.uk
-    rewrite ^view-lasting-power-of-attorney.service.gov.uk/$ https://www.gov.uk/view-lasting-power-of-attorney permanent;
-    rewrite ^use-lasting-power-of-attorney.service.gov.uk/$ https://www.gov.uk/use-lasting-power-of-attorney permanent;
+    rewrite ^view-lasting-power-of-attorney.service.gov.uk$ https://www.gov.uk/view-lasting-power-of-attorney permanent;
+    rewrite ^use-lasting-power-of-attorney.service.gov.uk$ https://www.gov.uk/use-lasting-power-of-attorney permanent;
 
     # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
     #

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -9,22 +9,6 @@ map $http_x_amzn_trace_id $trace_id {
     default "Root=1-$msec-$connection$connection_requests";
 }
 
-# Permanent redirect of root to gov.uk
-server {
-    listen       80;
-    server_name *view-lasting-power-of-attorney.service.gov.uk *view.lastingpowerofattorney.opg.service.justice.gov.uk;
-    location = / {
-      return 301 https://www.gov.uk/view-lasting-power-of-attorney;
-    }
-}
-server {
-    listen       80;
-    server_name *use-lasting-power-of-attorney.service.gov.uk *use.lastingpowerofattorney.opg.service.justice.gov.uk;
-    location = / {
-      return 301 https://www.gov.uk/use-lasting-power-of-attorney;
-    }
-}
-
 server {
     listen       80 default_server;
     server_name  _;

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -10,20 +10,21 @@ map $http_x_amzn_trace_id $trace_id {
 }
 
 # Permanent redirect of root to gov.uk
-# server {
-#     listen       80;
-#     server_name .view-lasting-power-of-attorney.service.gov.uk .view.lastingpowerofattorney.opg.service.justice.gov.uk;
-#     location = / {
-#       return 301 https://www.gov.uk/view-lasting-power-of-attorney;
-#     }
-# }
-# server {
-#     listen       80;
-#     server_name .use-lasting-power-of-attorney.service.gov.uk .use.lastingpowerofattorney.opg.service.justice.gov.uk;
-#     location = / {
-#       return 301 https://www.gov.uk/use-lasting-power-of-attorney;
-#     }
-# }
+server {
+    listen 80;
+    listen 443 ssl;
+    server_name *.view-lasting-power-of-attorney.service.gov.uk/ view-lasting-power-of-attorney.service.gov.uk/;
+    return 301 https://www.gov.uk/view-lasting-power-of-attorney;
+
+    #rewrite ^view-lasting-power-of-attorney.service.gov.uk$ https://www.gov.uk/view-lasting-power-of-attorney permanent;
+}
+server {
+    listen 80;
+    listen 443 ssl;
+    server_name *.use-lasting-power-of-attorney.service.gov.uk/ use-lasting-power-of-attorney.service.gov.uk/;
+    return 301 https://www.gov.uk/use-lasting-power-of-attorney;
+    #rewrite ^use-lasting-power-of-attorney.service.gov.uk$ https://www.gov.uk/use-lasting-power-of-attorney permanent;
+}
 
 server {
     listen       80 default_server;
@@ -60,9 +61,7 @@ server {
         root   /usr/share/nginx/html;
     }
 
-    # Permanent redirect of root to gov.uk
-    rewrite ^view-lasting-power-of-attorney.service.gov.uk$ https://www.gov.uk/view-lasting-power-of-attorney permanent;
-    rewrite ^use-lasting-power-of-attorney.service.gov.uk$ https://www.gov.uk/use-lasting-power-of-attorney permanent;
+
 
     # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
     #

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -12,15 +12,15 @@ map $http_x_amzn_trace_id $trace_id {
 # Permanent redirect of root to gov.uk
 server {
     listen       80;
-    server_name .view-lasting-power-of-attorney.service.gov.uk .view.lastingpowerofattorney.opg.service.justice.gov.uk;
-    location = /$ {
+    server_name *view-lasting-power-of-attorney.service.gov.uk *view.lastingpowerofattorney.opg.service.justice.gov.uk;
+    location = / {
       return 301 https://www.gov.uk/view-lasting-power-of-attorney;
     }
 }
 server {
     listen       80;
-    server_name .use-lasting-power-of-attorney.service.gov.uk .use.lastingpowerofattorney.opg.service.justice.gov.uk;
-    location = /$ {
+    server_name *use-lasting-power-of-attorney.service.gov.uk *use.lastingpowerofattorney.opg.service.justice.gov.uk;
+    location = / {
       return 301 https://www.gov.uk/use-lasting-power-of-attorney;
     }
 }

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -11,15 +11,15 @@ map $http_x_amzn_trace_id $trace_id {
 
 # Permanent redirect of root to gov.uk
 server {
-    listen       80 default_server;
-    server_name view-lasting-power-of-attorney.service.gov.uk *.view-lasting-power-of-attorney.service.gov.uk ;
+    listen       80;
+    server_name .view-lasting-power-of-attorney.service.gov.uk .view.lastingpowerofattorney.opg.service.justice.gov.uk;
     location = / {
       return 301 https://www.gov.uk/view-lasting-power-of-attorney;
     }
 }
 server {
-    listen       80 default_server;
-    server_name  use-lasting-power-of-attorney.service.gov.uk *.use-lasting-power-of-attorney.service.gov.uk;
+    listen       80;
+    server_name .use-lasting-power-of-attorney.service.gov.uk .use.lastingpowerofattorney.opg.service.justice.gov.uk;
     location = / {
       return 301 https://www.gov.uk/use-lasting-power-of-attorney;
     }
@@ -45,10 +45,10 @@ server {
     add_header X-Content-Type-Options "nosniff";
     add_header Strict-Transport-Security "max-age=3600; includeSubDomains";
 
-    # location / {
-    #     root    /web;
-    #     try_files $uri /index.php$is_args$args;
-    # }
+    location / {
+        root    /web;
+        try_files $uri /index.php$is_args$args;
+    }
 
     # serve noindex, nofollow meta tag on each page so that search engines do not index this domain
     add_header X-Robots-Tag "noindex, nofollow" always;

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -10,18 +10,32 @@ map $http_x_amzn_trace_id $trace_id {
 }
 
 # Permanent redirect of root to gov.uk
+# server {
+#     listen       80;
+#     server_name .view-lasting-power-of-attorney.service.gov.uk .view.lastingpowerofattorney.opg.service.justice.gov.uk;
+#     location = / {
+#       return 301 https://www.gov.uk/view-lasting-power-of-attorney;
+#     }
+# }
+# server {
+#     listen       80;
+#     server_name .use-lasting-power-of-attorney.service.gov.uk .use.lastingpowerofattorney.opg.service.justice.gov.uk;
+#     location = / {
+#       return 301 https://www.gov.uk/use-lasting-power-of-attorney;
+#     }
+# }
 server {
     listen       80;
     server_name .view-lasting-power-of-attorney.service.gov.uk .view.lastingpowerofattorney.opg.service.justice.gov.uk;
     location = / {
-      return 301 https://www.gov.uk/view-lasting-power-of-attorney;
+      return 302 /home;
     }
 }
 server {
     listen       80;
     server_name .use-lasting-power-of-attorney.service.gov.uk .use.lastingpowerofattorney.opg.service.justice.gov.uk;
     location = / {
-      return 301 https://www.gov.uk/use-lasting-power-of-attorney;
+      return 302 /home;
     }
 }
 

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -28,14 +28,14 @@ server {
     listen       80;
     server_name .view-lasting-power-of-attorney.service.gov.uk .view.lastingpowerofattorney.opg.service.justice.gov.uk;
     location = / {
-      return 302 $host/home;
+      return 302 /home;
     }
 }
 server {
     listen       80;
     server_name .use-lasting-power-of-attorney.service.gov.uk .use.lastingpowerofattorney.opg.service.justice.gov.uk;
     location = / {
-      return 302 $host/home;
+      return 302 $hostname/home;
     }
 }
 

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -28,7 +28,7 @@ server {
     listen       80;
     server_name .view-lasting-power-of-attorney.service.gov.uk .view.lastingpowerofattorney.opg.service.justice.gov.uk;
     location = / {
-      return 302 /home;
+      return 302 $scheme://$server_name/home;
     }
 }
 server {

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -60,8 +60,13 @@ server {
         root   /usr/share/nginx/html;
     }
 
+    # Permanent redirect of root to gov.uk
+    rewrite ^view-lasting-power-of-attorney.service.gov.uk/ https://www.gov.uk/view-lasting-power-of-attorney permanent;
+    rewrite ^use-lasting-power-of-attorney.service.gov.uk/ https://www.gov.uk/use-lasting-power-of-attorney permanent;
+
     # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
     #
+
     location ~ \.php$ {
         fastcgi_pass   {{getv "/app/host" }}:{{getv "/app/port" }};
         fastcgi_split_path_info ^(.+\.php)(/.*)$;

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -11,19 +11,18 @@ map $http_x_amzn_trace_id $trace_id {
 
 # Permanent redirect of root to gov.uk
 server {
-    listen 80;
-    listen 443 ssl;
-    server_name *.view-lasting-power-of-attorney.service.gov.uk/home view-lasting-power-of-attorney.service.gov.uk/;
-    return 301 https://www.gov.uk/view-lasting-power-of-attorney;
-
-    #rewrite ^view-lasting-power-of-attorney.service.gov.uk$ https://www.gov.uk/view-lasting-power-of-attorney permanent;
+    listen       80 default_server;
+    server_name *.view-lasting-power-of-attorney.service.gov.uk view-lasting-power-of-attorney.service.gov.uk;
+    location = / {
+      return 301 https://www.gov.uk/view-lasting-power-of-attorney;
+    }
 }
 server {
-    listen 80;
-    listen 443 ssl;
+    listen       80 default_server;
     server_name *.use-lasting-power-of-attorney.service.gov.uk/ use-lasting-power-of-attorney.service.gov.uk/;
-    return 301 https://www.gov.uk/use-lasting-power-of-attorney;
-    #rewrite ^use-lasting-power-of-attorney.service.gov.uk$ https://www.gov.uk/use-lasting-power-of-attorney permanent;
+    location = / {
+      return 301 https://www.gov.uk/use-lasting-power-of-attorney;
+    }
 }
 
 server {

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -28,14 +28,14 @@ server {
     listen       80;
     server_name .view-lasting-power-of-attorney.service.gov.uk .view.lastingpowerofattorney.opg.service.justice.gov.uk;
     location = / {
-      return 302 /home;
+      return 302 $host/home;
     }
 }
 server {
     listen       80;
     server_name .use-lasting-power-of-attorney.service.gov.uk .use.lastingpowerofattorney.opg.service.justice.gov.uk;
     location = / {
-      return 302 /home;
+      return 302 $host/home;
     }
 }
 

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -12,14 +12,14 @@ map $http_x_amzn_trace_id $trace_id {
 # Permanent redirect of root to gov.uk
 server {
     listen       80 default_server;
-    server_name *.view-lasting-power-of-attorney.service.gov.uk view-lasting-power-of-attorney.service.gov.uk;
+    server_name view-lasting-power-of-attorney.service.gov.uk *.view-lasting-power-of-attorney.service.gov.uk ;
     location = / {
       return 301 https://www.gov.uk/view-lasting-power-of-attorney;
     }
 }
 server {
     listen       80 default_server;
-    server_name *.use-lasting-power-of-attorney.service.gov.uk use-lasting-power-of-attorney.service.gov.uk;
+    server_name  use-lasting-power-of-attorney.service.gov.uk *.use-lasting-power-of-attorney.service.gov.uk;
     location = / {
       return 301 https://www.gov.uk/use-lasting-power-of-attorney;
     }
@@ -45,10 +45,10 @@ server {
     add_header X-Content-Type-Options "nosniff";
     add_header Strict-Transport-Security "max-age=3600; includeSubDomains";
 
-    location / {
-        root    /web;
-        try_files $uri /index.php$is_args$args;
-    }
+    # location / {
+    #     root    /web;
+    #     try_files $uri /index.php$is_args$args;
+    # }
 
     # serve noindex, nofollow meta tag on each page so that search engines do not index this domain
     add_header X-Robots-Tag "noindex, nofollow" always;

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -13,14 +13,14 @@ map $http_x_amzn_trace_id $trace_id {
 server {
     listen       80;
     server_name .view-lasting-power-of-attorney.service.gov.uk .view.lastingpowerofattorney.opg.service.justice.gov.uk;
-    location = / {
+    location = /$ {
       return 301 https://www.gov.uk/view-lasting-power-of-attorney;
     }
 }
 server {
     listen       80;
     server_name .use-lasting-power-of-attorney.service.gov.uk .use.lastingpowerofattorney.opg.service.justice.gov.uk;
-    location = / {
+    location = /$ {
       return 301 https://www.gov.uk/use-lasting-power-of-attorney;
     }
 }

--- a/terraform/environment/actor_load_balancer.tf
+++ b/terraform/environment/actor_load_balancer.tf
@@ -63,6 +63,31 @@ resource "aws_lb_listener_certificate" "actor_loadbalancer_live_service_certific
   certificate_arn = data.aws_acm_certificate.public_facing_certificate_use.arn
 }
 
+# redirect root to gov.uk
+resource "aws_lb_listener_rule" "redirect_use_root_to_gov" {
+  listener_arn = aws_lb_listener.actor_loadbalancer.arn
+  priority     = 1
+  action {
+    type = "redirect"
+
+    redirect {
+      host        = "www.gov.uk"
+      path        = "/use-lasting-power-of-attorney"
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = [
+        "/",
+      ]
+    }
+  }
+}
+
 # maintenance site switching
 resource "aws_ssm_parameter" "actor_maintenance_switch" {
   name            = "${local.environment}_actor_enable_maintenance"

--- a/terraform/environment/actor_load_balancer.tf
+++ b/terraform/environment/actor_load_balancer.tf
@@ -115,7 +115,7 @@ locals {
 
 resource "aws_lb_listener_rule" "actor_maintenance" {
   listener_arn = aws_lb_listener.actor_loadbalancer.arn
-
+  priority     = 2
   action {
     type = "fixed-response"
 

--- a/tests/features/user-journeys-start-on-gov-uk.feature
+++ b/tests/features/user-journeys-start-on-gov-uk.feature
@@ -4,12 +4,12 @@ Feature: User Journeys start on Gov.uk
   I want to have an introduction to the service,
   So that I know what it is about and what I will need to use it
 
-  @smoke
+  @smoke @viewer
   Scenario: I start a view journey
     Given I access the service root path
     Then the service should redirect me to "https://www.gov.uk/view-lasting-power-of-attorney"
 
-  @smoke
+  @smoke @actor
   Scenario: I start a use journey
     Given I access the service root path
     Then the service should redirect me to "https://www.gov.uk/use-lasting-power-of-attorney"

--- a/tests/features/user-journeys-start-on-gov-uk.feature
+++ b/tests/features/user-journeys-start-on-gov-uk.feature
@@ -7,9 +7,9 @@ Feature: User Journeys start on Gov.uk
   @smoke
   Scenario: I start a view journey
     Given I access the service root path
-    Then Then the service should redirect me to the "https://www.gov.uk/view-lasting-power-of-attorney"
+    Then the service should redirect me to "https://www.gov.uk/view-lasting-power-of-attorney"
 
   @smoke
   Scenario: I start a use journey
     Given I access the service root path
-    Then Then the use service should redirect me to the "https://www.gov.uk/use-lasting-power-of-attorney"
+    Then the use service should redirect me to "https://www.gov.uk/use-lasting-power-of-attorney"

--- a/tests/features/user-journeys-start-on-gov-uk.feature
+++ b/tests/features/user-journeys-start-on-gov-uk.feature
@@ -12,4 +12,4 @@ Feature: User Journeys start on Gov.uk
   @smoke
   Scenario: I start a use journey
     Given I access the service root path
-    Then the use service should redirect me to "https://www.gov.uk/use-lasting-power-of-attorney"
+    Then the service should redirect me to "https://www.gov.uk/use-lasting-power-of-attorney"

--- a/tests/features/user-journeys-start-on-gov-uk.feature
+++ b/tests/features/user-journeys-start-on-gov-uk.feature
@@ -1,4 +1,4 @@
-@viewer @actor
+@smoke
 Feature: User Journeys start on Gov.uk
   As a user of the service,
   I want to have an introduction to the service,

--- a/tests/features/user-journeys-start-on-gov-uk.feature
+++ b/tests/features/user-journeys-start-on-gov-uk.feature
@@ -1,0 +1,15 @@
+@viewer @actor
+Feature: User Journeys start on Gov.uk
+  As a user of the service,
+  I want to have an introduction to the service,
+  So that I know what it is about and what I will need to use it
+
+  @smoke
+  Scenario: I start a view journey
+    Given I access the service root path
+    Then Then the service should redirect me to the "https://www.gov.uk/view-lasting-power-of-attorney"
+
+  @smoke
+  Scenario: I start a use journey
+    Given I access the service root path
+    Then Then the use service should redirect me to the "https://www.gov.uk/use-lasting-power-of-attorney"

--- a/tests/smoke/context/CommonContext.php
+++ b/tests/smoke/context/CommonContext.php
@@ -80,7 +80,7 @@ class CommonContext implements Context
     }
 
     /**
-     * @Then the service should redirect me to the gov.uk start page
+     * @Then the service should redirect me to :startpage
      */
     public function theServiceShouldRedirectToGovUk(string $startpage): void
     {

--- a/tests/smoke/context/CommonContext.php
+++ b/tests/smoke/context/CommonContext.php
@@ -44,6 +44,19 @@ class CommonContext implements Context
     }
 
     /**
+     * @Given I access the service root path
+     * @Given I access the viewer root path
+     * @Given I access the actor root path
+     */
+    public function iAccessTheServiceRoot(): void
+    {
+        $baseUrlHost = parse_url($this->ui->getMinkParameter('base_url'), PHP_URL_HOST);
+        $rootUrl = sprintf('http://%s/', $baseUrlHost);
+
+        $this->ui->visit($rootUrl);
+    }
+
+    /**
      * @Given I fetch the healthcheck endpoint
      */
     public function iFetchTheHealthcheckEndpoint(): void
@@ -64,6 +77,16 @@ class CommonContext implements Context
         $expectedUrl = sprintf('https://%s/home', $baseUrlHost);
 
         $this->assertExactUrl($expectedUrl);
+    }
+
+    /**
+     * @Then the service should redirect me to the gov.uk start page
+     */
+    public function theServiceShouldRedirectToGovUk(string $startpage): void
+    {
+        $this->ui->assertResponseStatus(StatusCodeInterface::STATUS_OK);
+
+        $this->assertExactUrl($startpage);
     }
 
     /**


### PR DESCRIPTION
## Purpose
Users should start their journey from the gov.uk start page

Fixes UML-932

## Approach

Add rules to the Application Load Balancer

## Learning

Using referrers may be inconsistent
http://nginx.org/en/docs/http/ngx_http_referer_module.html
So instead we are performing a rewrite on the start page of the service.

http://nginx.org/en/docs/http/ngx_http_rewrite_module.html
https://www.liquidweb.com/kb/redirecting-urls-using-nginx/

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes

