### PR TITLE
use the correct fqdn for healthcheck tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -980,11 +980,11 @@ orbs:
           - run:
               name: Run test
               command: |
-                viewer_fqdn=$(cat /tmp/cluster_config.json | jq .viewer_fqdn | xargs)
+                viewer_fqdn=$(cat /tmp/cluster_config.json | jq .public_facing_view_fqdn | xargs)
                 viewer_response=$(curl --write-out %{http_code} --silent --output /dev/null https://$viewer_fqdn/healthcheck)
                 [[ $viewer_response == 200 ]] || (echo "Error with viewer health check. HTTP status: ${viewer_response}" && exit 1)
 
-                actor_fqdn=$(cat /tmp/cluster_config.json | jq .actor_fqdn | xargs)
+                actor_fqdn=$(cat /tmp/cluster_config.json | jq .public_facing_use_fqdn | xargs)
                 actor_response=$(curl --write-out %{http_code} --silent --output /dev/null https://$actor_fqdn/healthcheck)
                 [[ $actor_response == 200 ]] || (echo "Error with actor health check. HTTP status: ${actor_response}" && exit 1)
 


### PR DESCRIPTION
## Purpose
When running a check on the service health, use the correct fully qualified domain name.

When using the old fqdn, the http status is returned as 301 and as such fails the check.

![image](https://user-images.githubusercontent.com/6545556/88642602-99bbc100-d0b8-11ea-8762-b90565af9067.png)

Fixes UML-905

## Approach

Update test in CircleCI config.

## Learning



## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

