### PR TITLE
Adds Custom Email component for better control of validation

### DIFF
--- a/service-front/app/features/actor-account-creation.feature
+++ b/service-front/app/features/actor-account-creation.feature
@@ -40,12 +40,12 @@ Feature: Account creation
     When I have provided required information for account creation such as <email1> <password1> <password2> <terms>
     Then I should be told my account could not be created due to <reasons>
     Examples:
-      | email1          | password1 | password2 | terms | reasons                          |
-      |                 | Password1 | Password1 |   1   | Enter your email address         |
-      |invalid_email    | Password1 | Password1 |   1   | Enter a valid email address      |
-      |TEST@example.com | Password1 |           |   1   | Confirm your password            |
-      |test@EXAMPLE.com | Password1 | Password1 |       | You must accept the terms of use |
-      |test@ Example.com| Password1 | Password1 |   1   | Enter a valid email address      |
+      | email1          | password1 | password2 | terms | reasons                                                             |
+      |                 | Password1 | Password1 |   1   | Enter your email address                                            |
+      |invalid_email    | Password1 | Password1 |   1   | Enter an email address in the correct format, like name@example.com |
+      |TEST@example.com | Password1 |           |   1   | Confirm your password                                               |
+      |test@EXAMPLE.com | Password1 | Password1 |       | You must accept the terms of use                                    |
+      |test@ Example.com| Password1 | Password1 |   1   | Enter an email address in the correct format, like name@example.com |
 
 
   @ui @integration

--- a/service-front/app/features/actor-login.feature
+++ b/service-front/app/features/actor-login.feature
@@ -63,10 +63,10 @@ Feature: A user of the system is able to login
     When I enter incorrect login details with <email_format> and <password> below
     Then I should see relevant <error> message
     Examples:
-      |email_format           |password|error                       |
-      |GAP TEST@ test. com    |pa33w0rd|Enter a valid email address |
-      |                       |pa33w0rd|Enter your email address    |
-      |nopassword@test.com    |        |Enter your password         |
+      |email_format           |password|error                                                               |
+      |GAP TEST@ test. com    |pa33w0rd|Enter an email address in the correct format, like name@example.com |
+      |                       |pa33w0rd|Enter your email address                                            |
+      |nopassword@test.com    |        |Enter your password                                                 |
 
   @ui @security
   Scenario: A hacker attempts to forge the full CSRF value

--- a/service-front/app/features/actor-password-reset.feature
+++ b/service-front/app/features/actor-password-reset.feature
@@ -59,5 +59,4 @@ Feature: Password Reset
 
     Examples:
       |email           |email_confirmation | error                        |
-      |TEST@ test.com  |TEST@ test.com     | Enter a valid email address  |
-
+      |TEST@ test.com  |TEST@ test.com     | Enter an email address in the correct format, like name@example.com  |

--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -2894,7 +2894,7 @@ class AccountContext implements Context
      */
     public function iShouldBeToldThatICouldNotChangeMyEmailBecauseTheEmailIsInvalid()
     {
-        $this->ui->assertPageContainsText('Enter a valid email address');
+        $this->ui->assertPageContainsText('Enter an email address in the correct format, like name@example.com');
     }
 
     /**

--- a/service-front/app/src/Actor/src/Form/ChangeEmail.php
+++ b/service-front/app/src/Actor/src/Form/ChangeEmail.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Actor\Form;
 
 use Common\Form\AbstractForm;
+use Common\Form\Element\Email;
 use Common\Validator\EmailAddressValidator;
 use Laminas\Filter\StringToLower;
 use Laminas\Filter\StringTrim;
@@ -36,10 +37,7 @@ class ChangeEmail extends AbstractForm implements InputFilterProviderInterface
     {
         parent::__construct(self::FORM_NAME, $guard);
 
-        $this->add([
-            'name' => 'new_email_address',
-            'type' => 'Text',
-        ]);
+        $this->add(new Email('new_email_address'));
 
         $this->add([
             'name' => 'current_password',

--- a/service-front/app/src/Actor/src/Form/ChangeEmail.php
+++ b/service-front/app/src/Actor/src/Form/ChangeEmail.php
@@ -74,11 +74,6 @@ class ChangeEmail extends AbstractForm implements InputFilterProviderInterface
                     [
                         'name'                   => EmailAddressValidator::class,
                         'break_chain_on_failure' => true,
-                        'options'                => [
-                            'messages' => [
-                                EmailAddressValidator::INVALID => 'Enter a valid email address',
-                            ],
-                        ],
                     ]
                 ],
             ],

--- a/service-front/app/src/Actor/src/Form/CreateAccount.php
+++ b/service-front/app/src/Actor/src/Form/CreateAccount.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Actor\Form;
 
 use Common\Form\AbstractForm;
+use Common\Form\Element\Email;
 use Common\Validator\EmailAddressValidator;
 use Common\Validator\PasswordValidator;
 use Mezzio\Csrf\CsrfGuardInterface;
@@ -41,10 +42,7 @@ class CreateAccount extends AbstractForm implements InputFilterProviderInterface
     {
         parent::__construct(self::FORM_NAME, $csrfGuard);
 
-        $this->add([
-            'name' => 'email',
-            'type' => 'Email',
-        ]);
+        $this->add(new Email('email'));
 
         $this->add([
             'name' => 'password',

--- a/service-front/app/src/Actor/src/Form/Login.php
+++ b/service-front/app/src/Actor/src/Form/Login.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Actor\Form;
 
 use Common\Form\AbstractForm;
+use Common\Form\Element\Email;
 use Common\Validator\EmailAddressValidator;
 use Mezzio\Csrf\CsrfGuardInterface;
 use Laminas\Filter\StringToLower;
@@ -37,10 +38,7 @@ class Login extends AbstractForm implements InputFilterProviderInterface
     {
         parent::__construct(self::FORM_NAME, $csrfGuard);
 
-        $this->add([
-            'name' => 'email',
-            'type' => 'Email',
-        ]);
+        $this->add(new Email('email'));
 
         $this->add([
             'name' => 'password',

--- a/service-front/app/src/Actor/src/Form/Login.php
+++ b/service-front/app/src/Actor/src/Form/Login.php
@@ -32,8 +32,6 @@ class Login extends AbstractForm implements InputFilterProviderInterface
         self::NOT_SAME => 'Security validation failed. Please try again.'
     ];
 
-
-
     public function __construct(CsrfGuardInterface $csrfGuard)
     {
         parent::__construct(self::FORM_NAME, $csrfGuard);

--- a/service-front/app/src/Actor/src/Form/PasswordResetRequest.php
+++ b/service-front/app/src/Actor/src/Form/PasswordResetRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Actor\Form;
 
 use Common\Form\AbstractForm;
+use Common\Form\Element\Email;
 use Common\Validator\EmailAddressValidator;
 use Mezzio\Csrf\CsrfGuardInterface;
 use Laminas\Filter\StringToLower;
@@ -26,15 +27,9 @@ class PasswordResetRequest extends AbstractForm implements InputFilterProviderIn
     {
         parent::__construct(self::FORM_NAME, $guard);
 
-        $this->add([
-            'name' => 'email',
-            'type' => 'Email',
-        ]);
+        $this->add(new Email('email'));
 
-        $this->add([
-            'name' => 'email_confirm',
-            'type' => 'Email',
-        ]);
+        $this->add(new Email('email_confirm'));
     }
 
     /**

--- a/service-front/app/src/Common/src/Form/Element/Email.php
+++ b/service-front/app/src/Common/src/Form/Element/Email.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Form\Element;
+
+use Laminas\Filter\StringTrim;
+use Laminas\Form\Element\Email as LaminasEmail;
+
+/**
+ * Class Email
+ * @package Common\Form\Element
+ */
+class Email extends LaminasEmail
+{
+    public function __construct($name = null, $options = [])
+    {
+        if (null !== $name) {
+            $this->setName($name);
+        }
+
+        if (! empty($options)) {
+            $this->setOptions($options);
+        }
+    }
+
+    public function getInputSpecification()
+    {
+        return [
+            'name' => $this->getName(),
+            'required' => true,
+            'filters' => [
+                ['name' => StringTrim::class],
+            ],
+            'validators' => [
+            ],
+        ];
+    }
+}

--- a/service-front/app/src/Common/src/Validator/EmailAddressValidator.php
+++ b/service-front/app/src/Common/src/Validator/EmailAddressValidator.php
@@ -18,7 +18,7 @@ class EmailAddressValidator extends LaminasEmailAddressValidator
 
         if ($valid === false && count($this->getMessages()) > 0) {
             $this->abstractOptions['messages'] = [
-                'Enter a valid email address'
+                'Enter an email address in the correct format, like name@example.com'
             ];
         }
 

--- a/service-front/app/src/Common/src/View/Twig/GovUKLaminasFormExtension.php
+++ b/service-front/app/src/Common/src/View/Twig/GovUKLaminasFormExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Common\View\Twig;
 
 use Common\Form\AbstractForm;
+use Common\Form\Element\Email as CustomEmail;
 use Common\Form\Fieldset\Date;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
@@ -30,7 +31,7 @@ class GovUKLaminasFormExtension extends AbstractExtension
         Element\Csrf::class     => 'form_input_hidden',
         Element\Hidden::class   => 'form_input_hidden',
         Element\Password::class => 'form_input_password',
-        Element\Email::class    => 'form_input_email',
+        CustomEmail ::class     => 'form_input_email',
         Element\Text::class     => 'form_input_text',
         Element\Radio::class    => 'form_input_radio',
         //  Fieldsets

--- a/service-front/app/test/ActorTest/Form/CreateAccountTest.php
+++ b/service-front/app/test/ActorTest/Form/CreateAccountTest.php
@@ -10,7 +10,8 @@ use Common\Form\Element\Csrf;
 use CommonTest\Form\{TestsLaminasForm, LaminasFormTests};
 use PHPUnit\Framework\TestCase;
 use Mezzio\Csrf\CsrfGuardInterface;
-use Laminas\Form\Element\{Checkbox, Password, Email};
+use Laminas\Form\Element\{Checkbox, Password};
+use Common\Form\Element\Email;
 
 class CreateAccountTest extends TestCase implements TestsLaminasForm
 {

--- a/service-front/app/test/ActorTest/Form/EmailChangeTest.php
+++ b/service-front/app/test/ActorTest/Form/EmailChangeTest.php
@@ -10,7 +10,7 @@ use Common\Form\Element\Csrf;
 use CommonTest\Form\LaminasFormTests;
 use CommonTest\Form\TestsLaminasForm;
 use Laminas\Form\Element\Password;
-use Laminas\Form\Element\Text;
+use Common\Form\Element\Email;
 use Mezzio\Csrf\CsrfGuardInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -35,7 +35,7 @@ class EmailChangeTest extends TestCase implements TestsLaminasForm
     {
         return [
             '__csrf' => Csrf::class,
-            'new_email_address' => Text::class,
+            'new_email_address' => Email::class,
             'current_password' => Password::class,
         ];
     }

--- a/service-front/app/test/ActorTest/Form/LoginTest.php
+++ b/service-front/app/test/ActorTest/Form/LoginTest.php
@@ -10,7 +10,8 @@ use Common\Form\Element\Csrf;
 use CommonTest\Form\{TestsLaminasForm, LaminasFormTests};
 use PHPUnit\Framework\TestCase;
 use Mezzio\Csrf\CsrfGuardInterface;
-use Laminas\Form\Element\{Password, Email};
+use Laminas\Form\Element\Password;
+use Common\Form\Element\Email;
 
 class LoginTest extends TestCase implements TestsLaminasForm
 {

--- a/service-front/app/test/ActorTest/Form/PasswordResetRequestTest.php
+++ b/service-front/app/test/ActorTest/Form/PasswordResetRequestTest.php
@@ -10,7 +10,7 @@ use Common\Form\Element\Csrf;
 use CommonTest\Form\{TestsLaminasForm, LaminasFormTests};
 use PHPUnit\Framework\TestCase;
 use Mezzio\Csrf\CsrfGuardInterface;
-use Laminas\Form\Element\Email;
+use Common\Form\Element\Email;
 
 class PasswordResetRequestTest extends TestCase implements TestsLaminasForm
 {

--- a/service-front/app/test/CommonTest/Validator/EmailAddressValidatorTest.php
+++ b/service-front/app/test/CommonTest/Validator/EmailAddressValidatorTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 class EmailAddressValidatorTest extends TestCase
 {
     /** @test */
-    public function correctly_validates_known_good_email() 
+    public function correctly_validates_known_good_email()
     {
         $validator = new EmailAddressValidator();
 
@@ -37,6 +37,6 @@ class EmailAddressValidatorTest extends TestCase
         $valid = $validator->isValid('notan@email');
 
         $this->assertEquals(false, $valid);
-        $this->assertEquals('Enter a valid email address', $validator->getMessages()[0]);
+        $this->assertEquals('Enter an email address in the correct format, like name@example.com', $validator->getMessages()[0]);
     }
 }

--- a/tests/features/actor-login.feature
+++ b/tests/features/actor-login.feature
@@ -61,4 +61,4 @@ Feature: A user of the system is able to login
   Scenario: A user is not allowed to login with improper email address
     Given I access the login form
     When I enter incorrect email with "TEST@ test. com" and "pa33w0rd" below
-    Then I should see relevant "Enter a valid email address" message
+    Then I should see relevant "Enter an email address in the correct format, like name@example.com" message


### PR DESCRIPTION
## Purpose
Prevents the laminas email validator regex error from being displayed to the user if they do not enter a valid email address

Fixes UML-933

## Approach

Creates a custom email element to attach the custom email validator and display the correct error messages to the user

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes

