### PR TITLE
Changed hyperlink to go directly to gov uk site, works on both actor …

### DIFF
--- a/service-front/app/features/common-gov-uk-link.feature
+++ b/service-front/app/features/common-gov-uk-link.feature
@@ -1,0 +1,12 @@
+@actor @gov-uk-link
+
+Feature: Gov-UK hyperlink takes user to gov uk homepage
+  As a actor/viewer
+  I want to be able to access the Gov UK site
+  So I can access other Government services
+
+  @ui
+  Scenario: The user can access the Gov Uk site from the banner across our site
+    Given I am on the triage page
+    When I navigate to the gov uk page
+    Then I expect to be on the Gov uk homepage

--- a/service-front/app/features/context/UI/CommonContext.php
+++ b/service-front/app/features/context/UI/CommonContext.php
@@ -308,4 +308,20 @@ class CommonContext implements Context
         $this->ui->pressButton('Sign in');
         $this->ui->assertPageAddress('/lpa/dashboard');
     }
+
+    /**
+     * @When /^I navigate to the gov uk page$/
+     */
+    public function iNavigateToTheGovUkPage()
+    {
+        $this->ui->clickLink('GOV.UK');
+    }
+
+    /**
+     * @Then /^I expect to be on the Gov uk homepage$/
+     */
+    public function iExpectToBeOnTheGovUkHomepage()
+    {
+        $this->ui->assertPageAddress('https://www.gov.uk');
+    }
 }

--- a/service-front/app/src/Common/templates/layout/default.html.twig
+++ b/service-front/app/src/Common/templates/layout/default.html.twig
@@ -57,7 +57,7 @@
     <div class="govuk-header__container govuk-width-container">
 
         <div class="govuk-header__logo">
-            <a href="{{ path('home') }}" class="govuk-header__link govuk-header__link--homepage">
+            <a href="https://www.gov.uk" class="govuk-header__link govuk-header__link--homepage">
                 <span class="govuk-header__logotype">
 
                 <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="32" width="36">


### PR DESCRIPTION
…and viewer side. Added a behat test to check that this is done.

## Purpose
https://opgtransform.atlassian.net/browse/UML-971?atlOrigin=eyJpIjoiZmU0MzVhZmM0MTAxNGZiMWJkMWM0NzUyZjU5MzZjODciLCJwIjoiaiJ9 

Fixes UML-968

## Approach

Wrote a behat test to check that when clicking on the gov uk hyperlink banner you're taken to the correct site (rather than the lpa dashboard).
Then amended gov uk hyperlink in main header / banner. 
This is part of the twig template used in all pages across both sides of the site (actor/ viewer).

## Learning

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

