### PR TITLE
UML-1030 - Upgrade account Terraform AWS Provider to version 3.

### DIFF
--- a/terraform/account/certificate.tf
+++ b/terraform/account/certificate.tf
@@ -74,17 +74,25 @@ resource "aws_acm_certificate" "certificate_public_facing_view" {
 // Use Certificates
 
 resource "aws_route53_record" "certificate_validation_use" {
-  provider = aws.management
-  name     = aws_acm_certificate.certificate_use.domain_validation_options[0].resource_record_name
-  type     = aws_acm_certificate.certificate_use.domain_validation_options[0].resource_record_type
-  zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
-  records  = [aws_acm_certificate.certificate_use.domain_validation_options[0].resource_record_value]
-  ttl      = 60
+  for_each = {
+    for dvo in aws_acm_certificate.certificate_use.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
 }
 
-resource "aws_acm_certificate_validation" "certificate_use" {
+resource "aws_acm_certificate_validation" "certificate_validation_use" {
   certificate_arn         = aws_acm_certificate.certificate_use.arn
-  validation_record_fqdns = [aws_route53_record.certificate_validation_use.fqdn]
+  validation_record_fqdns = [for record in aws_route53_record.certificate_validation_use : record.fqdn]
 }
 
 resource "aws_acm_certificate" "certificate_use" {
@@ -93,17 +101,25 @@ resource "aws_acm_certificate" "certificate_use" {
 }
 
 resource "aws_route53_record" "certificate_validation_public_facing_use" {
-  provider = aws.management
-  name     = aws_acm_certificate.certificate_public_facing_use.domain_validation_options[0].resource_record_name
-  type     = aws_acm_certificate.certificate_public_facing_use.domain_validation_options[0].resource_record_type
-  zone_id  = data.aws_route53_zone.live_service_use_lasting_power_of_attorney.zone_id
-  records  = [aws_acm_certificate.certificate_public_facing_use.domain_validation_options[0].resource_record_value]
-  ttl      = 60
+  for_each = {
+    for dvo in aws_acm_certificate.certificate_public_facing_use.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.live_service_use_lasting_power_of_attorney.zone_id
 }
 
 resource "aws_acm_certificate_validation" "certificate_public_facing_use" {
   certificate_arn         = aws_acm_certificate.certificate_public_facing_use.arn
-  validation_record_fqdns = [aws_route53_record.certificate_validation_public_facing_use.fqdn]
+  validation_record_fqdns = [for record in aws_route53_record.certificate_validation_public_facing_use : record.fqdn]
 }
 
 resource "aws_acm_certificate" "certificate_public_facing_use" {

--- a/terraform/account/certificate.tf
+++ b/terraform/account/certificate.tf
@@ -17,6 +17,7 @@ data "aws_route53_zone" "live_service_view_lasting_power_of_attorney" {
 // View Certificates
 
 resource "aws_route53_record" "certificate_validation_view" {
+  provider = aws.management
   for_each = {
     for dvo in aws_acm_certificate.certificate_view.domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name
@@ -44,6 +45,7 @@ resource "aws_acm_certificate" "certificate_view" {
 }
 
 resource "aws_route53_record" "certificate_validation_public_facing_view" {
+  provider = aws.management
   for_each = {
     for dvo in aws_acm_certificate.certificate_public_facing_view.domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name
@@ -74,6 +76,7 @@ resource "aws_acm_certificate" "certificate_public_facing_view" {
 // Use Certificates
 
 resource "aws_route53_record" "certificate_validation_use" {
+  provider = aws.management
   for_each = {
     for dvo in aws_acm_certificate.certificate_use.domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name
@@ -101,6 +104,7 @@ resource "aws_acm_certificate" "certificate_use" {
 }
 
 resource "aws_route53_record" "certificate_validation_public_facing_use" {
+  provider = aws.management
   for_each = {
     for dvo in aws_acm_certificate.certificate_public_facing_use.domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name

--- a/terraform/account/certificate.tf
+++ b/terraform/account/certificate.tf
@@ -16,18 +16,49 @@ data "aws_route53_zone" "live_service_view_lasting_power_of_attorney" {
 //------------------------
 // View Certificates
 
+# resource "aws_route53_record" "certificate_validation_view" {
+#   provider = aws.management
+#   name     = aws_acm_certificate.certificate_view.domain_validation_options[0].resource_record_name
+#   type     = aws_acm_certificate.certificate_view.domain_validation_options[0].resource_record_type
+#   zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
+#   records  = [aws_acm_certificate.certificate_view.domain_validation_options[0].resource_record_value]
+#   ttl      = 60
+# }
+
+# resource "aws_route53_record" "certificate_validation_view" {
+#   provider = aws.management
+#   name     = tolist(aws_acm_certificate.certificate_view.domain_validation_options)[0].resource_record_name
+#   type     = tolist(aws_acm_certificate.certificate_view.domain_validation_options)[0].resource_record_type
+#   zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
+#   records  = [tolist(aws_acm_certificate.certificate_view.domain_validation_options)[0].resource_record_value]
+#   ttl      = 60
+# }
+
+# resource "aws_acm_certificate_validation" "certificate_view" {
+#   certificate_arn         = aws_acm_certificate.certificate_view.arn
+#   validation_record_fqdns = [aws_route53_record.certificate_validation_view.fqdn]
+# }
+
 resource "aws_route53_record" "certificate_validation_view" {
-  provider = aws.management
-  name     = aws_acm_certificate.certificate_view.domain_validation_options[0].resource_record_name
-  type     = aws_acm_certificate.certificate_view.domain_validation_options[0].resource_record_type
-  zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
-  records  = [aws_acm_certificate.certificate_view.domain_validation_options[0].resource_record_value]
-  ttl      = 60
+  for_each = {
+    for dvo in aws_acm_certificate.certificate_view.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
 }
 
 resource "aws_acm_certificate_validation" "certificate_view" {
   certificate_arn         = aws_acm_certificate.certificate_view.arn
-  validation_record_fqdns = [aws_route53_record.certificate_validation_view.fqdn]
+  validation_record_fqdns = [for record in aws_route53_record.certificate_validation_view : record.fqdn]
 }
 
 resource "aws_acm_certificate" "certificate_view" {

--- a/terraform/account/certificate.tf
+++ b/terraform/account/certificate.tf
@@ -16,29 +16,6 @@ data "aws_route53_zone" "live_service_view_lasting_power_of_attorney" {
 //------------------------
 // View Certificates
 
-# resource "aws_route53_record" "certificate_validation_view" {
-#   provider = aws.management
-#   name     = aws_acm_certificate.certificate_view.domain_validation_options[0].resource_record_name
-#   type     = aws_acm_certificate.certificate_view.domain_validation_options[0].resource_record_type
-#   zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
-#   records  = [aws_acm_certificate.certificate_view.domain_validation_options[0].resource_record_value]
-#   ttl      = 60
-# }
-
-# resource "aws_route53_record" "certificate_validation_view" {
-#   provider = aws.management
-#   name     = tolist(aws_acm_certificate.certificate_view.domain_validation_options)[0].resource_record_name
-#   type     = tolist(aws_acm_certificate.certificate_view.domain_validation_options)[0].resource_record_type
-#   zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
-#   records  = [tolist(aws_acm_certificate.certificate_view.domain_validation_options)[0].resource_record_value]
-#   ttl      = 60
-# }
-
-# resource "aws_acm_certificate_validation" "certificate_view" {
-#   certificate_arn         = aws_acm_certificate.certificate_view.arn
-#   validation_record_fqdns = [aws_route53_record.certificate_validation_view.fqdn]
-# }
-
 resource "aws_route53_record" "certificate_validation_view" {
   for_each = {
     for dvo in aws_acm_certificate.certificate_view.domain_validation_options : dvo.domain_name => {
@@ -67,17 +44,25 @@ resource "aws_acm_certificate" "certificate_view" {
 }
 
 resource "aws_route53_record" "certificate_validation_public_facing_view" {
-  provider = aws.management
-  name     = aws_acm_certificate.certificate_public_facing_view.domain_validation_options[0].resource_record_name
-  type     = aws_acm_certificate.certificate_public_facing_view.domain_validation_options[0].resource_record_type
-  zone_id  = data.aws_route53_zone.live_service_view_lasting_power_of_attorney.zone_id
-  records  = [aws_acm_certificate.certificate_public_facing_view.domain_validation_options[0].resource_record_value]
-  ttl      = 60
+  for_each = {
+    for dvo in aws_acm_certificate.certificate_public_facing_view.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.live_service_view_lasting_power_of_attorney.zone_id
 }
 
 resource "aws_acm_certificate_validation" "certificate_public_facing_view" {
   certificate_arn         = aws_acm_certificate.certificate_public_facing_view.arn
-  validation_record_fqdns = [aws_route53_record.certificate_validation_public_facing_view.fqdn]
+  validation_record_fqdns = [for record in aws_route53_record.certificate_validation_public_facing_view : record.fqdn]
 }
 
 resource "aws_acm_certificate" "certificate_public_facing_view" {

--- a/terraform/account/credentials.tf
+++ b/terraform/account/credentials.tf
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.70.0"
+      version = "~> 3.0"
     }
     local = {
       source  = "hashicorp/local"
@@ -35,8 +35,7 @@ variable "management_role" {
 }
 
 provider "aws" {
-  version = "~> 2.70.0"
-  region  = "eu-west-1"
+  region = "eu-west-1"
 
   assume_role {
     role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
@@ -45,9 +44,8 @@ provider "aws" {
 }
 
 provider "aws" {
-  version = "~> 2.70.0"
-  region  = "eu-west-1"
-  alias   = "management"
+  region = "eu-west-1"
+  alias  = "management"
 
   assume_role {
     role_arn     = "arn:aws:iam::311462405659:role/${var.management_role}"
@@ -56,6 +54,5 @@ provider "aws" {
 }
 
 provider "pagerduty" {
-  version = "~> 1.7.4"
-  token   = var.pagerduty_token
+  token = var.pagerduty_token
 }


### PR DESCRIPTION
## Purpose
Upgrade account Terraform AWS Provider to version 3.

Fixes UML-1030
## Approach

AWS ACM Certificates
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_acm_certificate
There were to options for addressing the change of domain validation records from lists to sets.
Option A was to use the `tolist()` function.

```hcl
resource "aws_route53_record" "certificate_validation_use" {
  provider = aws.management
  name     = tolist(aws_acm_certificate.certificate_use.domain_validation_options)[0].resource_record_name
  type     = tolist(aws_acm_certificate.certificate_use.domain_validation_options)[0].resource_record_type
  zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
  records  = [tolist(aws_acm_certificate.certificate_use.domain_validation_options)[0].resource_record_value]
  ttl      = 60
}

resource "aws_acm_certificate_validation" "certificate_use" {
  certificate_arn         = aws_acm_certificate.certificate_use.arn
  validation_record_fqdns = [aws_route53_record.certificate_validation_use.fqdn]
}
```

This is fine for single records.

Option B was to use `for_each`.
```hcl
resource "aws_route53_record" "certificate_validation_use" {
  for_each = {
    for dvo in aws_acm_certificate.certificate_use.domain_validation_options : dvo.domain_name => {
      name   = dvo.resource_record_name
      record = dvo.resource_record_value
      type   = dvo.resource_record_type
    }
  }

  allow_overwrite = true
  name            = each.value.name
  records         = [each.value.record]
  ttl             = 60
  type            = each.value.type
  zone_id         = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
}

resource "aws_acm_certificate_validation" "certificate_validation_use" {
  certificate_arn         = aws_acm_certificate.certificate_use.arn
  validation_record_fqdns = [for record in aws_route53_record.certificate_validation_use : record.fqdn]
}
```

This works if there is more than one validation to create a record for.

At present, we only need one validation per certificate. But if we implement the `for_each` option, we give ourselves room to add subject alternative names to each certificate. This could be used to consolidate the two certificates for each front end (private beta URL and live service URL) into a single certificate without further refactoring of the domain validation records.

I've gone with option B.

Following this change, it's necessary to move the resources in the state file to resolve the diff in the plan.

```hcl
tf state mv 'aws_route53_record.certificate_validation_public_facing_use' 'aws_route53_record.certificate_validation_public_facing_use["*.use-lasting-power-of-attorney.service.gov.uk"]'
tf state mv 'aws_route53_record.certificate_validation_public_facing_view' 'aws_route53_record.certificate_validation_public_facing_view["*.view-lasting-power-of-attorney.service.gov.uk"]'
tf state mv 'aws_route53_record.certificate_validation_use' 'aws_route53_record.certificate_validation_use["*.use.lastingpowerofattorney.opg.service.justice.gov.uk"]'
tf state mv 'aws_route53_record.certificate_validation_view' 'aws_route53_record.certificate_validation_view["*.view.lastingpowerofattorney.opg.service.justice.gov.uk"]'
```

And due to changes between provider versions, cleaning up the data sources is necessary

```hcl
tf state rm data.aws_availability_zones.default
```
## Learning

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_acm_certificate

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes

