### PR TITLE
Fix to identity generation

### DIFF
--- a/service-front/app/src/Common/src/Service/Security/UserIdentificationService.php
+++ b/service-front/app/src/Common/src/Service/Security/UserIdentificationService.php
@@ -31,22 +31,27 @@ class UserIdentificationService
     public function id(\Psr\Http\Message\ServerRequestInterface $request): string
     {
         $headersToHash = [
-            'accept',
-            'accept-encoding',
-            'accept-language',
-            'user-agent',
-            'x-forwarded-for'
+            'accept' => '',
+            'accept-encoding' => '',
+            'accept-language' => '',
+            'user-agent' => '',
+            'x-forwarded-for' => ''
         ];
 
         // pull each header value out (if it exists)
-        foreach ($headersToHash as $header) {
+        foreach ($headersToHash as $header => $value) {
             $headersToHash[$header] =
                 $request->hasHeader($header)
-                    ? $request->getHeader($header)
+                    ? $request->getHeader($header)[0]
                     : $header;
         }
 
         $this->logger->debug('Identity of incoming request built', $headersToHash);
+
+        $this->logger->debug(
+            'Identity of incoming request built',
+            ['prehash_id' => implode('', $headersToHash)]
+        );
 
         return hash('sha256', implode('', $headersToHash));
     }

--- a/service-front/app/test/CommonTest/Service/Security/UserIdentificationServiceTest.php
+++ b/service-front/app/test/CommonTest/Service/Security/UserIdentificationServiceTest.php
@@ -28,7 +28,7 @@ class UserIdentificationServiceTest extends TestCase
 
         $id = $service->id($requestProphecy->reveal());
 
-        $this->assertEquals('da97c8ccc40114128dcaeff8be27d9481c116eb01cbf9007c0e1a02d2590a197', $id);
+        $this->assertEquals('224fb6e8b478de4a0d10bbeb92a07ffe095df3f9e1b1b50197d88f4c48192025', $id);
     }
 
     /**
@@ -59,7 +59,7 @@ class UserIdentificationServiceTest extends TestCase
         return [
             [ # the realistic bare minimum unique thing to track
                 ['x-forwarded-for'],
-                'f9bcf7fa2cc63932adedba2696f4c8b6c86404c420ea201310dcd13b73710bde'
+                'c6f41b7d23a875f6b1ba03cea0207c8340563e2df9fc43cb1b331717b999d099'
             ],
             [ # the complete set
                 [
@@ -69,7 +69,7 @@ class UserIdentificationServiceTest extends TestCase
                     'user-agent',
                     'x-forwarded-for'
                 ],
-                'a3b74c076c52c08495a7c37135db24becdeff0bcd88a3b40e0b3279d7349ef66'
+                '3afdc96b35e60a6c3d98fc06ca8647ad5a106c862503cb64f982d260928c7285'
             ],
             [ # not a complete set
                 [
@@ -77,7 +77,7 @@ class UserIdentificationServiceTest extends TestCase
                     'user-agent',
                     'x-forwarded-for'
                 ],
-                'be4e45e3a7274376b3e1f9fdc9e96c7af8eb9cbcfd397a30266ac0ab0ec9fa54'
+                'f2978681b9f61976090c88df4dfce164513606996cf4d5c4203121a14eec13f9'
             ],
             [ # only use specified headers
                 [
@@ -86,7 +86,7 @@ class UserIdentificationServiceTest extends TestCase
                     'not-a-real-header',
                     'x-forwarded-for'
                 ],
-                'be4e45e3a7274376b3e1f9fdc9e96c7af8eb9cbcfd397a30266ac0ab0ec9fa54'
+                'f2978681b9f61976090c88df4dfce164513606996cf4d5c4203121a14eec13f9'
             ],
         ];
     }


### PR DESCRIPTION
## Purpose
The algorithm that generated the identity key that is given to users was incorrect and quite fundamentally broken. This PR addresses that by reworking the algorithm to actually output a useful value.

## Approach
The original algorithm used `implode` correctly on an incorrectly structured array. Resulting in a hash of the string "ArrayArrayArrayArrayArray". The array is now structured so that it contains the actual values. Something like;

`text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8gzip, deflateen-GB,en;q=0.5Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:78.0) Gecko/20100101 Firefox/78.0172.18.0.1`

## Learning
Always verify string inputs to functions.

**Although the tests have been updated to get this PR to pass additional tests need writing to check that the expected header values are a part of the hash. This can be done by listening to the logged out debug value in the test.**

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes

