### PR TITLE
Fix up static links for root pages

### DIFF
--- a/service-front/app/config/autoload/envs.global.php
+++ b/service-front/app/config/autoload/envs.global.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 return [
 
-    'application' => getenv('CONTEXT'),
+    'application' => getenv('CONTEXT') ?: null,
 
     'version' => getenv('CONTAINER_VERSION') ?: 'dev',
 

--- a/service-front/app/config/routes.php
+++ b/service-front/app/config/routes.php
@@ -40,11 +40,11 @@ $viewerRoutes = function (Application $app, MiddlewareFactory $factory, Containe
     $app->get('/check-code', Viewer\Handler\CheckCodeHandler::class, 'check-code');
     $app->get('/view-lpa', Viewer\Handler\ViewLpaHandler::class, 'view-lpa');
     $app->get('/download-lpa', Viewer\Handler\DownloadLpaHandler::class, 'download-lpa');
-    $app->get('/terms-of-use', Viewer\Handler\ViewerTermsOfUseHandler::class, 'viewer-terms-of-use');
-    $app->get('/privacy-notice', Viewer\Handler\ViewerPrivacyNoticeHandler::class, 'viewer-privacy-notice');
+    $app->get('/terms-of-use', Viewer\Handler\ViewerTermsOfUseHandler::class, 'terms-of-use');
+    $app->get('/privacy-notice', Viewer\Handler\ViewerPrivacyNoticeHandler::class, 'privacy-notice');
     $app->get('/stats', Viewer\Handler\StatsPageHandler::class, 'viewer-stats');
     $app->get('/session-expired', Viewer\Handler\ViewerSessionExpiredHandler::class, 'session-expired');
-    $app->route('/cookies', Common\Handler\CookiesPageHandler::class, ['GET', 'POST'], 'viewer-cookies');
+    $app->route('/cookies', Common\Handler\CookiesPageHandler::class, ['GET', 'POST'], 'cookies');
 };
 
 $actorRoutes = function (Application $app, MiddlewareFactory $factory, ContainerInterface $container): void {
@@ -53,9 +53,9 @@ $actorRoutes = function (Application $app, MiddlewareFactory $factory, Container
     $app->get('/healthcheck', Common\Handler\HealthcheckHandler::class, 'healthcheck');
     $app->get('/stats', Actor\Handler\StatsPageHandler::class, 'actor-stats');
 
-    $app->route('/cookies', Common\Handler\CookiesPageHandler::class, ['GET', 'POST'], 'actor-cookies');
-    $app->get('/terms-of-use', [Actor\Handler\ActorTermsOfUseHandler::class], 'actor-terms-of-use');
-    $app->get('/privacy-notice', [Actor\Handler\ActorPrivacyNoticeHandler::class], 'actor-privacy-notice');
+    $app->route('/cookies', Common\Handler\CookiesPageHandler::class, ['GET', 'POST'], 'cookies');
+    $app->get('/terms-of-use', [Actor\Handler\ActorTermsOfUseHandler::class], 'terms-of-use');
+    $app->get('/privacy-notice', [Actor\Handler\ActorPrivacyNoticeHandler::class], 'privacy-notice');
 
     // User creation
     $app->route('/create-account', Actor\Handler\CreateAccountHandler::class, ['GET', 'POST'], 'create-account');

--- a/service-front/app/features/bootstrap/behat.config.php
+++ b/service-front/app/features/bootstrap/behat.config.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 return [
+    Laminas\ConfigAggregator\ConfigAggregator::ENABLE_CACHE => false,
+
     'dependencies' => [
         'factories' => [
             \Http\Adapter\Guzzle6\Client::class => \BehatTest\Http\Adapter\Guzzle6\TestClientFactory::class,

--- a/service-front/app/features/bootstrap/behat.config.php
+++ b/service-front/app/features/bootstrap/behat.config.php
@@ -2,12 +2,7 @@
 
 declare(strict_types=1);
 
-use Laminas\ConfigAggregator\ConfigAggregator;
-
 return [
-    'debug' => true,
-    ConfigAggregator::ENABLE_CACHE => false,
-
     'dependencies' => [
         'factories' => [
             \Http\Adapter\Guzzle6\Client::class => \BehatTest\Http\Adapter\Guzzle6\TestClientFactory::class,

--- a/service-front/app/features/bootstrap/config.php
+++ b/service-front/app/features/bootstrap/config.php
@@ -14,10 +14,10 @@ $aggregator = new ConfigAggregator([
 
     // Include cache configuration
     new ArrayProvider(
-       [
-           'debug' => true,
-           ConfigAggregator::ENABLE_CACHE => false,
-       ]
+        [
+            'debug' => true,
+            ConfigAggregator::ENABLE_CACHE => false,
+        ]
     ),
 ]);
 

--- a/service-front/app/features/bootstrap/config.php
+++ b/service-front/app/features/bootstrap/config.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Laminas\ConfigAggregator\ArrayProvider;
 use Laminas\ConfigAggregator\ConfigAggregator;
 use Laminas\ConfigAggregator\PhpFileProvider;
 
@@ -11,14 +10,6 @@ $aggregator = new ConfigAggregator([
 
     // Load development config if it exists
     new PhpFileProvider(realpath(__DIR__) . '/behat.config.php'),
-
-    // Include cache configuration
-    new ArrayProvider(
-        [
-            'debug' => true,
-            ConfigAggregator::ENABLE_CACHE => false,
-        ]
-    ),
-]);
+], null);
 
 return $aggregator->getMergedConfig();

--- a/service-front/app/features/bootstrap/config.php
+++ b/service-front/app/features/bootstrap/config.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Laminas\ConfigAggregator\ArrayProvider;
 use Laminas\ConfigAggregator\ConfigAggregator;
 use Laminas\ConfigAggregator\PhpFileProvider;
 
@@ -10,6 +11,14 @@ $aggregator = new ConfigAggregator([
 
     // Load development config if it exists
     new PhpFileProvider(realpath(__DIR__) . '/behat.config.php'),
+
+    // Include cache configuration
+    new ArrayProvider(
+       [
+           'debug' => true,
+           ConfigAggregator::ENABLE_CACHE => false,
+       ]
+    ),
 ]);
 
 return $aggregator->getMergedConfig();

--- a/service-front/app/features/bootstrap/config.php
+++ b/service-front/app/features/bootstrap/config.php
@@ -6,7 +6,29 @@ use Laminas\ConfigAggregator\ConfigAggregator;
 use Laminas\ConfigAggregator\PhpFileProvider;
 
 $aggregator = new ConfigAggregator([
-    new PhpFileProvider(realpath(__DIR__) . '/../../config/config.php'),
+    \Mezzio\Authentication\Session\ConfigProvider::class,
+    \Mezzio\Router\FastRouteRouter\ConfigProvider::class,
+    \Laminas\HttpHandlerRunner\ConfigProvider::class,
+    \Mezzio\Authentication\ConfigProvider::class,
+    \Mezzio\Session\ConfigProvider::class,
+    \Mezzio\Helper\ConfigProvider::class,
+    \Mezzio\Router\ConfigProvider::class,
+    \Mezzio\Csrf\ConfigProvider::class,
+    \Mezzio\Twig\ConfigProvider::class,
+    \Mezzio\ConfigProvider::class,
+
+    // App module(s) config
+    Common\ConfigProvider::class,
+    Actor\ConfigProvider::class,
+    Viewer\ConfigProvider::class,
+
+    // Load application config in a pre-defined order in such a way that local settings
+    // overwrite global settings. (Loaded as first to last):
+    //   - `global.php`
+    //   - `*.global.php`
+    //   - `local.php`
+    //   - `*.local.php`
+    new PhpFileProvider(realpath(__DIR__) . '/../../config/autoload/{{,*.}global,{,*.}local}.php'),
 
     // Load development config if it exists
     new PhpFileProvider(realpath(__DIR__) . '/behat.config.php'),

--- a/service-front/app/languages/messages.pot
+++ b/service-front/app/languages/messages.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Language: en_GB\n"
-"POT-Creation-Date: 2020-09-04T09:59:45+00:00\n"
+"POT-Creation-Date: 2020-09-04T20:21:01+00:00\n"
 "X-Domain: messages\n"
 
 #: src/Actor/templates/actor/lpa-show-viewercode.html.twig:3
@@ -289,6 +289,7 @@ msgid "Change password"
 msgstr ""
 
 #: src/Actor/templates/actor/actor-terms-of-use.html.twig:14
+#: src/Common/templates/layout/default.html.twig:104
 #: src/Viewer/templates/viewer/viewer-terms-of-use.html.twig:16
 msgid "Terms of use"
 msgstr ""
@@ -1050,27 +1051,27 @@ msgid "We’ll never:"
 msgstr ""
 
 #: src/Actor/templates/actor/actor-privacy-notice.html.twig:192
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:153
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:152
 msgid "share your information with other organisations for marketing, market research or commercial purposes"
 msgstr ""
 
 #: src/Actor/templates/actor/actor-privacy-notice.html.twig:193
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:155
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:153
 msgid "sell or rent your data to third parties"
 msgstr ""
 
 #: src/Actor/templates/actor/actor-privacy-notice.html.twig:195
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:158
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:155
 msgid "Getting more information"
 msgstr ""
 
 #: src/Actor/templates/actor/actor-privacy-notice.html.twig:197
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:162
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:159
 msgid "You can get more details on:"
 msgstr ""
 
 #: src/Actor/templates/actor/actor-privacy-notice.html.twig:200
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:165
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:162
 msgid "agreements we have with other organisations for sharing information"
 msgstr ""
 
@@ -1081,42 +1082,42 @@ msgid ""
 msgstr ""
 
 #: src/Actor/templates/actor/actor-privacy-notice.html.twig:203
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:167
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:164
 msgid "instructions we give to staff on how to collect, use or delete your personal data"
 msgstr ""
 
 #: src/Actor/templates/actor/actor-privacy-notice.html.twig:204
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:168
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:165
 msgid "how we check that the information we hold is accurate and up-to-date"
 msgstr ""
 
 #: src/Actor/templates/actor/actor-privacy-notice.html.twig:205
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:169
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:166
 msgid "how to make a complaint"
 msgstr ""
 
 #: src/Actor/templates/actor/actor-privacy-notice.html.twig:206
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:170
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:167
 msgid "anything in this privacy notice"
 msgstr ""
 
 #: src/Actor/templates/actor/actor-privacy-notice.html.twig:207
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:171
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:168
 msgid "what to do if you think that your personal data has been misused or mishandled"
 msgstr ""
 
 #: src/Actor/templates/actor/actor-privacy-notice.html.twig:210
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:175
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:171
 msgid "For more information, please contact:"
 msgstr ""
 
 #: src/Actor/templates/actor/actor-privacy-notice.html.twig:219
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:186
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:182
 msgid "Changes to this notice"
 msgstr ""
 
 #: src/Actor/templates/actor/actor-privacy-notice.html.twig:221
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:188
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:184
 msgid "We may change this privacy notice from time to time. When we do, we’ll update the ‘last updated’ date at the bottom of this page."
 msgstr ""
 
@@ -1125,12 +1126,12 @@ msgid "If these changes affect how your personal data is processed, we’ll take
 msgstr ""
 
 #: src/Actor/templates/actor/actor-privacy-notice.html.twig:227
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:194
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:190
 msgid "Any changes to this privacy notice will apply to you and your data immediately."
 msgstr ""
 
 #: src/Actor/templates/actor/actor-privacy-notice.html.twig:229
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:196
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:192
 msgid "Making a complaint"
 msgstr ""
 
@@ -1509,115 +1510,115 @@ msgid "Enter an activation key in the correct format"
 msgstr ""
 
 #. Add LPA
-#: src/Actor/templates/actor/form-error-messages.html.twig:32
+#: src/Actor/templates/actor/form-error-messages.html.twig:33
 msgctxt "error"
 msgid "The LPA reference number you entered is too short"
 msgstr ""
 
 #. Add LPA
-#: src/Actor/templates/actor/form-error-messages.html.twig:33
+#: src/Actor/templates/actor/form-error-messages.html.twig:34
 msgctxt "error"
 msgid "The LPA reference number you entered is too long"
 msgstr ""
 
 #. Add LPA
-#: src/Actor/templates/actor/form-error-messages.html.twig:34
+#: src/Actor/templates/actor/form-error-messages.html.twig:35
 msgctxt "error"
 msgid "Enter the 12 numbers of the LPA reference number. Do not include letters or other characters"
 msgstr ""
 
 #. Add LPA
-#: src/Actor/templates/actor/form-error-messages.html.twig:35
+#: src/Actor/templates/actor/form-error-messages.html.twig:36
 msgctxt "error"
 msgid "Date of birth value must be provided in an array"
 msgstr ""
 
 #. Add LPA
-#: src/Actor/templates/actor/form-error-messages.html.twig:36
+#: src/Actor/templates/actor/form-error-messages.html.twig:37
 msgctxt "error"
 msgid "Enter your date of birth"
 msgstr ""
 
 #. Add LPA
-#: src/Actor/templates/actor/form-error-messages.html.twig:37
+#: src/Actor/templates/actor/form-error-messages.html.twig:38
 msgctxt "error"
 msgid "Date of birth must be a real date"
 msgstr ""
 
 #. Add LPA
-#: src/Actor/templates/actor/form-error-messages.html.twig:38
+#: src/Actor/templates/actor/form-error-messages.html.twig:39
 msgctxt "error"
 msgid "Date of birth must include a day"
 msgstr ""
 
 #. Add LPA
-#: src/Actor/templates/actor/form-error-messages.html.twig:39
+#: src/Actor/templates/actor/form-error-messages.html.twig:40
 msgctxt "error"
 msgid "Date of birth must include a month"
 msgstr ""
 
 #. Add LPA
-#: src/Actor/templates/actor/form-error-messages.html.twig:40
+#: src/Actor/templates/actor/form-error-messages.html.twig:41
 msgctxt "error"
 msgid "Date of birth must include a year"
 msgstr ""
 
 #. Add LPA
-#: src/Actor/templates/actor/form-error-messages.html.twig:41
+#: src/Actor/templates/actor/form-error-messages.html.twig:42
 msgctxt "error"
 msgid "Date of birth must be in the past"
 msgstr ""
 
 #. Add LPA
-#: src/Actor/templates/actor/form-error-messages.html.twig:42
+#: src/Actor/templates/actor/form-error-messages.html.twig:43
 msgctxt "error"
 msgid "Check your date of birth is correct - you cannot be an attorney or donor if you’re under 18"
 msgstr ""
 
 #. Create viewer code
-#: src/Actor/templates/actor/form-error-messages.html.twig:45
+#: src/Actor/templates/actor/form-error-messages.html.twig:46
 msgctxt "error"
 msgid "Enter an organisation name"
 msgstr ""
 
 #. Change password
-#: src/Actor/templates/actor/form-error-messages.html.twig:48
+#: src/Actor/templates/actor/form-error-messages.html.twig:49
 msgctxt "error"
 msgid "Enter your current password"
 msgstr ""
 
 #. Change password
-#: src/Actor/templates/actor/form-error-messages.html.twig:49
+#: src/Actor/templates/actor/form-error-messages.html.twig:50
 msgctxt "error"
 msgid "Current password is incorrect"
 msgstr ""
 
 #. Change password
-#: src/Actor/templates/actor/form-error-messages.html.twig:50
+#: src/Actor/templates/actor/form-error-messages.html.twig:51
 msgctxt "error"
 msgid "Enter your new password"
 msgstr ""
 
 #. Change password, password reset
-#: src/Actor/templates/actor/form-error-messages.html.twig:51
+#: src/Actor/templates/actor/form-error-messages.html.twig:52
 msgctxt "error"
 msgid "New password and confirm new password do not match"
 msgstr ""
 
 #. Change password
-#: src/Actor/templates/actor/form-error-messages.html.twig:52
+#: src/Actor/templates/actor/form-error-messages.html.twig:53
 msgctxt "error"
 msgid "Enter your password again to confirm it"
 msgstr ""
 
 #. Password reset
-#: src/Actor/templates/actor/form-error-messages.html.twig:55
+#: src/Actor/templates/actor/form-error-messages.html.twig:56
 msgctxt "error"
 msgid "Confirm your email address"
 msgstr ""
 
 #. Password reset
-#: src/Actor/templates/actor/form-error-messages.html.twig:56
+#: src/Actor/templates/actor/form-error-messages.html.twig:57
 msgctxt "error"
 msgid "The emails did not match"
 msgstr ""
@@ -2398,6 +2399,7 @@ msgstr ""
 msgid "Error:"
 msgstr ""
 
+#: src/Common/templates/layout/default.html.twig:109
 #: src/Common/templates/partials/cookies.html.twig:23
 msgid "Cookies"
 msgstr ""
@@ -2875,11 +2877,11 @@ msgstr ""
 msgid "We’ll only share the information you give us when the law says we can. For example, we may share information with the police to help them prevent or investigate crime."
 msgstr ""
 
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:166
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:163
 msgid "when we can pass on personal information without telling you, for example, to help with the prevention or detection of crime or to produce anonymised statistics"
 msgstr ""
 
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:178
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:174
 msgid ""
 "MOJ Data Protection Officer<br>\n"
 "                    Post point 10.38<br>\n"
@@ -2888,15 +2890,15 @@ msgid ""
 "                    SW1H 9AJ<br>"
 msgstr ""
 
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:191
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:187
 msgid "If these changes affect how your personal data is processed, We’ll take reasonable steps to let you know."
 msgstr ""
 
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:198
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:194
 msgid "When we ask for personal data, we’ll keep to the law. If you think that your information has not been handled correctly, in addition to contacting the MOJ Data Protection Officer, you can contact the Information Commissioner for independent advice about data protection at the address below:"
 msgstr ""
 
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:201
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:197
 msgid ""
 "Information Commissioner's Office <br>\n"
 "                    Wycliffe House <br>\n"
@@ -2906,19 +2908,19 @@ msgid ""
 "                    SK9 5AF <br>"
 msgstr ""
 
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:211
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:207
 msgid "Phone: 0303 123 1113"
 msgstr ""
 
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:212
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:208
 msgid "Textphone: 01625 545860"
 msgstr ""
 
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:213
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:209
 msgid "Monday to Friday, 9am to 4:30pm"
 msgstr ""
 
-#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:219
+#: src/Viewer/templates/viewer/viewer-privacy-notice.html.twig:215
 msgid "Last updated: 24 May 2019"
 msgstr ""
 
@@ -2940,4 +2942,60 @@ msgstr ""
 
 #: src/Viewer/templates/viewer/viewer-session-expired.html.twig:18
 msgid "Start again"
+msgstr ""
+
+#: src/Common/templates/layout/default.html.twig:41
+msgid "Skip to main content"
+msgstr ""
+
+#: src/Common/templates/layout/default.html.twig:49
+msgid "Tell us whether you accept cookies"
+msgstr ""
+
+#: src/Common/templates/layout/default.html.twig:50
+msgid ""
+"GOV.UK uses cookies which are essential for the site to work. We also use non-essential cookies to help us\n"
+"                    improve government digital services. Any data collected is anonymised."
+msgstr ""
+
+#: src/Common/templates/layout/default.html.twig:55
+msgid "Accept all cookies"
+msgstr ""
+
+#: src/Common/templates/layout/default.html.twig:58
+msgid "Set cookie preferences"
+msgstr ""
+
+#: src/Common/templates/layout/default.html.twig:5
+msgid "GOV.UK"
+msgstr ""
+
+#: src/Common/templates/layout/default.html.twig:100
+msgid "Support links"
+msgstr ""
+
+#: src/Common/templates/layout/default.html.twig:114
+msgid "Contact us"
+msgstr ""
+
+#: src/Common/templates/layout/default.html.twig:119
+msgid "Built by OPG Digital"
+msgstr ""
+
+#: src/Common/templates/layout/default.html.twig:129
+msgid ""
+"All content is available under the\n"
+"                    <a class=\"govuk-footer__link\" href=\"https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\" rel=\"license\">\n"
+"                        Open Government Licence v3.0\n"
+"                    </a>, except where otherwise stated"
+msgstr ""
+
+#: src/Common/templates/layout/default.html.twig:138
+msgid "© Crown copyright"
+msgstr ""
+
+#. Add LPA
+#: src/Actor/templates/actor/form-error-messages.html.twig:32
+msgctxt "error"
+msgid "Enter the LPA reference number"
 msgstr ""

--- a/service-front/app/src/Actor/templates/actor/actor-privacy-notice.html.twig
+++ b/service-front/app/src/Actor/templates/actor/actor-privacy-notice.html.twig
@@ -6,7 +6,7 @@
 <div class="govuk-width-container">
 {{ include('@partials/new-service.html.twig') }}
 
-    <a class="govuk-link govuk-back-link" href="{{ path('actor-terms-of-use') }}">{% trans %}Back{% endtrans %}</a>
+    <a class="govuk-link govuk-back-link" href="{{ path('terms-of-use') }}">{% trans %}Back{% endtrans %}</a>
     <main class="govuk-main-wrapper" id="main-content" role="main">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
@@ -56,26 +56,18 @@
                 {% endtrans %}
                 </p>
 
-                <p class="govuk-body">{% trans with {'%terms-of-use%': path('actor-terms-of-use'), '%cookie%': path('actor-cookies')} %}You can find more information about using the Use a lasting power of attorney service in our
+                <p class="govuk-body">{% trans with {'%terms-of-use%': path('terms-of-use'), '%cookie%': path('cookies')} %}You can find more information about using the Use a lasting power of attorney service in our
                     <a class="govuk-link" href="%terms-of-use%">terms of use</a> and <a class="govuk-link" href="%cookie%">cookie policy.{% endtrans %}</a>
                 </p>
                 <h2 class="govuk-heading-m">{% trans %}Why we collect personal data and how we use it{% endtrans %}</h2>
                 <p class="govuk-body">{% trans %}We only collect the personal data that is relevant for the services we are providing to you.{% endtrans %}</p>
                 <p class="govuk-body">{% trans %}In order to use this service, you need to enter some personal data and create an account{% endtrans %}</p>
                 <p class="govuk-body">{% trans %}The personal data we collect includes:{% endtrans %}</p>
-                    <ul class="govuk-list govuk-list--bullet">
-
-
-
-
-                        <li>{% trans %}your email address{% endtrans %}</li>
-                        <li>{% trans %}your name and date of birth{% endtrans %}</li>
-                        <li>{% trans %}your computer’s IP address while you use this service{% endtrans %}</li>
-
-
-
-
-                    </ul>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>{% trans %}your email address{% endtrans %}</li>
+                    <li>{% trans %}your name and date of birth{% endtrans %}</li>
+                    <li>{% trans %}your computer’s IP address while you use this service{% endtrans %}</li>
+                </ul>
 
                 <p class="govuk-body">
                     {% trans %}We use the data to find the <abbr title="Lasting power of attorney">LPA</abbr> you’re named on and to create your account.{% endtrans %}
@@ -112,20 +104,12 @@
                     {% trans %}This summary includes:{% endtrans %}
                 </p>
                 <ul class="govuk-list govuk-list--bullet">
-
-
-
-
                     <li>{% trans %}the name and address of the donor and any active attorneys{% endtrans %}</li>
                     <li>{% trans %}the name of any inactive attorneys{% endtrans %}</li>
                     <li>{% trans %}whether the <abbr title="lasting power of attorney">LPA</abbr> is currently valid{% endtrans %}</li>
                     <li>{% trans %}when the <abbr title="lasting power of attorney">LPA</abbr> can be used (property and finance <abbr title="lasting powers of attorney">LPAs</abbr> only){% endtrans %}</li>
                     <li>{% trans %}whether the donor chose to allow their attorneys to make decisions on life-sustaining treatment
                         (health and welfare <abbr title="lasting powers of attorney">LPAs</abbr> only){% endtrans %}</li>
-
-
-
-
                 </ul>
                 <p class="govuk-body">
                     {% trans %}Third parties can download and keep a copy of the summary.{% endtrans %}

--- a/service-front/app/src/Actor/templates/actor/actor-terms-of-use.html.twig
+++ b/service-front/app/src/Actor/templates/actor/actor-terms-of-use.html.twig
@@ -133,7 +133,7 @@
                     </ul>
                     <h2 class="govuk-heading-m">{% trans %}Keeping your information safe{% endtrans %}</h2>
                     <p class="govuk-body">
-                        {% trans with {'%privacy-notice%': path('actor-privacy-notice'), '%cookie%': path('actor-cookies')} %}
+                        {% trans with {'%privacy-notice%': path('privacy-notice'), '%cookie%': path('cookies')} %}
                         Any information you submit will be stored securely and used inline with our <a class="govuk-link" href="%privacy-notice%">privacy notice</a>
                         and <a class="govuk-link" href="%cookie%">cookie policy</a>.
                         {% endtrans %}

--- a/service-front/app/src/Actor/templates/actor/create-account.html.twig
+++ b/service-front/app/src/Actor/templates/actor/create-account.html.twig
@@ -48,7 +48,7 @@
                                   </strong>
                                 </div>
 
-                                {{ govuk_form_element(form.get('terms'), { 'label': 'I agree to the <a href="%link%" class="govuk-link">terms of use</a>' | trans({ '%link%': path('actor-terms-of-use') }) }) }}
+                                {{ govuk_form_element(form.get('terms'), { 'label': 'I agree to the <a href="%link%" class="govuk-link">terms of use</a>' | trans({ '%link%': path('terms-of-use') }) }) }}
 
                                 <button data-prevent-double-click="true" type="submit" class="govuk-button">{% trans %}Create account{% endtrans %}</button>
 

--- a/service-front/app/src/Actor/templates/actor/form-error-messages.html.twig
+++ b/service-front/app/src/Actor/templates/actor/form-error-messages.html.twig
@@ -29,6 +29,7 @@
 {# Add lpa #}
 {% trans %}Enter your activation key{% context %}error{% notes %}Add LPA{% endtrans %}
 {% trans %}Enter an activation key in the correct format{% context %}error{% notes %}Add LPA{% endtrans %}
+{% trans %}Enter the LPA reference number{% context %}error{% notes %}Add LPA{% endtrans %}
 {% trans %}The LPA reference number you entered is too short{% context %}error{% notes %}Add LPA{% endtrans %}
 {% trans %}The LPA reference number you entered is too long{% context %}error{% notes %}Add LPA{% endtrans %}
 {% trans %}Enter the 12 numbers of the LPA reference number. Do not include letters or other characters{% context %}error{% notes %}Add LPA{% endtrans %}

--- a/service-front/app/src/Common/src/ConfigProvider.php
+++ b/service-front/app/src/Common/src/ConfigProvider.php
@@ -84,6 +84,7 @@ class ConfigProvider
                 \Mezzio\Authentication\UserInterface::class => Entity\UserFactory::class,
 
                 // Handlers
+                Handler\CookiesPageHandler::class => Handler\Factory\CookiesPageHandlerFactory::class,
                 Handler\HealthcheckHandler::class => Handler\Factory\HealthcheckHandlerFactory::class,
 
                 \Acpr\I18n\TranslatorInterface::class => I18n\TranslatorFactory::class,

--- a/service-front/app/src/Common/src/Handler/Factory/CookiesPageHandlerFactory.php
+++ b/service-front/app/src/Common/src/Handler/Factory/CookiesPageHandlerFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Handler\Factory;
+
+use Common\Handler\CookiesPageHandler;
+use Common\Service\Url\UrlValidityCheckService;
+use Mezzio\Helper\UrlHelper;
+use Mezzio\Template\TemplateRendererInterface;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+
+class CookiesPageHandlerFactory
+{
+    public function __invoke(ContainerInterface $container): CookiesPageHandler
+    {
+        $config = $container->get('config');
+
+        if (!isset($config['application'])) {
+            throw new RuntimeException('Missing application type, should be one of "viewer" or "actor"');
+        }
+
+        return new CookiesPageHandler(
+            $container->get(TemplateRendererInterface::class),
+            $container->get(UrlHelper::class),
+            $container->get(UrlValidityCheckService::class),
+            $config['application']
+        );
+    }
+}

--- a/service-front/app/src/Common/templates/layout/default.html.twig
+++ b/service-front/app/src/Common/templates/layout/default.html.twig
@@ -100,12 +100,12 @@
                 <h2 class="govuk-visually-hidden">{% trans %}Support links{% endtrans %}</h2>
                 <ul class="govuk-footer__inline-list">
                     <li class="govuk-footer__inline-list-item">
-                        <a class="govuk-footer__link" href="/terms-of-use">
+                        <a class="govuk-footer__link" href="{{ path('terms-of-use') }}">
                             {% trans %}Terms of use{% endtrans %}
                         </a>
                     </li>
                     <li class="govuk-footer__inline-list-item">
-                        <a class="govuk-footer__link" href="/cookies">
+                        <a class="govuk-footer__link" href="{{ path('cookies') }}">
                             {% trans %}Cookies{% endtrans %}
                         </a>
                     </li>

--- a/service-front/app/src/Common/templates/layout/default.html.twig
+++ b/service-front/app/src/Common/templates/layout/default.html.twig
@@ -55,7 +55,7 @@
                     <button class="govuk-button button--inline" name="accept-all-cookies" type="submit" role="button">{% trans %}Accept all cookies{% endtrans %}</button>
                 </div>
                 <div class="cookie-banner__button govuk-grid-column-full govuk-grid-column-one-half-from-desktop govuk-!-padding-left-0">
-                    <a href="/cookies" class="govuk-button govuk-button--secondary button--inline" name="set-cookie-preferences" role="button">{% trans %}Set cookie preferences{% endtrans %}</a>
+                    <a href="{{ path('cookies') }}" class="govuk-button govuk-button--secondary button--inline" name="set-cookie-preferences" role="button">{% trans %}Set cookie preferences{% endtrans %}</a>
                 </div>
             </div>
         </div>

--- a/service-front/app/src/Common/templates/partials/cookies.html.twig
+++ b/service-front/app/src/Common/templates/partials/cookies.html.twig
@@ -3,11 +3,11 @@
 {% block html_title %}{% trans %}Cookies{% endtrans %} - {{ block('service_name') }} - {{ parent() }}{% endblock %}
 
 {% block service_name %}
-    {% if routeName == "actor-cookies" %}
-        {% trans %}Use a lasting power of attorney{% endtrans %}
-    {% elseif routeName == "viewer-cookies" %}
-        {% trans %}View a lasting power of attorney{% endtrans %}
-    {% endif %}
+{% if routeName == "actor" %}
+    {% trans %}Use a lasting power of attorney{% endtrans %}
+{% elseif routeName == "viewer" %}
+    {% trans %}View a lasting power of attorney{% endtrans %}
+{% endif %}
 {% endblock %}
 
 {% set usageCookies = form.get('usageCookies') %}
@@ -24,9 +24,9 @@
             <p class="govuk-body">{% trans %}Cookies are files saved on your phone, tablet or computer when you visit a website.{% endtrans %}</p>
 
             <p class="govuk-body">
-            {% if routeName == "actor-cookies" %}
+            {% if routeName == "actor" %}
                 {% trans %}We use cookies to store information about how you use the Use a lasting power of attorney service, such as the pages you visit.{% endtrans %}
-            {% elseif routeName == "viewer-cookies" %}
+            {% elseif routeName == "viewer" %}
                 {% trans %}We use cookies to store information about how you use the View a lasting power of attorney service, such as the pages you visit.{% endtrans %}
             {% endif %}
             </p>

--- a/service-front/app/src/Common/templates/partials/cookies.html.twig
+++ b/service-front/app/src/Common/templates/partials/cookies.html.twig
@@ -3,9 +3,9 @@
 {% block html_title %}{% trans %}Cookies{% endtrans %} - {{ block('service_name') }} - {{ parent() }}{% endblock %}
 
 {% block service_name %}
-{% if routeName == "actor" %}
+{% if application == "actor" %}
     {% trans %}Use a lasting power of attorney{% endtrans %}
-{% elseif routeName == "viewer" %}
+{% elseif application == "viewer" %}
     {% trans %}View a lasting power of attorney{% endtrans %}
 {% endif %}
 {% endblock %}
@@ -24,9 +24,9 @@
             <p class="govuk-body">{% trans %}Cookies are files saved on your phone, tablet or computer when you visit a website.{% endtrans %}</p>
 
             <p class="govuk-body">
-            {% if routeName == "actor" %}
+            {% if application == "actor" %}
                 {% trans %}We use cookies to store information about how you use the Use a lasting power of attorney service, such as the pages you visit.{% endtrans %}
-            {% elseif routeName == "viewer" %}
+            {% elseif application == "viewer" %}
                 {% trans %}We use cookies to store information about how you use the View a lasting power of attorney service, such as the pages you visit.{% endtrans %}
             {% endif %}
             </p>

--- a/service-front/app/src/Viewer/templates/viewer/enter-code.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/enter-code.html.twig
@@ -51,7 +51,7 @@
                             {% trans %}An <abbr title="lasting power of attorney">LPA</abbr> access code is a unique code given to you by the donor or an attorney named on a lasting power of attorney.{% endtrans %}
                         </div>
 
-                        <p class="govuk-body">{% trans with {'{link}': path('terms-of-use')} %}By continuing you agree to our <a href="{link}" class="govuk-link">terms of use</a>.{% endtrans %}</p>
+                        <p class="govuk-body">{% trans with {'%link%': path('terms-of-use')} %}By continuing you agree to our <a href="%link%" class="govuk-link">terms of use</a>.{% endtrans %}</p>
 
                         <button data-prevent-double-click="true" type="submit" class="govuk-button">{% trans %}Continue{% endtrans %}</button>
 

--- a/service-front/app/src/Viewer/templates/viewer/enter-code.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/enter-code.html.twig
@@ -51,7 +51,7 @@
                             {% trans %}An <abbr title="lasting power of attorney">LPA</abbr> access code is a unique code given to you by the donor or an attorney named on a lasting power of attorney.{% endtrans %}
                         </div>
 
-                        <p class="govuk-body">{% trans with {'%link%': path('viewer-terms-of-use')} %}By continuing you agree to our <a href="%link%" class="govuk-link">terms of use</a>.{% endtrans %}</p>
+                        <p class="govuk-body">{% trans with {'{link}': path('terms-of-use')} %}By continuing you agree to our <a href="{link}" class="govuk-link">terms of use</a>.{% endtrans %}</p>
 
                         <button data-prevent-double-click="true" type="submit" class="govuk-button">{% trans %}Continue{% endtrans %}</button>
 

--- a/service-front/app/src/Viewer/templates/viewer/viewer-privacy-notice.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/viewer-privacy-notice.html.twig
@@ -6,7 +6,7 @@
 <div class="govuk-width-container">
 {{ include('@partials/new-service.html.twig') }}
 
-    <a href="{{ path('viewer-terms-of-use') }}" class="govuk-back-link">{% trans %}Back{% endtrans %}</a>
+    <a href="{{ path('terms-of-use') }}" class="govuk-back-link">Back</a>
     <main class="govuk-main-wrapper" id="main-content" role="main">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
@@ -52,9 +52,8 @@
                         explains how we process personal data.
                     {% endtrans %}
                 </p>
-                <p class="govuk-body">{% trans with {'%terms-of-use%': path('viewer-terms-of-use'), '%cookie%': path('viewer-cookies')} %}You can find more information about using the View a lasting power of attorney service in our
-                        <a class="govuk-link" href="%terms-of-use%">terms of use</a> and <a class="govuk-link" class="govuk-link"  href="%cookie%">cookie policy</a>.
-                    {% endtrans %}
+                <p class="govuk-body">
+                    You can find more information about using the View a lasting power of attorney service in our <a class="govuk-link" href="{{ path('terms-of-use') }}">terms of use</a> and <a class="govuk-link" class="govuk-link"  href="{{ path('cookies')}}">cookie policy</a>.
                 </p>
                 <h2 class="govuk-heading-m">{% trans %}What data we collect and how we use it{% endtrans %}</h2>
 
@@ -72,7 +71,6 @@
                     <li>{% trans %}when the access code is used to view an  <abbr title="lasting power of attorney">LPA</abbr>{% endtrans %}</li>
                     <li>{% trans %}the name of the organisation or individual the donor or attorney said they were giving that code to{% endtrans %}</li>
                     <li>{% trans %}your computer’s IP address while you use this service{% endtrans %}</li>
-                    </li>
                 </ul>
                 <p class="govuk-body">
                     {% trans %}This information will be shared with the donor and attorneys on the <abbr title="lasting power of attorney">LPA</abbr>, if they’re using the Use a lasting power of attorney service. This is to help prevent and detect unauthorised access.{% endtrans %}

--- a/service-front/app/src/Viewer/templates/viewer/viewer-terms-of-use.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/viewer-terms-of-use.html.twig
@@ -79,7 +79,7 @@
                     </h2>
 
                     <p class="govuk-body">{% trans %}We keep a record of when an access code has been used to view an <abbr title="lasting power of attorney">LPA</abbr>. This information is available to the donor and attorneys.{% endtrans %}</p>
-                    <p class="govuk-body">{%trans with {'%privacy-link%': path('viewer-privacy-notice'), '%cookies-link%': path('viewer-cookies')} %}The information will be stored securely and used in line with our <a class="govuk-link" href="%privacy-link%">privacy notice</a> and <a class="govuk-link" href="%cookies-link%">cookie policy</a>.{% endtrans %}</p>
+                    <p class="govuk-body">{%trans with {'%privacy-link%': path('privacy-notice'), '%cookies-link%': path('cookies')} %}The information will be stored securely and used in line with our <a class="govuk-link" href="%privacy-link%">privacy notice</a> and <a class="govuk-link" href="%cookies-link%">cookie policy</a>.{% endtrans %}</p>
                     <h2 class="govuk-heading-m">
                         {% trans %}If you suspect fraud or abuse{% endtrans %}
                     </h2>

--- a/service-front/app/test/CommonTest/Handler/Factory/CookiesPageHandlerFactoryTest.php
+++ b/service-front/app/test/CommonTest/Handler/Factory/CookiesPageHandlerFactoryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommonTest\Handler\Factory;
+
+use Common\Handler\CookiesPageHandler;
+use Common\Handler\Factory\CookiesPageHandlerFactory;
+use Common\Service\Url\UrlValidityCheckService;
+use Mezzio\Helper\UrlHelper;
+use Mezzio\Template\TemplateRendererInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+
+class CookiesPageHandlerFactoryTest extends TestCase
+{
+    /** @test */
+    public function it_returns_a_CookiesPageHandler(): void
+    {
+        $containerProphecy = $this->prophesize(ContainerInterface::class);
+        $containerProphecy
+            ->get('config')
+            ->willReturn(['application' => 'viewer']);
+        $containerProphecy
+            ->get(TemplateRendererInterface::class)
+            ->willReturn($this->prophesize(TemplateRendererInterface::class)->reveal());
+        $containerProphecy
+            ->get(UrlHelper::class)
+            ->willReturn($this->prophesize(UrlHelper::class)->reveal());
+        $containerProphecy
+            ->get(UrlValidityCheckService::class)
+            ->willReturn($this->prophesize(UrlValidityCheckService::class)->reveal());
+
+        $factory = new CookiesPageHandlerFactory();
+
+        $instance = $factory($containerProphecy->reveal());
+
+        $this->assertInstanceOf(CookiesPageHandler::class, $instance);
+    }
+
+    /** @test */
+    public function it_needs_an_application_configuration_value(): void
+    {
+        $containerProphecy = $this->prophesize(ContainerInterface::class);
+        $containerProphecy
+            ->get('config')
+            ->willReturn([]);
+
+        $factory = new CookiesPageHandlerFactory();
+
+        $this->expectException(RuntimeException::class);
+        $instance = $factory($containerProphecy->reveal());
+    }
+}


### PR DESCRIPTION
## Purpose
Fixes up links across the site to the static privacy policy, cookies and terms of use pages. Sets them up to properly interpret the current language on the site and set links accordingly.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes

