### PR TITLE
pin the version of terraform used for workspace cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1064,7 +1064,7 @@ jobs:
 
   workspace_cleanup:
     docker:
-      - image: hashicorp/terraform
+      - image: hashicorp/terraform:0.12.29
     resource_class: small
     steps:
       - checkout


### PR DESCRIPTION
## Purpose
Pin workspace cleanup terraform image to 0.12.29

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Refunds service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

