### PR TITLE
Changed GA path_name to just path and not the full url

### DIFF
--- a/service-front/web/src/javascript/googleAnalytics.js
+++ b/service-front/web/src/javascript/googleAnalytics.js
@@ -30,7 +30,7 @@ export default class GoogleAnalytics {
             'allow_google_signals': false, // https://developers.google.com/analytics/devguides/collection/gtagjs/display-features
             'allow_ad_personalization_signals': false, // https://developers.google.com/analytics/devguides/collection/gtagjs/display-features
             'page_title' : document.title,
-            'page_path': `${location.protocol}//${location.host}${location.pathname}`
+            'page_path': `${location.pathname}`
         });
         this._trackExternalLinks();
 

--- a/service-front/web/src/javascript/googleAnalytics.test.js
+++ b/service-front/web/src/javascript/googleAnalytics.test.js
@@ -190,6 +190,6 @@ describe('given Google Analytics is enabled', () => {
     test('it should strip querystrings out of the pageview', () => {
         console.log(global.dataLayer)
         expect(global.dataLayer[1][2].page_title).toBe('Test Page Title');
-        expect(global.dataLayer[1][2].page_path).toBe('https://localhost/use-lpa');
+        expect(global.dataLayer[1][2].page_path).toBe('/use-lpa');
     });
 });


### PR DESCRIPTION
## Purpose
Fixes an issue with path_name passing the full url rather than just the pages path.

Fixes UML-961

## Approach

Removed the full url creation from the JS

## Learning



## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes

