### PR TITLE
Replace any strings after the first ? in a url for GA

### DIFF
--- a/service-front/web/src/javascript/googleAnalytics.js
+++ b/service-front/web/src/javascript/googleAnalytics.js
@@ -30,7 +30,7 @@ export default class GoogleAnalytics {
             'allow_google_signals': false, // https://developers.google.com/analytics/devguides/collection/gtagjs/display-features
             'allow_ad_personalization_signals': false, // https://developers.google.com/analytics/devguides/collection/gtagjs/display-features
             'page_title' : document.title,
-            'page_path': `${location.pathname}`
+            'page_path': `${location.pathname.split('?')[0]}`
         });
         this._trackExternalLinks();
 

--- a/service-front/web/src/javascript/googleAnalytics.test.js
+++ b/service-front/web/src/javascript/googleAnalytics.test.js
@@ -57,7 +57,7 @@ describe('given Google Analytics is enabled', () => {
             protocol: 'https:',
             host: 'localhost',
             hostname: 'localhost',
-            pathname: '/use-lpa',
+            pathname: '/use-lpa?email=email@test.com',
             search: "?v=email@test.com"
         };
         global.dataLayer = [];


### PR DESCRIPTION
## Purpose
In some browsers location.pathname also send the querystring and isn't split into the search property. This means we are still being sent email addresses and other data.

Fixes UML-969

## Approach

Added test case and fix to make it pass

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes

