### PR TITLE
work around difference in provider installation behaviour

### DIFF
--- a/terraform/account/credentials.tf
+++ b/terraform/account/credentials.tf
@@ -12,15 +12,15 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "-/aws"
+      source  = "hashicorp/aws"
       version = "~> 2.70.0"
     }
     local = {
-      source  = "-/local"
+      source  = "hashicorp/local"
       version = "~> 1.4.0"
     }
     pagerduty = {
-      source  = "-/pagerduty"
+      source  = "terraform-providers/pagerduty"
       version = "~> 1.7.4"
     }
   }

--- a/terraform/account/credentials.tf
+++ b/terraform/account/credentials.tf
@@ -35,7 +35,8 @@ variable "management_role" {
 }
 
 provider "aws" {
-  region = "eu-west-1"
+  version = "~> 2.70.0"
+  region  = "eu-west-1"
 
   assume_role {
     role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
@@ -44,8 +45,9 @@ provider "aws" {
 }
 
 provider "aws" {
-  region = "eu-west-1"
-  alias  = "management"
+  version = "~> 2.70.0"
+  region  = "eu-west-1"
+  alias   = "management"
 
   assume_role {
     role_arn     = "arn:aws:iam::311462405659:role/${var.management_role}"
@@ -54,5 +56,6 @@ provider "aws" {
 }
 
 provider "pagerduty" {
-  token = var.pagerduty_token
+  version = "~> 1.7.4"
+  token   = var.pagerduty_token
 }

--- a/terraform/environment/credentials.tf
+++ b/terraform/environment/credentials.tf
@@ -12,15 +12,15 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "-/aws"
+      source  = "hashicorp/aws"
       version = "~> 2.70.0"
     }
     local = {
-      source  = "-/local"
+      source  = "hashicorp/local"
       version = "~> 1.4.0"
     }
     pagerduty = {
-      source  = "-/pagerduty"
+      source  = "terraform-providers/pagerduty"
       version = "~> 1.7.4"
     }
   }
@@ -35,7 +35,8 @@ variable "management_role" {
 }
 
 provider "aws" {
-  region = "eu-west-1"
+  version = "~> 2.70.0"
+  region  = "eu-west-1"
 
   assume_role {
     role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
@@ -44,8 +45,9 @@ provider "aws" {
 }
 
 provider "aws" {
-  region = "us-east-1"
-  alias  = "us-east-1"
+  version = "~> 2.70.0"
+  region  = "us-east-1"
+  alias   = "us-east-1"
 
   assume_role {
     role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
@@ -54,8 +56,9 @@ provider "aws" {
 }
 
 provider "aws" {
-  region = "eu-west-1"
-  alias  = "management"
+  version = "~> 2.70.0"
+  region  = "eu-west-1"
+  alias   = "management"
 
   assume_role {
     role_arn     = "arn:aws:iam::311462405659:role/${var.management_role}"
@@ -64,5 +67,6 @@ provider "aws" {
 }
 
 provider "pagerduty" {
-  token = var.pagerduty_token
+  version = "~> 1.7.4"
+  token   = var.pagerduty_token
 }


### PR DESCRIPTION
## Purpose
Provider installation is not consistant and introduces unintended upgrade of AWS provider.

Fixes UML-1027

## Approach

Address the difference in behaviour between account and environment `terraform init` commands.

## Learning

The issue is caused by the way that Terraform 0.13 references legacy providers using `-/`.
https://github.com/hashicorp/terraform/blob/guide-v0.13-beta/draft-upgrade-guide.md

This is fixed by replacing the provider in the state file

```
tf state replace-provider registry.terraform.io/-/aws registry.terraform.io/hashicorp/aws 
tf state replace-provider registry.terraform.io/-/local registry.terraform.io/hashicorp/local 
tf state replace-provider registry.terraform.io/-/pagerduty registry.terraform.io/terraform-providers/pagerduty 
```

I have written a script to do this for all environments.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

