### PR TITLE
UML-1031 - Upgrade Environment Terraform AWS provider to v3

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,4 +1,5 @@
-## Purpose
+# Purpose
+
 _Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_
 
 Fixes UML-####
@@ -9,7 +10,7 @@ _Explain how your code addresses the purpose of the change_
 
 ## Learning
 
-_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Refunds service_
+_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_
 
 ## Checklist
 
@@ -18,4 +19,3 @@ _Any tips and tricks, blog posts or tools which helped you. Plus anything notabl
 * [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
 * [ ] I have added tests to prove my work
 * [ ] The product team have tested these changes
-

--- a/docs/runbooks/maintenance_mode/README.md
+++ b/docs/runbooks/maintenance_mode/README.md
@@ -2,7 +2,43 @@
 
 This script will enable or disable maintenance mode for a targeted environment.
 
-## Setup
+## Setup - Local Credentials Route
+
+Use this route if you have the required access via aws-vault to make changes to the environment that needs to be put into maintenenance mode.
+
+You will need have to set up assumable roles in aws-vault. Follow the instructions at `../aws-vault-assumable-roles.md`.
+
+### Usage
+
+To turn on maintenance mode for both the use and view front ends
+
+``` bash
+
+aws-vault exec ual-preprod -- ./manage_maintenance.sh \
+  --environment preproduction \
+  --maintenance_mode
+```
+
+To turn off maintenance mode for both the use and view front ends
+
+``` bash
+aws-vault exec ual-preprod -- ./manage_maintenance.sh \
+  --environment preproduction \
+  --disable_maintenance_mode
+```
+
+To turn on maintenance mode for just one front end, use `--front_end view` or `--front_end use`
+
+``` bash
+aws-vault exec ual-preprod -- ./manage_maintenance.sh \
+  --environment preproduction \
+  --front_end view \
+  --maintenance_mode
+```
+
+___
+
+## Setup - Cloud9 Route
 
 ### Start a Cloud9 Instance
 

--- a/docs/runbooks/maintenance_mode/manage_maintenance.sh
+++ b/docs/runbooks/maintenance_mode/manage_maintenance.sh
@@ -15,7 +15,6 @@ function set_service_name() {
 function get_alb_rule_arn() {
   MM_ALB_ARN=$(aws elbv2 describe-load-balancers --names  "${ENVIRONMENT}-${SERVICE}" | jq -r .[][]."LoadBalancerArn")
   MM_LISTENER_ARN=$(aws elbv2 describe-listeners --load-balancer-arn ${MM_ALB_ARN} | jq -r '.[][]  | select(.Protocol == "HTTPS") | .ListenerArn')
-  MM_RULES=$(aws elbv2 describe-rules --listener-arn ${MM_LISTENER_ARN})
   MM_RULE_ARN=$(aws elbv2 describe-rules --listener-arn ${MM_LISTENER_ARN} | jq -r '.[][]  | select(.Priority == "100") | .RuleArn')
 
 }

--- a/docs/runbooks/maintenance_mode/manage_maintenance.sh
+++ b/docs/runbooks/maintenance_mode/manage_maintenance.sh
@@ -26,14 +26,14 @@ function enable_maintenance() {
   then
     MM_DNS_PREFIX=""
   fi
-  aws ssm put-parameter --name "${ENVIRONMENT}_${SERVICE}_enable_maintenance" --type "String" --value "true" --overwrite
+  aws ssm put-parameter --name "${ENVIRONMENT}_${SERVICE}_maintenance" --type "String" --value "true" --overwrite
   aws elbv2 modify-rule \
   --rule-arn $MM_RULE_ARN \
-  --conditions Field=host-header,Values="${MM_DNS_PREFIX}${front_end}.lastingpowerofattorney.opg.service.justice.gov.uk"
+  --conditions Field=host-header,Values="${MM_DNS_PREFIX}${front_end}-lasting-power-of-attorney.service.gov.uk"
 }
 
 function disable_maintenance() {
-  aws ssm put-parameter --name "${ENVIRONMENT}_${SERVICE}_enable_maintenance" --type "String" --value "false" --overwrite
+  aws ssm put-parameter --name "${ENVIRONMENT}_${SERVICE}_maintenance" --type "String" --value "false" --overwrite
   aws elbv2 modify-rule \
   --rule-arn $MM_RULE_ARN \
   --conditions Field=path-pattern,Values='/maintenance'

--- a/terraform/environment/actor_load_balancer.tf
+++ b/terraform/environment/actor_load_balancer.tf
@@ -126,30 +126,6 @@ resource "aws_ssm_parameter" "actor_maintenance_switch" {
   }
 }
 
-locals {
-  actor_path_pattern = {
-    field  = "path-pattern"
-    values = ["/maintenance"]
-  }
-  actor_host_pattern = {
-    field  = "host-header"
-    values = [aws_route53_record.actor-use-my-lpa.fqdn]
-  }
-
-  actor_path_pattern_condition = {
-    path_pattern = {
-      values = ["/maintenance"]
-    }
-  }
-  actor_host_pattern_condition = {
-    host_header = {
-      values = [aws_route53_record.actor-use-my-lpa.fqdn]
-    }
-  }
-
-  actor_rule_condition = aws_ssm_parameter.actor_maintenance_switch.value ? local.actor_host_pattern_condition : local.actor_path_pattern_condition
-}
-
 resource "aws_lb_listener_rule" "enable_actor_maintenance" {
   count        = aws_ssm_parameter.actor_maintenance_switch.value ? 1 : 0
   listener_arn = aws_lb_listener.actor_loadbalancer.arn
@@ -165,7 +141,10 @@ resource "aws_lb_listener_rule" "enable_actor_maintenance" {
   }
   condition {
     host_header {
-      values = [aws_route53_record.actor-use-my-lpa.fqdn]
+      values = [
+        aws_route53_record.actor-use-my-lpa.fqdn,
+        aws_route53_record.public_facing_use_lasting_power_of_attorney.fqdn,
+      ]
     }
 
   }

--- a/terraform/environment/actor_load_balancer.tf
+++ b/terraform/environment/actor_load_balancer.tf
@@ -129,7 +129,6 @@ resource "aws_ssm_parameter" "actor_maintenance_switch" {
 resource "aws_lb_listener_rule" "enable_actor_maintenance" {
   count        = aws_ssm_parameter.actor_maintenance_switch.value ? 1 : 0
   listener_arn = aws_lb_listener.actor_loadbalancer.arn
-  priority     = 3
   action {
     type = "fixed-response"
 

--- a/terraform/environment/credentials.tf
+++ b/terraform/environment/credentials.tf
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3"
+      version = "~> 3.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/terraform/environment/credentials.tf
+++ b/terraform/environment/credentials.tf
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.70.0"
+      version = "~> 3"
     }
     local = {
       source  = "hashicorp/local"
@@ -35,8 +35,7 @@ variable "management_role" {
 }
 
 provider "aws" {
-  version = "~> 2.70.0"
-  region  = "eu-west-1"
+  region = "eu-west-1"
 
   assume_role {
     role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
@@ -45,9 +44,8 @@ provider "aws" {
 }
 
 provider "aws" {
-  version = "~> 2.70.0"
-  region  = "us-east-1"
-  alias   = "us-east-1"
+  region = "us-east-1"
+  alias  = "us-east-1"
 
   assume_role {
     role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
@@ -56,9 +54,8 @@ provider "aws" {
 }
 
 provider "aws" {
-  version = "~> 2.70.0"
-  region  = "eu-west-1"
-  alias   = "management"
+  region = "eu-west-1"
+  alias  = "management"
 
   assume_role {
     role_arn     = "arn:aws:iam::311462405659:role/${var.management_role}"
@@ -67,6 +64,5 @@ provider "aws" {
 }
 
 provider "pagerduty" {
-  version = "~> 1.7.4"
-  token   = var.pagerduty_token
+  token = var.pagerduty_token
 }

--- a/terraform/environment/viewer_load_balancer.tf
+++ b/terraform/environment/viewer_load_balancer.tf
@@ -126,19 +126,9 @@ resource "aws_ssm_parameter" "viewer_maintenance_switch" {
   }
 }
 
-locals {
-  viewer_path_pattern = {
-    field  = "path-pattern"
-    values = ["/maintenance"]
-  }
-  viewer_host_pattern = {
-    field  = "host-header"
-    values = [aws_route53_record.viewer-use-my-lpa.fqdn]
-  }
-  viewer_rule_condition = aws_ssm_parameter.viewer_maintenance_switch.value ? local.viewer_host_pattern : local.viewer_path_pattern
-}
 
-resource "aws_lb_listener_rule" "viewer_maintenance" {
+resource "aws_lb_listener_rule" "enable_viewer_maintenance" {
+  count        = aws_ssm_parameter.viewer_maintenance_switch.value ? 1 : 0
   listener_arn = aws_lb_listener.viewer_loadbalancer.arn
   priority     = 3
   action {
@@ -150,13 +140,35 @@ resource "aws_lb_listener_rule" "viewer_maintenance" {
       status_code  = "503"
     }
   }
-
   condition {
-    field  = local.viewer_rule_condition.field
-    values = local.viewer_rule_condition.values
+    host_header {
+      values = [
+        aws_route53_record.viewer-use-my-lpa.fqdn,
+        aws_route53_record.public_facing_view_lasting_power_of_attorney.fqdn,
+      ]
+    }
+
   }
 }
 
+resource "aws_lb_listener_rule" "viewer_maintenance" {
+  listener_arn = aws_lb_listener.viewer_loadbalancer.arn
+  priority     = 4
+  action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/html"
+      message_body = file("${path.module}/maintenance/viewer_maintenance.html")
+      status_code  = "503"
+    }
+  }
+  condition {
+    path_pattern {
+      values = ["/maintenance"]
+    }
+  }
+}
 resource "aws_security_group" "viewer_loadbalancer" {
   name        = "${local.environment}-viewer-loadbalancer"
   description = "Allow inbound traffic"

--- a/terraform/environment/viewer_load_balancer.tf
+++ b/terraform/environment/viewer_load_balancer.tf
@@ -126,33 +126,9 @@ resource "aws_ssm_parameter" "viewer_maintenance_switch" {
   }
 }
 
-
-resource "aws_lb_listener_rule" "enable_viewer_maintenance" {
-  count        = aws_ssm_parameter.viewer_maintenance_switch.value ? 1 : 0
-  listener_arn = aws_lb_listener.viewer_loadbalancer.arn
-  action {
-    type = "fixed-response"
-
-    fixed_response {
-      content_type = "text/html"
-      message_body = file("${path.module}/maintenance/viewer_maintenance.html")
-      status_code  = "503"
-    }
-  }
-  condition {
-    host_header {
-      values = [
-        aws_route53_record.viewer-use-my-lpa.fqdn,
-        aws_route53_record.public_facing_view_lasting_power_of_attorney.fqdn,
-      ]
-    }
-
-  }
-}
-
 resource "aws_lb_listener_rule" "viewer_maintenance" {
   listener_arn = aws_lb_listener.viewer_loadbalancer.arn
-  priority     = 4
+  priority     = 100 # Specifically set so that maintenance mode scripts can locate the correct rule to modify
   action {
     type = "fixed-response"
 
@@ -166,6 +142,13 @@ resource "aws_lb_listener_rule" "viewer_maintenance" {
     path_pattern {
       values = ["/maintenance"]
     }
+  }
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to the condition as this is modified by a script
+      # when putting the service into maintenance mode.
+      condition,
+    ]
   }
 }
 resource "aws_security_group" "viewer_loadbalancer" {

--- a/terraform/environment/viewer_load_balancer.tf
+++ b/terraform/environment/viewer_load_balancer.tf
@@ -130,7 +130,6 @@ resource "aws_ssm_parameter" "viewer_maintenance_switch" {
 resource "aws_lb_listener_rule" "enable_viewer_maintenance" {
   count        = aws_ssm_parameter.viewer_maintenance_switch.value ? 1 : 0
   listener_arn = aws_lb_listener.viewer_loadbalancer.arn
-  priority     = 3
   action {
     type = "fixed-response"
 


### PR DESCRIPTION
## Purpose
Upgrade environment Terraform AWS provider to v3

Fixes UML-1031

## Approach

Work through upgrade guide and address conflicts.

## Learning

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade

The change in how loadbalancer listener rule conditions are defined means the conditional setting of `field` and `values` is no longer possible in the same way. 

Instead, I have created just a single rule that sets a fixed response when the path_pattern is`/maintenance`. I've set the condition on this rule to be ignored after creating it. This allows a script to enable maintenance and a deployment (perhaps intended to fix the reason for maintenance) to not make the service live again. Only the maintenance script can put the service live again.

In addition, now that the team all have assumable roles set up with AWS vault, I have updated the maintenance script readme to show that maintenance can be set from your own machine provided you have permission.

Lastly, I have had to use a specific value for Rule Priority. This is the only way I could target the rule for changes as the API request for listener rules does not return any other fixed value (like a name or description). The Terraform code and maintenance script have been updated to accommodate this.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

