### PR TITLE
rewrite private beta url to live service url

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -940,13 +940,19 @@ orbs:
           - run:
               name: Run suite
               command: |
-                viewer_fqdn=$(cat /tmp/cluster_config.json | jq .public_facing_view_fqdn | xargs)
-                actor_fqdn=$(cat /tmp/cluster_config.json | jq .public_facing_use_fqdn | xargs)
+                viewer_fqdn=$(cat /tmp/cluster_config.json | jq .viewer_fqdn | xargs)
+                actor_fqdn=$(cat /tmp/cluster_config.json | jq .actor_fqdn | xargs)
+                public_facing_view_fqdn=$(cat /tmp/cluster_config.json | jq .public_facing_view_fqdn | xargs)
+                public_facing_use_fqdn=$(cat /tmp/cluster_config.json | jq .public_facing_use_fqdn | xargs)
 
                 ln -sf ../features tests/smoke/features
 
                 cd tests/smoke
-                BEHAT_VIEWER_URL=https://$viewer_fqdn BEHAT_ACTOR_URL=https://$actor_fqdn vendor/bin/behat
+                BEHAT_VIEWER_URL=https://$public_facing_view_fqdn \
+                  BEHAT_ACTOR_URL=https://$public_facing_use_fqdn \
+                  BEHAT_OLD_VIEWER_URL=https://$viewer_fqdn \
+                  BEHAT_OLD_ACTOR_URL=https://$actor_fqdn \
+                  vendor/bin/behat
           - store_artifacts:
               path: tests/smoke/failed_step_screenshots
           - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -940,8 +940,8 @@ orbs:
           - run:
               name: Run suite
               command: |
-                viewer_fqdn=$(cat /tmp/cluster_config.json | jq .viewer_fqdn | xargs)
-                actor_fqdn=$(cat /tmp/cluster_config.json | jq .actor_fqdn | xargs)
+                viewer_fqdn=$(cat /tmp/cluster_config.json | jq .public_facing_view_fqdn | xargs)
+                actor_fqdn=$(cat /tmp/cluster_config.json | jq .public_facing_use_fqdn | xargs)
 
                 ln -sf ../features tests/smoke/features
 

--- a/docker-compose.testing.yml
+++ b/docker-compose.testing.yml
@@ -19,6 +19,8 @@ services:
     environment:
       BEHAT_VIEWER_URL: http://viewer-web
       BEHAT_ACTOR_URL: http://actor-web
+      BEHAT_OLD_VIEWER_URL: http://viewer-web
+      BEHAT_OLD_ACTOR_URL: http://actor-web
 
   lpa-codes-pact-mock:
     image: pactfoundation/pact-cli:latest

--- a/terraform/environment/actor_load_balancer.tf
+++ b/terraform/environment/actor_load_balancer.tf
@@ -140,7 +140,7 @@ locals {
 
 resource "aws_lb_listener_rule" "actor_maintenance" {
   listener_arn = aws_lb_listener.actor_loadbalancer.arn
-  priority     = 2
+  priority     = 3
   action {
     type = "fixed-response"
 

--- a/terraform/environment/actor_load_balancer.tf
+++ b/terraform/environment/actor_load_balancer.tf
@@ -88,6 +88,31 @@ resource "aws_lb_listener_rule" "redirect_use_root_to_gov" {
   }
 }
 
+# rewrite to live service url
+resource "aws_lb_listener_rule" "rewrite_use_to_live_service_url" {
+  listener_arn = aws_lb_listener.actor_loadbalancer.arn
+  priority     = 2
+  action {
+    type = "redirect"
+
+    redirect {
+      host        = aws_route53_record.public_facing_use_lasting_power_of_attorney.fqdn
+      path        = "/#{path}"
+      query       = "#{query}"
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+  condition {
+    host_header {
+      values = [
+        aws_route53_record.actor-use-my-lpa.fqdn
+      ]
+    }
+  }
+}
+
 # maintenance site switching
 resource "aws_ssm_parameter" "actor_maintenance_switch" {
   name            = "${local.environment}_actor_enable_maintenance"

--- a/terraform/environment/viewer_load_balancer.tf
+++ b/terraform/environment/viewer_load_balancer.tf
@@ -88,6 +88,31 @@ resource "aws_lb_listener_rule" "redirect_view_root_to_gov" {
   }
 }
 
+# rewrite to live service url
+resource "aws_lb_listener_rule" "rewrite_view_to_live_service_url" {
+  listener_arn = aws_lb_listener.viewer_loadbalancer.arn
+  priority     = 2
+  action {
+    type = "redirect"
+
+    redirect {
+      host        = aws_route53_record.public_facing_view_lasting_power_of_attorney.fqdn
+      path        = "/#{path}"
+      query       = "#{query}"
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+  condition {
+    host_header {
+      values = [
+        aws_route53_record.viewer-use-my-lpa.fqdn
+      ]
+    }
+  }
+}
+
 # maintenance site switching
 resource "aws_ssm_parameter" "viewer_maintenance_switch" {
   name            = "${local.environment}_viewer_enable_maintenance"
@@ -115,7 +140,7 @@ locals {
 
 resource "aws_lb_listener_rule" "viewer_maintenance" {
   listener_arn = aws_lb_listener.viewer_loadbalancer.arn
-  priority     = 2
+  priority     = 3
   action {
     type = "fixed-response"
 

--- a/tests/features/always-use-the-live-service-url.feature
+++ b/tests/features/always-use-the-live-service-url.feature
@@ -1,0 +1,15 @@
+@smoke
+Feature: User is sent to the live sevice URL
+  As a user of the service who has been given an old web address for the service,
+  I want to be redirected to the new live service url,
+  So that I can continue to use the service correctly.
+
+  @smoke @viewer
+  Scenario: I start a view journey
+    Given I access the service with the old web address
+    Then Then the service homepage should be shown securely
+
+  @smoke @actor
+  Scenario: I start a use journey
+    Given I access the service with the old web address
+    Then Then the service homepage should be shown securely

--- a/tests/features/always-use-the-live-service-url.feature
+++ b/tests/features/always-use-the-live-service-url.feature
@@ -7,9 +7,9 @@ Feature: User is sent to the live sevice URL
   @smoke @viewer
   Scenario: I start a view journey
     Given I access the service with the old web address
-    Then Then the service homepage should be shown securely
+    Then the service homepage should be shown securely
 
   @smoke @actor
   Scenario: I start a use journey
     Given I access the service with the old web address
-    Then Then the service homepage should be shown securely
+    Then the service homepage should be shown securely

--- a/tests/smoke/context/BaseContext.php
+++ b/tests/smoke/context/BaseContext.php
@@ -55,7 +55,10 @@ class BaseContext implements Context
             }
         }
     }
-
+    /**
+     * @BeforeScenario
+     * @param BeforeScenarioScope $scope
+     */
     public function setupOldBaseUrl(BeforeScenarioScope $scope): void
     {
         switch ($scope->getSuite()->getName()) {

--- a/tests/smoke/context/BaseContext.php
+++ b/tests/smoke/context/BaseContext.php
@@ -56,6 +56,31 @@ class BaseContext implements Context
         }
     }
 
+    public function setupOldBaseUrl(BeforeScenarioScope $scope): void
+    {
+        switch ($scope->getSuite()->getName()) {
+            case 'viewer':
+                $this->OldBaseUrl = getenv('BEHAT_OLD_VIEWER_URL') ?: 'http://viewer-web';
+                break;
+            case 'actor':
+                $this->OldBaseUrl = getenv('BEHAT_OLD_ACTOR_URL') ?: 'http://actor-web';
+                break;
+            default:
+                throw new SuiteConfigurationException(
+                    sprintf('Suite "%s" does not have a valid url configured', $scope->getSuite()->getName())
+                );
+        }
+
+        $environment = $scope->getEnvironment();
+
+        // we need to set this on *all* contexts
+        foreach ($environment->getContexts() as $context) {
+            if ($context instanceof RawMinkContext) {
+                $context->setMinkParameter('old_base_url', $this->OldBaseUrl);
+            }
+        }
+    }
+
     /**
      * @BeforeScenario
      * @param BeforeScenarioScope $scope

--- a/tests/smoke/context/CommonContext.php
+++ b/tests/smoke/context/CommonContext.php
@@ -62,7 +62,7 @@ class CommonContext implements Context
     public function iAccessTheOldServiceUrl(): void
     {
         $oldUrlHost = parse_url($this->ui->getMinkParameter('old_base_url'), PHP_URL_HOST);
-        $rootUrl = sprintf('http://%s/', $oldUrlHost);
+        $rootUrl = sprintf('https://%s/home', $oldUrlHost);
 
         $this->ui->visit($rootUrl);
     }

--- a/tests/smoke/context/CommonContext.php
+++ b/tests/smoke/context/CommonContext.php
@@ -57,6 +57,17 @@ class CommonContext implements Context
     }
 
     /**
+     * @I access the service with the old web address
+     */
+    public function iAccessTheOldServiceUrl(): void
+    {
+        $oldUrlHost = parse_url($this->ui->getMinkParameter('old_base_url'), PHP_URL_HOST);
+        $rootUrl = sprintf('http://%s/', $oldUrlHost);
+
+        $this->ui->visit($rootUrl);
+    }
+
+    /**
      * @Given I fetch the healthcheck endpoint
      */
     public function iFetchTheHealthcheckEndpoint(): void

--- a/tests/smoke/context/CommonContext.php
+++ b/tests/smoke/context/CommonContext.php
@@ -57,7 +57,7 @@ class CommonContext implements Context
     }
 
     /**
-     * @I access the service with the old web address
+     * @Given I access the service with the old web address
      */
     public function iAccessTheOldServiceUrl(): void
     {


### PR DESCRIPTION
## Purpose
Users should visit the service using the live service URL.

Fixes UML-905

## Approach

Add a permanent redirect from `*.view-lasting-power-of-attorney.service.gov.uk` to `*.view.lastingpowerofattorney.opg.service.justice.gov.uk`

## Learning

https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-listeners.html

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes

