### PR TITLE
UML-934 Death notification page

### DIFF
--- a/service-front/app/config/routes.php
+++ b/service-front/app/config/routes.php
@@ -151,6 +151,10 @@ $actorRoutes = function (Application $app, MiddlewareFactory $factory, Container
         Mezzio\Authentication\AuthenticationMiddleware::class,
         Actor\Handler\InstructionsPreferencesHandler::class
     ], 'lpa.instructions-preferences');
+    $app->get('/lpa/death-notification', [
+        Mezzio\Authentication\AuthenticationMiddleware::class,
+        Actor\Handler\DeathNotificationHandler::class
+    ], 'lpa.death-notification');
 };
 
 switch (getenv('CONTEXT')) {

--- a/service-front/app/features/actor-death-notification.feature
+++ b/service-front/app/features/actor-death-notification.feature
@@ -1,0 +1,22 @@
+@actor @death-notification
+
+Feature: Death Notification
+  As a user
+  I want to be able to inform OPG if the donor, attorney or replacement attorney dies
+  So that my account is accurate
+
+  Background:
+    Given I am a user of the lpa application
+    And I am currently signed in
+    And I have added an LPA to my account
+
+  @ui
+  Scenario Outline: A user can view the death notification page
+    Given I am on the change details page
+    When I select to find out more if a <donor> dies
+    Then I expect to be on the death notification page
+    Examples:
+      | donor |
+      |the donor or an attorney dies|
+      |the donor dies|
+      |the attorney dies|

--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -3506,4 +3506,29 @@ class AccountContext implements Context
     {
         assertFalse($this->elementisOpen('.govuk-details'));
     }
+
+    /**
+     * @Given /^I am on the change details page$/
+     */
+    public function iAmOnTheChangeDetailsPage()
+    {
+        $this->ui->visit('/lpa/change-details');
+        $this->ui->assertPageAddress('/lpa/change-details');
+    }
+
+    /**
+     * @When /^I select to find out more if a (.*) dies$/
+     */
+    public function iSelectToFindOutMoreIfADies($link)
+    {
+        $this->ui->clickLink($link);
+    }
+
+    /**
+     * @Then /^I expect to be on the death notification page$/
+     */
+    public function iExpectToBeOnTheDeathNotificationPage()
+    {
+        $this->ui->assertPageAddress('/lpa/death-notification');
+    }
 }

--- a/service-front/app/src/Actor/src/Handler/DeathNotificationHandler.php
+++ b/service-front/app/src/Actor/src/Handler/DeathNotificationHandler.php
@@ -5,24 +5,21 @@ declare(strict_types=1);
 namespace Actor\Handler;
 
 use Common\Handler\AbstractHandler;
-use Common\Handler\SessionAware;
-use Common\Handler\Traits\Session as SessionTrait;
 use Common\Handler\Traits\User;
-use Common\Handler\UserAware;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Mezzio\Authentication\AuthenticationInterface;
 use Mezzio\Helper\UrlHelper;
 use Mezzio\Template\TemplateRendererInterface;
 use Laminas\Diactoros\Response\HtmlResponse;
+use Common\Handler\UserAware;
 
 /**
- * Class ChangeDetailsHandler
- *
+ * Class DeathNotificationHandler
  * @package Actor\Handler
  * @codeCoverageIgnore
  */
-class ChangeDetailsHandler extends AbstractHandler implements UserAware
+class DeathNotificationHandler extends AbstractHandler implements UserAware
 {
     use User;
 
@@ -42,16 +39,16 @@ class ChangeDetailsHandler extends AbstractHandler implements UserAware
      * @param ServerRequestInterface $request
      * @return ResponseInterface
      */
+
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        // coming from the 'your details' page, there will not be an actorLpaToken
         $actorLpaToken = !empty($request->getQueryParams()) ? $request->getQueryParams()['lpa'] : 'null';
 
         $user = $this->getUser($request);
 
-        return new HtmlResponse($this->renderer->render('actor::change-details', [
+        return new HtmlResponse($this->renderer->render('actor::death-notification', [
             'actorToken' => $actorLpaToken,
-            'user' => $user,
+            'user' => $user
         ]));
     }
 }

--- a/service-front/app/src/Actor/templates/actor/change-details.html.twig
+++ b/service-front/app/src/Actor/templates/actor/change-details.html.twig
@@ -32,6 +32,11 @@
                         <li>the donor or an attorney has changed their name by marriage or deed poll</li>
                         <li>the donor's or an attorney's name or address is misspelt</li>
                         <li>a date of birth is wrong</li>
+                        {% if actorToken != 'null' %}
+                            <li><a class="govuk-link" href="{{ path('lpa.death-notification', {}, {'lpa': actorToken}) }}">the donor or an attorney dies</a></li>
+                        {% else %}
+                            <li><a class="govuk-link" href="{{ path('lpa.death-notification') }}">the donor or an attorney dies</a></li>
+                        {% endif %}
                     </ul>
 
                     <p class="govuk-body">We’ll update the online <abbr title="lasting power of attorney">LPA</abbr> summary and our records.</p>
@@ -64,6 +69,25 @@
                       Birmingham<br>
                       B2 2WH
                     </p>
+
+                    {{ include('@partials/section-break.html.twig') }}
+
+                    <h2 class="govuk-heading-m govuk-!-margin-top-6">Let us know if a donor or attorney dies</h2>
+
+                    <p class="govuk-body">It's important that we hold up-to-date information about donors and attorneys.
+                        This is because an LPA will end when the donor dies, and can end if an attorney dies.</p>
+
+                    <p class="govuk-body">Find out more about what to do if:</p>
+
+                    <ul class="govuk-list">
+                        {% if actorToken != 'null' %}
+                            <li><a class="govuk-link" href="{{ path('lpa.death-notification', {}, {'lpa': actorToken}) }}">the donor dies</a></li>
+                            <li><a class="govuk-link" href="{{ path('lpa.death-notification', {}, {'lpa': actorToken}) }}">the attorney dies</a></li>
+                        {% else %}
+                            <li><a class="govuk-link" href="{{ path('lpa.death-notification') }}">the donor dies</a></li>
+                            <li><a class="govuk-link" href="{{ path('lpa.death-notification') }}">the attorney dies</a></li>
+                        {% endif %}
+                    </ul>
 
                 </div>
             </div>

--- a/service-front/app/src/Actor/templates/actor/death-notification.html.twig
+++ b/service-front/app/src/Actor/templates/actor/death-notification.html.twig
@@ -1,0 +1,81 @@
+{% extends '@actor/layout.html.twig' %}
+
+{% block html_title %}Death Notification - {{ parent() }} {% endblock %}
+
+{% block content %}
+
+    <div class="govuk-width-container">
+        {{ include('@actor/partials/new-use-service.html.twig') }}
+
+        {{ include('@partials/account-bar.html.twig') }}
+
+        {% if actorToken != 'null' %}
+            <a href="{{ path('lpa.change-details', {}, {'lpa': actorToken}) }}" class="govuk-back-link">Back</a>
+        {% else %}
+            <a href="{{ path('lpa.change-details') }}" class="govuk-back-link">Back</a>
+        {% endif %}
+
+        <main class="govuk-main-wrapper" id="main-content" role="main">
+
+            <div class="govuk-grid-row">
+
+                <div class="govuk-grid-column-two-thirds">
+                    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">Let us know if a donor or attorney dies</h1>
+
+                    <p class="govuk-body">
+                        It's important that we hold up-to-date information about donors and attorneys.
+                        This is because an LPA will end when the donor dies, and they can end if an attorney dies.
+                    </p>
+                    <p class="govuk-body">You should contact us if:</p>
+                    <ul class="govuk-list govuk-list--bullet">
+                        <li>the donor dies</li>
+                        <li>an attorney dies</li>
+                        <li>a replacement attorney dies</li>
+                    </ul>
+
+                    <p class="govuk-body">We'll update the online LPA summary and our records</p>
+
+                    <h2 class="govuk-heading-m">If the donor dies</h2>
+                    <p class="govuk-body">
+                        The LPA ends when the donor dies. The donor’s affairs will be looked after
+                        by their executors or personal representatives from that point, not their attorneys.
+                    </p>
+
+                    <h2 class="govuk-heading-m">If an attorney or replacement attorney dies</h2>
+                    <p class="govuk-body">The LPA will end if your attorney dies and there is not a replacement attorney.</p>
+
+                    <p class="govuk-body">The LPA can continue if:</p>
+
+                    <ul class="govuk-list govuk-list--bullet">
+                        <li>there are other attorneys who can act 'jointly and severally' -
+                            but not if they are only allowed to act ‘jointly’</li>
+                        <li>there are replacement attorneys</li>
+                    </ul>
+
+                    <h2 class="govuk-heading-m">How to let us know</h2>
+                    <p class="govuk-body">You'll need to send us:</p>
+
+                    <ul class="govuk-list govuk-list--bullet">
+                        <li>a copy of the death certificate</li>
+                        <li>the original LPA</li>
+                        <li>all certified copies of the LPA</li>
+                        <li>a return address where your documents can be sent back to</li>
+                    </ul>
+                    <div class="govuk-inset-text">
+                        <p class="govuk-body">
+                            Office of the Public Guardian<br>
+                            PO Box 16185<br>
+                            Birmingham<br>
+                            B2 2WH
+                        </p>
+                    </div>
+                    <p class="govuk-body">
+                        <a class="govuk-link" href="mailto:customerservices@publicguardian.gov.uk">customerservices@publicguardian.gov.uk</a>
+                        <br>
+                    </p>
+                </div>
+            </div>
+        </main>
+    </div>
+
+{% endblock %}


### PR DESCRIPTION
# Purpose

Informs users of what to do if a donor or attorney dies. The new death notification page can be accessed from the change details page

Fixes UML-934

## Approach

Created new handler, route and twig file. Added links to the death notification page on the change details twig, with alternate routes depending on whether the user has access the change details page from the lpa summary where the actorLpaToken exists and can be used for navigating back

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes
