### PR TITLE
DEV FIX: Fix dev seeding lpa add issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,29 @@ Packages can be removed with:
 
 <DOCKER_COMPOSE> run front-composer composer remove author/package
 ```
+
+##Troubleshooting
+There are occasions when your local dev environment doesn't quite act as it should.
+_Feel free to add further troubleshooting steps here._
+
+Here are some common problems we've come across:
+
+- I cannot login with the seeded user.
+
+its possible seeding of Use an LPA was not successful.
+make sure all docker compose services are running and have settled first, then try again.
+run the following command:
+```shell
+<DOCKER_COMPOSE> run api-seeding
+```
+then try again
+
+- I cannot add  LPA's locally, which are in the seeded data set.
+
+This could be because the LPA Gateway (Sirius Gateway) has not been properly initialised.
+make sure all docker compose services are running andhave settled first, then try again.
+If still not working,run the following command:
+```shell
+<DOCKER_COMPOSE> run lpa-gateway-setup
+```
+if that doesn't work try running the api-seeding step, mentioned with the login failure error.

--- a/docker-compose.dependencies.yml
+++ b/docker-compose.dependencies.yml
@@ -46,11 +46,16 @@ services:
 
       PASSTHROUGH_DYNAMODB_DATA_CACHE_TABLE_NAME: opg-gateway-cache-data
       PASSTHROUGH_DYNAMODB_AUTH_CACHE_TABLE_NAME: opg-gateway-cache-auth
-      PASSTHROUGH_AWS_ENDPOINT_DYNAMODB: http://localstack:14569
+      PASSTHROUGH_AWS_ENDPOINT_DYNAMODB : http://localstack:14569
       PASSTHROUGH_URL_MEMBRANE: https://membrane
       PASSTHROUGH_CREDENTIALS: '{"email": "publicapi@opgtest.com","password": "Password1"}' # Non-secret credentials, deliberately committed.
       PASSTHROUGH_ENABLE_DEBUG: 'false'
       PASSTHROUGH_DATA_PROVIDER: json
+      PASSTHROUGH_AWS_ACCESS_KEY_ID: testing
+      PASSTHROUGH_AWS_SECRET_ACCESS_KEY: testing
+      PASSTHROUGH_AWS_SECURITY_TOKEN: testing
+      PASSTHROUGH_AWS_SESSION_TOKEN: testing
+      PASSTHROUGH_AWS_DEFAULT_REGION: eu-west-1
 
   # -----
   # Code Generation API development environment


### PR DESCRIPTION
## Purpose
To fix an issue where we have problems retrieving LPACollections data on local dev enviroments

Fixes Dev environments locally.

## Approach
- Add `PASSTHROUGH_` env vars relating to aws credentials
- update Readme with troubleshooting section to solve further issues manually.


## Learning
found similar issue here: https://github.com/localstack/localstack/issues/528#issuecomment-356453460

from slack conversation: 
https://mojdt.slack.com/archives/CAQ3T5JFQ/p1597404794306100
"... We've added a bunch of PASSTHROUGH_ variables relating to aws, this is based on conversation yesterday to try this. but we'd not got that format quite right. on digging in the gateway code it mentions the above prefix, so proceeded to add that. this solved the problem, and a PR is to follow to fix that. here are the env vars:
``` shell
PASSTHROUGH_AWS_ACCESS_KEY_ID: testing
PASSTHROUGH_AWS_SECRET_ACCESS_KEY: testing
PASSTHROUGH_AWS_SECURITY_TOKEN: testing
PASSTHROUGH_AWS_SESSION_TOKEN: testing
PASSTHROUGH_AWS_DEFAULT_REGION: eu-west-1
```

Also - we are getting 500's sometimes for lpa-gateway, which is because the LPA-Gateway-setup service is not seeding the cache tables properly occasionally. the solution at least for now is to run `<DOCKER-COMPOSE commands> run lpa-gateway-setup` manually to realign the data tables into dynamo.
you can also try to run `<DOCKER-COMPOSE commands> run api-seeding` if you need to to reseed lpa data"

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

