### PR TITLE
pin version of aws provider to 2.70.0

### DIFF
--- a/terraform/account/credentials.tf
+++ b/terraform/account/credentials.tf
@@ -18,7 +18,8 @@ variable "management_role" {
 }
 
 provider "aws" {
-  region = "eu-west-1"
+  version = "2.70.0"
+  region  = "eu-west-1"
 
   assume_role {
     role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
@@ -27,8 +28,9 @@ provider "aws" {
 }
 
 provider "aws" {
-  region = "eu-west-1"
-  alias  = "management"
+  version = "2.70.0"
+  region  = "eu-west-1"
+  alias   = "management"
 
   assume_role {
     role_arn     = "arn:aws:iam::311462405659:role/${var.management_role}"

--- a/terraform/environment/credentials.tf
+++ b/terraform/environment/credentials.tf
@@ -18,7 +18,8 @@ variable "management_role" {
 }
 
 provider "aws" {
-  region = "eu-west-1"
+  version = "2.70.0"
+  region  = "eu-west-1"
 
   assume_role {
     role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
@@ -27,8 +28,9 @@ provider "aws" {
 }
 
 provider "aws" {
-  region = "us-east-1"
-  alias  = "us-east-1"
+  version = "2.70.0"
+  region  = "us-east-1"
+  alias   = "us-east-1"
 
   assume_role {
     role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
@@ -37,8 +39,9 @@ provider "aws" {
 }
 
 provider "aws" {
-  region = "eu-west-1"
-  alias  = "management"
+  version = "2.70.0"
+  region  = "eu-west-1"
+  alias   = "management"
 
   assume_role {
     role_arn     = "arn:aws:iam::311462405659:role/${var.management_role}"


### PR DESCRIPTION
## Purpose
We're not yet ready to use the new version 3 of the aws provider for terraform. This PR will pin us to 2.70.0.

Fixes UML-989

## Approach

add `version = 2.70.0` to each provider.

## Learning


## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

