### PR TITLE
Upgrade opg-performance-analytics to fix console error

### DIFF
--- a/service-front/web/package-lock.json
+++ b/service-front/web/package-lock.json
@@ -3642,11 +3642,11 @@
       }
     },
     "@ministryofjustice/opg-performance-analytics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/opg-performance-analytics/-/opg-performance-analytics-1.1.0.tgz",
-      "integrity": "sha512-rHeRcOLROQfOcNQ7Oo97cgVgM7SgjOZjRvepezaI51AQ2ObZYdKG8bSJRE72s2r5B2HfNIQzx2r2YtRkf8xVXQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/opg-performance-analytics/-/opg-performance-analytics-1.1.1.tgz",
+      "integrity": "sha512-48+kqzXOe3YSnSQjeiHOzhI8+uiGqvYiLY80jH1W1ydNudDLbcuhgSpgirCX7maaqx3Yomto6sYeZNkhbyFENA==",
       "requires": {
-        "perfume.js": "^5.0.0-rc.15"
+        "perfume.js": "^5.1.0"
       }
     },
     "@nodelib/fs.scandir": {

--- a/service-front/web/package.json
+++ b/service-front/web/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@ministryofjustice/frontend": "0.0.18-alpha",
-    "@ministryofjustice/opg-performance-analytics": "^1.1.0",
+    "@ministryofjustice/opg-performance-analytics": "^1.1.1",
     "govuk-frontend": "^3.6.0"
   },
   "jest-junit": {


### PR DESCRIPTION
## Purpose
perfume.js has a known bug in their library that creates an error in the console where the PerformanceObserver does not disconnect correctly.

Upgrading the above package includes the fix for it. (1.1.1)

Fixes UML-970

## Approach

Bump the version in the package.json file

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Refunds service_

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes

