### PR TITLE
Uml 1000 add twig extension code

### DIFF
--- a/service-front/app/src/Actor/src/Form/ChangeEmail.php
+++ b/service-front/app/src/Actor/src/Form/ChangeEmail.php
@@ -74,11 +74,6 @@ class ChangeEmail extends AbstractForm implements InputFilterProviderInterface
                     [
                         'name'                   => EmailAddressValidator::class,
                         'break_chain_on_failure' => true,
-                        'options'                => [
-                            'messages' => [
-                                EmailAddressValidator::INVALID => 'Enter an email address in the correct format, like name@example.com',
-                            ],
-                        ],
                     ]
                 ],
             ],

--- a/service-front/app/src/Actor/src/Form/CreateAccount.php
+++ b/service-front/app/src/Actor/src/Form/CreateAccount.php
@@ -24,16 +24,6 @@ class CreateAccount extends AbstractForm implements InputFilterProviderInterface
 {
     const FORM_NAME = 'create_account';
 
-    public const NEW_EMAIL_CONFLICT = 'NewEmailConflict';
-
-    /**
-     * Error messages
-     * @var array
-     */
-    protected array $messageTemplates = [
-        self::NEW_EMAIL_CONFLICT => 'Sorry, there was a problem with that email address. Please try a different one'
-    ];
-
     /**
      * CreateAccount constructor.
      * @param CsrfGuardInterface $csrfGuard

--- a/service-front/app/src/Actor/src/Form/Login.php
+++ b/service-front/app/src/Actor/src/Form/Login.php
@@ -64,7 +64,7 @@ class Login extends AbstractForm implements InputFilterProviderInterface
                         'break_chain_on_failure' => true,
                         'options'                => [
                             'messages'           => [
-                                NotEmpty::IS_EMPTY => 'Enter your email address',
+                                NotEmpty::IS_EMPTY => 'Enter an email address in the correct format, like name@example.com',
                             ],
                         ],
                     ],

--- a/service-front/app/src/Actor/src/Form/Login.php
+++ b/service-front/app/src/Actor/src/Form/Login.php
@@ -64,7 +64,7 @@ class Login extends AbstractForm implements InputFilterProviderInterface
                         'break_chain_on_failure' => true,
                         'options'                => [
                             'messages'           => [
-                                NotEmpty::IS_EMPTY => 'Enter an email address in the correct format, like name@example.com',
+                                NotEmpty::IS_EMPTY => 'Enter your email address',
                             ],
                         ],
                     ],

--- a/service-front/app/src/Actor/templates/actor/change-email.html.twig
+++ b/service-front/app/src/Actor/templates/actor/change-email.html.twig
@@ -3,6 +3,26 @@
 {% block html_title %}Change your email address - {{ parent() }} {% endblock %}
 
 {% block content %}
+    {{
+    translate_validation_messages(form,
+        {
+            '__csrf' :
+            {
+                'notSame'              : 'As you have not used this service for over 20 minutes, the page has timed out. We\'ve now refreshed the page - please try to sign in again' | trans,
+            },
+            'new_email_address' :
+            {
+                'isEmpty'              : 'Enter your new email address' | trans,
+                'invalidEmailAddress'  : 'Enter an email address in the correct format, like name@example.com' | trans,
+                'NewEmailNotDifferent' : 'he new email address you entered is the same as your current email address. They must be different.' | trans
+            },
+            'current_password' :
+            {
+                'isEmpty'              : 'Enter your password' | trans,
+                'invalidPassword'      : 'The password you entered is incorrect' | trans
+            }
+        })
+    }}
     <div class="govuk-width-container">
         {{ include('@actor/partials/new-use-service.html.twig') }}
 

--- a/service-front/app/src/Actor/templates/actor/check-lpa.html.twig
+++ b/service-front/app/src/Actor/templates/actor/check-lpa.html.twig
@@ -3,6 +3,19 @@
 {% block html_title %}Is this the LPA you want to add? - {{ parent() }} {% endblock %}
 
 {% block content %}
+    {{
+    translate_validation_messages(form,
+        {
+            '__csrf' :
+            {
+                'notSame'              : 'As you have not used this service for over 20 minutes, the page has timed out. We\'ve now refreshed the page - please try to sign in again' | trans,
+            },
+            'org_name' :
+            {
+                'isEmpty'              : 'Enter an organisation name' | trans
+            }
+        })
+    }}
     <div class="govuk-width-container">
         {{ include('@actor/partials/new-use-service.html.twig') }}
 

--- a/service-front/app/src/Actor/templates/actor/create-account.html.twig
+++ b/service-front/app/src/Actor/templates/actor/create-account.html.twig
@@ -3,6 +3,38 @@
 {% block html_title %}Create an account - {{ parent() }} {% endblock %}
 
 {% block content %}
+    {{
+    translate_validation_messages(form,
+        {
+            '__csrf' :
+            {
+                'notSame'              : 'As you have not used this service for over 20 minutes, the page has timed out. We\'ve now refreshed the page - please try to sign in again' | trans,
+            },
+            'email' :
+            {
+                'isEmpty'              : 'Enter an email address in the correct format, like name@example.com' | trans,
+                'invalidEmailAddress'  : 'Enter an email address in the correct format, like name@example.com' | trans,
+            },
+            'password' :
+            {
+                'isEmpty'              : 'Enter your password' | trans,
+                'stringLengthTooShort' : 'Password must be 8 characters or more' | trans,
+                'notSame'              : 'Passwords do not match' | trans,
+                'mustIncludeDigit'     : 'Password must include a number' | trans,
+                'mustIncludeLowerCase' : 'Password must include a lower case letter' | trans,
+                'mustIncludeUpperCase' : 'Password must include a capital letter' | trans,
+            },
+            'password_confirm' :
+            {
+                'isEmpty'              : 'Confirm your password' | trans
+            },
+            'terms' :
+            {
+                'notSame'              : 'You must accept the terms of use to create an account' | trans,
+                'error_message'        : 'You must accept the terms of use to create an account' | trans
+            }
+        })
+    }}
 <div class="govuk-width-container">
     {{ include('@actor/partials/new-use-service.html.twig') }}
 

--- a/service-front/app/src/Actor/templates/actor/home-page.html.twig
+++ b/service-front/app/src/Actor/templates/actor/home-page.html.twig
@@ -5,6 +5,19 @@
 {% block service_name %}Use a lasting power of attorney{% endblock %}
 
 {% block content %}
+    {{
+    translate_validation_messages(form,
+        {
+            '__csrf' :
+            {
+                'notSame'              : 'As you have not used this service for over 20 minutes, the page has timed out. We\'ve now refreshed the page - please try to sign in again' | trans,
+            },
+            'triageEntry' :
+            {
+                'isEmpty'              : 'Select yes if you have a Use a lasting power of attorney account' | trans
+            }
+        })
+    }}
 <div class="govuk-width-container">
     {{ include('@actor/partials/new-use-service.html.twig') }}
 

--- a/service-front/app/src/Actor/templates/actor/login.html.twig
+++ b/service-front/app/src/Actor/templates/actor/login.html.twig
@@ -8,12 +8,13 @@
         {
             '__csrf' :
             {
-                'notSame'              : 'As you have not used this service for over 20 minutes, the page has timed out. We\'ve now refreshed the page - please try to sign in again' | trans,
+                'notSame'              : 'Security validation failed. Please try again.' | trans,
             },
             'email' :
             {
-                'isEmpty'              : 'Enter your email address' | trans,
+                'isEmpty'              : 'Enter an email address in the correct format, like name@example.com' | trans,
                 'invalidEmailAddress'  : 'Enter an email address in the correct format, like name@example.com' | trans,
+                'invalidLogin'         : 'We cannot find an account with that email address and password'      | trans,
             },
             'password' :
             {

--- a/service-front/app/src/Actor/templates/actor/login.html.twig
+++ b/service-front/app/src/Actor/templates/actor/login.html.twig
@@ -3,6 +3,24 @@
 {% block html_title %}Sign in to your Use a lasting power of attorney account - {{ parent() }} {% endblock %}
 
 {% block content %}
+    {{
+    translate_validation_messages(form,
+        {
+            '__csrf' :
+            {
+                'notSame'              : 'As you have not used this service for over 20 minutes, the page has timed out. We\'ve now refreshed the page - please try to sign in again' | trans,
+            },
+            'email' :
+            {
+                'isEmpty'              : 'Enter your email address' | trans,
+                'invalidEmailAddress'  : 'Enter an email address in the correct format, like name@example.com' | trans,
+            },
+            'password' :
+            {
+                'isEmpty'              : 'Enter your password' | trans
+            }
+        })
+    }}
 <div class="govuk-width-container">
     {{ include('@actor/partials/new-use-service.html.twig') }}
 

--- a/service-front/app/src/Actor/templates/actor/lpa-add.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-add.html.twig
@@ -20,9 +20,9 @@
         {
             'stringLengthTooShort' : 'The LPA reference number you entered is too short' | trans,
             'stringLengthTooLong'  : 'The LPA reference number you entered is too long'  | trans,
-            'regexNotMatch'        : 'Enter the 12 numbers of the LPA reference number.Do not include letters or other characters' | trans,
-            'regexInvalid'         : 'Enter the 12 numbers of the LPA reference number.Do not include letters or other characters' | trans,
-            'regexErrorous'        : 'Enter the 12 numbers of the LPA reference number.Do not include letters or other characters' | trans,
+            'regexNotMatch'        : 'Enter the 12 numbers of the LPA reference number. Do not include letters or other characters' | trans,
+            'regexInvalid'         : 'Enter the 12 numbers of the LPA reference number. Do not include letters or other characters' | trans,
+            'regexErrorous'        : 'Enter the 12 numbers of the LPA reference number. Do not include letters or other characters' | trans,
         },
         'dob' :
         {

--- a/service-front/app/src/Actor/templates/actor/lpa-add.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-add.html.twig
@@ -6,6 +6,10 @@
     {{
     translate_validation_messages(form,
     {
+        '__csrf' :
+        {
+            'notSame'              : 'As you have not used this service for over 20 minutes, the page has timed out. We\'ve now refreshed the page - please try to sign in again' | trans,
+        },
         'passcode' :
         {
             'isEmpty'              : 'Enter your activation key' | trans,

--- a/service-front/app/src/Actor/templates/actor/lpa-add.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-add.html.twig
@@ -3,6 +3,34 @@
 {% block html_title %}Add a lasting power of attorney - {{ parent() }} {% endblock %}
 
 {% block content %}
+    {{
+    translate_validation_messages(form,
+    {
+        'passcode' :
+        {
+            'isEmpty': 'Enter your activation key' | trans,
+            'stringLengthTooShort' : 'Your activation key is too short' | trans
+        },
+        'reference_number' :
+        {
+            'stringLengthTooShort':  'The LPA reference number you entered is too short' | trans,
+            'regexNotMatch' : 'Enter the 12 numbers of the LPA reference number.Do not include letters or other characters' | trans
+
+        },
+        'dob' :
+        {
+            'dateEmpty': 'Enter your date of birth1' | trans,
+            'dateInvalidFormat' : 'Date of birth value must be provided in an array' | trans,
+            'dateEmpty' :'Enter your date of birth' | trans,
+            'dateInvalid' :  'Date of birth must be a real date' | trans,
+            'dayIncomplete':  'Date of birth must include a day' | trans,
+            'monthIncomplete' : 'Date of birth must include a month' |trans,
+            'yearIncomplete' : 'Date of birth must include a year' | trans,
+            'ageNegative': 'Date of birth must be in the past' | trans,
+            'ageTooYoung':'Check your date of birth is correct - you cannot be an attorney or donor if you’re under 18' | trans
+        }
+    })
+    }}
 <div class="govuk-width-container">
     {{ include('@actor/partials/new-use-service.html.twig') }}
 

--- a/service-front/app/src/Actor/templates/actor/lpa-add.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-add.html.twig
@@ -5,41 +5,41 @@
 {% block content %}
     {{
     translate_validation_messages(form,
-    {
-        '__csrf' :
         {
-            'notSame'              : 'As you have not used this service for over 20 minutes, the page has timed out. We\'ve now refreshed the page - please try to sign in again' | trans,
-        },
-        'passcode' :
-        {
-            'isEmpty'              : 'Enter your activation key' | trans,
-            'stringLengthTooShort' : 'Enter an activation key in the correct format' | trans,
-            'stringLengthTooLong'  : 'Enter an activation key in the correct format' | trans,
-            'stringLengthInvalid'  : 'Enter an activation key in the correct format' | trans,
-            'regexNotMatch'        : 'Enter an activation key in the correct format' | trans,
-            'regexInvalid'         : 'Enter an activation key in the correct format' | trans,
-            'regexErrorous'        : 'Enter an activation key in the correct format' | trans,
-        },
-        'reference_number' :
-        {
-            'stringLengthTooShort' : 'The LPA reference number you entered is too short' | trans,
-            'stringLengthTooLong'  : 'The LPA reference number you entered is too long'  | trans,
-            'regexNotMatch'        : 'Enter the 12 numbers of the LPA reference number. Do not include letters or other characters' | trans,
-            'regexInvalid'         : 'Enter the 12 numbers of the LPA reference number. Do not include letters or other characters' | trans,
-            'regexErrorous'        : 'Enter the 12 numbers of the LPA reference number. Do not include letters or other characters' | trans,
-        },
-        'dob' :
-        {
-            'dateInvalidFormat' : 'Date of birth value must be provided in an array' | trans,
-            'dateEmpty'         : 'Enter your date of birth' | trans,
-            'dateInvalid'       : 'Date of birth must be a real date' | trans,
-            'dayIncomplete'     : 'Date of birth must include a day'  | trans,
-            'monthIncomplete'   : 'Date of birth must include a month'| trans,
-            'yearIncomplete'    : 'Date of birth must include a year' | trans,
-            'ageNegative'       : 'Date of birth must be in the past' | trans,
-            'ageTooYoung'       : 'Check your date of birth is correct - you cannot be an attorney or donor if you’re under 18' | trans
-        }
-    })
+            '__csrf' :
+            {
+                'notSame'              : 'As you have not used this service for over 20 minutes, the page has timed out. We\'ve now refreshed the page - please try to sign in again' | trans,
+            },
+            'passcode' :
+            {
+                'isEmpty'              : 'Enter your activation key' | trans,
+                'stringLengthTooShort' : 'Enter an activation key in the correct format' | trans,
+                'stringLengthTooLong'  : 'Enter an activation key in the correct format' | trans,
+                'stringLengthInvalid'  : 'Enter an activation key in the correct format' | trans,
+                'regexNotMatch'        : 'Enter an activation key in the correct format' | trans,
+                'regexInvalid'         : 'Enter an activation key in the correct format' | trans,
+                'regexErrorous'        : 'Enter an activation key in the correct format' | trans,
+            },
+            'reference_number' :
+            {
+                'stringLengthTooShort' : 'The LPA reference number you entered is too short' | trans,
+                'stringLengthTooLong'  : 'The LPA reference number you entered is too long'  | trans,
+                'regexNotMatch'        : 'Enter the 12 numbers of the LPA reference number. Do not include letters or other characters' | trans,
+                'regexInvalid'         : 'Enter the 12 numbers of the LPA reference number. Do not include letters or other characters' | trans,
+                'regexErrorous'        : 'Enter the 12 numbers of the LPA reference number. Do not include letters or other characters' | trans,
+            },
+            'dob' :
+            {
+                'dateInvalidFormat' : 'Date of birth value must be provided in an array' | trans,
+                'dateEmpty'         : 'Enter your date of birth' | trans,
+                'dateInvalid'       : 'Date of birth must be a real date' | trans,
+                'dayIncomplete'     : 'Date of birth must include a day'  | trans,
+                'monthIncomplete'   : 'Date of birth must include a month'| trans,
+                'yearIncomplete'    : 'Date of birth must include a year' | trans,
+                'ageNegative'       : 'Date of birth must be in the past' | trans,
+                'ageTooYoung'       : 'Check your date of birth is correct - you cannot be an attorney or donor if you’re under 18' | trans
+            }
+        })
     }}
 <div class="govuk-width-container">
     {{ include('@actor/partials/new-use-service.html.twig') }}
@@ -65,13 +65,7 @@
                     {{ govuk_form_element(form.get('__csrf')) }}
 
 
-                    {{ govuk_form_element(form.get('reference_number'),
-                        {
-                            'label': 'LPA reference number' | trans,
-                            'hint': 'LPA reference numbers are 12 numbers long<br/>For example, 7000-0000-0000' |trans,
-                            'attr' : {'class': 'govuk-input--width-20'}
-                        })
-                    }}
+                    {{ govuk_form_element(form.get('reference_number'), { 'label': 'LPA reference number', 'hint': 'LPA reference numbers are 12 numbers long<br/>For example, 7000-0000-0000', 'attr' : {'class': 'govuk-input--width-20'} }) }}
 
                     <details class="govuk-details" data-module="govuk-details">
                         <summary class="govuk-details__summary">
@@ -93,14 +87,7 @@
 
                     <p class="govuk-body">The donor and each of the attorneys will have their own activation key. The activation key and date of birth must be for the same person.</p>
 
-                    {{ govuk_form_element(form.get('passcode'),
-                        {
-                            'label': 'Activation key' | trans,
-                            'hint': 'Activation keys are 13 letters and numbers long and start with a C<br/>For example, C-AB12 CD34 EF56' | trans,
-                            'input_prefix': 'C - ',
-                            'attr' : {'class': 'govuk-input--width-10'}
-                        })
-                    }}
+                    {{ govuk_form_element(form.get('passcode'), { 'label': 'Activation key', 'hint': 'Activation keys are 13 letters and numbers long and start with a C<br/>For example, C-AB12 CD34 EF56', 'input_prefix': 'C - ', 'attr' : {'class': 'govuk-input--width-10'} }) }}
 
                     <details class="govuk-details" data-module="govuk-details">
                         <summary class="govuk-details__summary">
@@ -120,13 +107,7 @@
                     </details>
 
 
-                    {{ govuk_form_fieldset(form.get('dob'),
-                        {
-                            'label': 'What is your date of birth?' | trans,
-                            'hint': 'For example, 31 03 1980' | trans,
-                            'attr': {'class': 'xyz'}
-                        })
-                    }}
+                    {{ govuk_form_fieldset(form.get('dob'), { 'label': 'What is your date of birth?', 'hint': 'For example, 31 03 1980', 'attr': {'class': 'xyz'} }) }}
 
                     <button data-prevent-double-click="true" type="submit" class="govuk-button govuk-!-margin-right-1">Continue</button>
 

--- a/service-front/app/src/Actor/templates/actor/lpa-add.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-add.html.twig
@@ -8,26 +8,32 @@
     {
         'passcode' :
         {
-            'isEmpty': 'Enter your activation key' | trans,
-            'stringLengthTooShort' : 'Your activation key is too short' | trans
+            'isEmpty'              : 'Enter your activation key' | trans,
+            'stringLengthTooShort' : 'Enter an activation key in the correct format' | trans,
+            'stringLengthTooLong'  : 'Enter an activation key in the correct format' | trans,
+            'stringLengthInvalid'  : 'Enter an activation key in the correct format' | trans,
+            'regexNotMatch'        : 'Enter an activation key in the correct format' | trans,
+            'regexInvalid'         : 'Enter an activation key in the correct format' | trans,
+            'regexErrorous'        : 'Enter an activation key in the correct format' | trans,
         },
         'reference_number' :
         {
-            'stringLengthTooShort':  'The LPA reference number you entered is too short' | trans,
-            'regexNotMatch' : 'Enter the 12 numbers of the LPA reference number.Do not include letters or other characters' | trans
-
+            'stringLengthTooShort' : 'The LPA reference number you entered is too short' | trans,
+            'stringLengthTooLong'  : 'The LPA reference number you entered is too long'  | trans,
+            'regexNotMatch'        : 'Enter the 12 numbers of the LPA reference number.Do not include letters or other characters' | trans,
+            'regexInvalid'         : 'Enter the 12 numbers of the LPA reference number.Do not include letters or other characters' | trans,
+            'regexErrorous'        : 'Enter the 12 numbers of the LPA reference number.Do not include letters or other characters' | trans,
         },
         'dob' :
         {
-            'dateEmpty': 'Enter your date of birth1' | trans,
             'dateInvalidFormat' : 'Date of birth value must be provided in an array' | trans,
-            'dateEmpty' :'Enter your date of birth' | trans,
-            'dateInvalid' :  'Date of birth must be a real date' | trans,
-            'dayIncomplete':  'Date of birth must include a day' | trans,
-            'monthIncomplete' : 'Date of birth must include a month' |trans,
-            'yearIncomplete' : 'Date of birth must include a year' | trans,
-            'ageNegative': 'Date of birth must be in the past' | trans,
-            'ageTooYoung':'Check your date of birth is correct - you cannot be an attorney or donor if you’re under 18' | trans
+            'dateEmpty'         : 'Enter your date of birth' | trans,
+            'dateInvalid'       : 'Date of birth must be a real date' | trans,
+            'dayIncomplete'     : 'Date of birth must include a day'  | trans,
+            'monthIncomplete'   : 'Date of birth must include a month'| trans,
+            'yearIncomplete'    : 'Date of birth must include a year' | trans,
+            'ageNegative'       : 'Date of birth must be in the past' | trans,
+            'ageTooYoung'       : 'Check your date of birth is correct - you cannot be an attorney or donor if you’re under 18' | trans
         }
     })
     }}
@@ -55,7 +61,13 @@
                     {{ govuk_form_element(form.get('__csrf')) }}
 
 
-                    {{ govuk_form_element(form.get('reference_number'), { 'label': 'LPA reference number', 'hint': 'LPA reference numbers are 12 numbers long<br/>For example, 7000-0000-0000', 'attr' : {'class': 'govuk-input--width-20'} }) }}
+                    {{ govuk_form_element(form.get('reference_number'),
+                        {
+                            'label': 'LPA reference number' | trans,
+                            'hint': 'LPA reference numbers are 12 numbers long<br/>For example, 7000-0000-0000' |trans,
+                            'attr' : {'class': 'govuk-input--width-20'}
+                        })
+                    }}
 
                     <details class="govuk-details" data-module="govuk-details">
                         <summary class="govuk-details__summary">
@@ -77,7 +89,14 @@
 
                     <p class="govuk-body">The donor and each of the attorneys will have their own activation key. The activation key and date of birth must be for the same person.</p>
 
-                    {{ govuk_form_element(form.get('passcode'), { 'label': 'Activation key', 'hint': 'Activation keys are 13 letters and numbers long and start with a C<br/>For example, C-AB12 CD34 EF56', 'input_prefix': 'C - ', 'attr' : {'class': 'govuk-input--width-10'} }) }}
+                    {{ govuk_form_element(form.get('passcode'),
+                        {
+                            'label': 'Activation key' | trans,
+                            'hint': 'Activation keys are 13 letters and numbers long and start with a C<br/>For example, C-AB12 CD34 EF56' | trans,
+                            'input_prefix': 'C - ',
+                            'attr' : {'class': 'govuk-input--width-10'}
+                        })
+                    }}
 
                     <details class="govuk-details" data-module="govuk-details">
                         <summary class="govuk-details__summary">
@@ -97,7 +116,13 @@
                     </details>
 
 
-                    {{ govuk_form_fieldset(form.get('dob'), { 'label': 'What is your date of birth?', 'hint': 'For example, 31 03 1980', 'attr': {'class': 'xyz'} }) }}
+                    {{ govuk_form_fieldset(form.get('dob'),
+                        {
+                            'label': 'What is your date of birth?' | trans,
+                            'hint': 'For example, 31 03 1980' | trans,
+                            'attr': {'class': 'xyz'}
+                        })
+                    }}
 
                     <button data-prevent-double-click="true" type="submit" class="govuk-button govuk-!-margin-right-1">Continue</button>
 

--- a/service-front/app/src/Actor/templates/actor/lpa-create-viewercode.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-create-viewercode.html.twig
@@ -3,6 +3,19 @@
 {% block html_title %}Which organisation do you want to give access to - {{ parent() }} {% endblock %}
 
 {% block content %}
+    {{
+    translate_validation_messages(form,
+        {
+            '__csrf' :
+            {
+                'notSame' : 'As you have not used this service for over 20 minutes, the page has timed out. We\'ve now refreshed the page - please try to sign in again' | trans
+            },
+            'org_name' :
+            {
+                'isEmpty' : 'Enter an organisation name' | trans
+            }
+        })
+    }}
     <div class="govuk-width-container">
         {{ include('@actor/partials/new-use-service.html.twig') }}
 

--- a/service-front/app/src/Actor/templates/actor/password-change.html.twig
+++ b/service-front/app/src/Actor/templates/actor/password-change.html.twig
@@ -3,6 +3,33 @@
 {% block html_title %}Change your password - {{ parent() }} {% endblock %}
 
 {% block content %}
+    {{
+    translate_validation_messages(form,
+        {
+            '__csrf' :
+            {
+                'notSame'              : 'As you have not used this service for over 20 minutes, the page has timed out. We\'ve now refreshed the page - please try to sign in again' | trans,
+            },
+            'current_password' :
+            {
+                'isEmpty'              : 'Enter your current password' | trans,
+                'invalidPassword'      : 'Current password is incorrect' | trans,
+            },
+            'new_password' :
+            {
+                'isEmpty'              : 'Enter your new password' | trans,
+                'stringLengthTooShort' : 'Enter your new password' | trans,
+                'notSame'              : 'New password and confirm new password do not match' | trans,
+                'mustIncludeDigit'     : 'Password must include a number' | trans,
+                'mustIncludeLowerCase' : 'Password must include a lower case letter' | trans,
+                'mustIncludeUpperCase' : 'Password must include a capital letter' | trans,
+            },
+            'new_password_confirm' :
+            {
+                'isEmpty'              : 'Enter your password again to confirm it' | trans
+            }
+        })
+    }}
     <div class="govuk-width-container">
         {{ include('@actor/partials/new-use-service.html.twig') }}
 

--- a/service-front/app/src/Actor/templates/actor/password-change.html.twig
+++ b/service-front/app/src/Actor/templates/actor/password-change.html.twig
@@ -18,7 +18,7 @@
             'new_password' :
             {
                 'isEmpty'              : 'Enter your new password' | trans,
-                'stringLengthTooShort' : 'Enter your new password' | trans,
+                'stringLengthTooShort' : 'Password must be 8 characters or more' | trans,
                 'notSame'              : 'New password and confirm new password do not match' | trans,
                 'mustIncludeDigit'     : 'Password must include a number' | trans,
                 'mustIncludeLowerCase' : 'Password must include a lower case letter' | trans,

--- a/service-front/app/src/Actor/templates/actor/password-reset-request.html.twig
+++ b/service-front/app/src/Actor/templates/actor/password-reset-request.html.twig
@@ -3,6 +3,25 @@
 {% block html_title %}Reset your password - {{ parent() }}{% endblock %}
 
 {% block content %}
+    {{
+    translate_validation_messages(form,
+        {
+            '__csrf' :
+            {
+                'notSame'              : 'As you have not used this service for over 20 minutes, the page has timed out. We\'ve now refreshed the page - please try to sign in again' | trans,
+            },
+            'email' :
+            {
+                'isEmpty'              : 'Enter an email address in the correct format, like name@example.com' | trans,
+                'invalidEmailAddress'  : 'Enter an email address in the correct format, like name@example.com' | trans,
+            },
+            'email_confirm' :
+            {
+                'isEmpty'              : 'Confirm your email address' | trans,
+                'notSame'              : 'The emails did not match'   | trans,
+            }
+        })
+    }}
 <div class="govuk-width-container">
     {{ include('@actor/partials/new-use-service.html.twig') }}
 

--- a/service-front/app/src/Actor/templates/actor/password-reset.html.twig
+++ b/service-front/app/src/Actor/templates/actor/password-reset.html.twig
@@ -3,6 +3,28 @@
 {% block html_title %}Change your password - {{ parent() }} {% endblock %}
 
 {% block content %}
+    {{
+    translate_validation_messages(form,
+        {
+            '__csrf' :
+            {
+                'notSame'              : 'As you have not used this service for over 20 minutes, the page has timed out. We\'ve now refreshed the page - please try to sign in again' | trans,
+            },
+            'password' :
+            {
+                'isEmpty'              : 'Enter your password' | trans,
+                'stringLengthTooShort' : 'Password must be 8 characters or more' | trans,
+                'notSame'              : 'New password and confirm new password do not match' | trans,
+                'mustIncludeDigit'     : 'Password must include a number' | trans,
+                'mustIncludeLowerCase' : 'Password must include a lower case letter' | trans,
+                'mustIncludeUpperCase' : 'Password must include a capital letter' | trans,
+            },
+            'password_confirm' :
+            {
+                'isEmpty'              : 'Confirm your password' | trans
+            }
+        })
+    }}
     <div class="govuk-width-container">
         {{ include('@actor/partials/new-use-service.html.twig') }}
 

--- a/service-front/app/src/Common/src/Form/AbstractForm.php
+++ b/service-front/app/src/Common/src/Form/AbstractForm.php
@@ -20,8 +20,7 @@ abstract class AbstractForm extends Form
      * @var array
      */
     protected array $messageTemplates = [
-        self::NOT_SAME=> "As you have not used this service for over 20 minutes," .
-            "the page has timed out. We've now refreshed the page - please try to sign in again."
+        self::NOT_SAME=> "As you have not used this service for over 20 minutes, the page has timed out. We've now refreshed the page - please try to sign in again."
     ];
 
     /**

--- a/service-front/app/src/Common/src/Validator/EmailAddressValidator.php
+++ b/service-front/app/src/Common/src/Validator/EmailAddressValidator.php
@@ -7,6 +7,12 @@ use Laminas\Validator\EmailAddress as LaminasEmailAddressValidator;
 class EmailAddressValidator extends LaminasEmailAddressValidator
 {
     /**
+     * Error codes
+     * @const string
+     */
+    const INVALID_EMAIL = 'invalidEmailAddress';
+
+    /**
      * Overridden function to translate error messages
      *
      * @param string $value
@@ -18,7 +24,7 @@ class EmailAddressValidator extends LaminasEmailAddressValidator
 
         if ($valid === false && count($this->getMessages()) > 0) {
             $this->abstractOptions['messages'] = [
-                'Enter an email address in the correct format, like name@example.com'
+                self::INVALID_EMAIL => 'Enter an email address in the correct format, like name@example.com'
             ];
         }
 

--- a/service-front/app/src/Common/src/View/Twig/GovUKLaminasFormErrorsExtension.php
+++ b/service-front/app/src/Common/src/View/Twig/GovUKLaminasFormErrorsExtension.php
@@ -12,16 +12,29 @@ use Laminas\Form\FormInterface;
 
 class GovUKLaminasFormErrorsExtension extends AbstractExtension
 {
-    const THEME_FILE = '@partials/govuk_error.html.twig';
+    public const THEME_FILE = '@partials/govuk_error.html.twig';
 
     /**
      * @return array
+     * @inheritDoc
      */
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('govuk_error', [$this, 'errorMessage'], ['needs_environment' => true, 'is_safe' => ['html']]),
-            new TwigFunction('govuk_error_summary', [$this, 'errorSummary'], ['needs_environment' => true, 'is_safe' => ['html']])
+            new TwigFunction(
+                'govuk_error',
+                [$this, 'errorMessage'],
+                ['needs_environment' => true, 'is_safe' => ['html']]
+            ),
+            new TwigFunction(
+                'govuk_error_summary',
+                [$this, 'errorSummary'],
+                ['needs_environment' => true, 'is_safe' => ['html']]
+            ),
+            new TwigFunction(
+                "translate_validation_messages",
+                [$this,'applyTranslatedMessages']
+            ),
         ];
     }
 
@@ -33,6 +46,7 @@ class GovUKLaminasFormErrorsExtension extends AbstractExtension
      * @throws \Twig\Error\LoaderError
      * @throws \Twig\Error\RuntimeError
      * @throws \Twig\Error\SyntaxError
+     * Generate an error message
      */
     public function errorMessage(Environment $twigEnv, ElementInterface $element): string
     {
@@ -52,18 +66,31 @@ class GovUKLaminasFormErrorsExtension extends AbstractExtension
      * @throws \Twig\Error\LoaderError
      * @throws \Twig\Error\RuntimeError
      * @throws \Twig\Error\SyntaxError
+     * Generate an error summary
      */
     public function errorSummary(Environment $twigEnv, FormInterface $form): string
     {
         $template = $twigEnv->load(self::THEME_FILE);
 
         // if the form has no overall errors it'll be an empty array
+
+        $returnedErrors = $form->getMessages();
         $errors = $form->getMessages();
         $invalidInput = $form->getInputFilter()->getInvalidInput();
 
         //  Flatten each set of messages for each input
         foreach ($invalidInput as $name => $input) {
-            $errors[$name] = $this->flattenMessages($input->getMessages());
+            $inputMessages = $input->getMessages();
+
+            // check and replace where you can the error message.
+            foreach ($inputMessages as $key => $value) {
+                if (key_exists($name, $returnedErrors) && key_exists($key, $returnedErrors[$name])) {
+                    $inputMessages[$key] = $returnedErrors[$name][$key];
+                }
+            }
+
+            // this sets the error array format needed for the sumary render.
+            $errors[$name] = $this ->flattenMessages($inputMessages);
         }
 
         return $template->renderBlock('error_summary', [
@@ -74,6 +101,7 @@ class GovUKLaminasFormErrorsExtension extends AbstractExtension
     /**
      * @param array $messages
      * @return array
+     * Flattens the input validation messages into a form acceptable to the error summary.
      */
     private function flattenMessages(array $messages): array
     {
@@ -84,5 +112,48 @@ class GovUKLaminasFormErrorsExtension extends AbstractExtension
         });
 
         return $messagesToPrint;
+    }
+
+    /**
+     * @param FormInterface $form
+     * @param $messages
+     * Apply  any translated messages, if found in the twig template.
+     */
+    public function applyTranslatedMessages(FormInterface $form, $messages)
+    {
+        //1. retrieve messages that are already set.
+        $formMessages = $form->getMessages();
+
+        //2. replace messages.
+        $replacedErrors = $this->replaceMessages($messages, $formMessages);
+
+        //3. reapply to the form.
+        $form->setMessages($replacedErrors);
+    }
+
+
+    /**
+     * @param $translatedMessages
+     * @param $formMessages
+     * @return array
+     * replaces messages with the translated messages.
+     * this is assumed to be both in the same structure all the way through.
+     */
+    public function replaceMessages($translatedMessages, $formMessages)
+    {
+        $replacedArray = [];
+        foreach ($formMessages as $elementName => $messages) {
+            if (key_exists($elementName, $translatedMessages)) {
+                $result = $translatedMessages[$elementName];
+                $replacedArray[$elementName] = $messages;
+
+                foreach ($replacedArray[$elementName] as $message => $value) {
+                    if (key_exists($message, $result)) {
+                        $replacedArray[$elementName][$message] = $result[$message];
+                    }
+                }
+            }
+        }
+        return $replacedArray;
     }
 }

--- a/service-front/app/src/Common/templates/partials/cookies.html.twig
+++ b/service-front/app/src/Common/templates/partials/cookies.html.twig
@@ -14,6 +14,27 @@
 {% set referer = form.get('referer') %}
 
 {% block content %}
+    {% if routeName == "actor-cookies" %}
+        {{
+        translate_validation_messages(form,
+            {
+                '__csrf' :
+                {
+                    'notSame' : 'As you have not used this service for over 20 minutes, the page has timed out. We\'ve now refreshed the page - please try to sign in again' | trans
+                }
+            })
+        }}
+    {% elseif routeName == "viewer-cookies" %}
+        {{
+        translate_validation_messages(form,
+            {
+                '__csrf' :
+                {
+                    'notSame' : 'Do you want to continue? You have not used this service for 30 minutes. Click continue to use any details you entered' | trans
+                }
+            })
+        }}
+    {% endif %}
     <div class="govuk-width-container">
 
         <a class="govuk-link govuk-back-link" href="{{ form.get('referer').getValue() }}">Back</a>

--- a/service-front/app/src/Viewer/src/Form/ShareCode.php
+++ b/service-front/app/src/Viewer/src/Form/ShareCode.php
@@ -19,9 +19,7 @@ class ShareCode extends AbstractForm implements InputFilterProviderInterface
 
 
     protected array $messageTemplates = [
-        self::NOT_SAME => "Do you want to continue?" .
-            " You have not used this service for 30 minutes." .
-            " Click continue to use any details you entered"
+        self::NOT_SAME => "Do you want to continue? You have not used this service for 30 minutes. Click continue to use any details you entered"
     ];
 
     public function __construct(CsrfGuardInterface $csrfGuard)

--- a/service-front/app/src/Viewer/templates/viewer/enter-code.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/enter-code.html.twig
@@ -6,14 +6,18 @@
     {{
     translate_validation_messages(form,
         {
+            '__csrf' :
+            {
+                'notSame'       : 'As you have not used this service for over 20 minutes, the page has timed out. We\'ve now refreshed the page - please try to sign in again' | trans,
+            },
             'lpa_code':
             {
-                'isEmpty'      : 'Enter your LPA access code' | trans,
+                'isEmpty'       : 'Enter your LPA access code'                  | trans,
                 'regexNotMatch' : 'Enter LPA access code in the correct format' | trans
             },
             'donor_surname':
             {
-                'isEmpty'     : 'Enter the donor\'s last name' | trans
+                'isEmpty'       : 'Enter the donor\'s last name' | trans
             }
         }
 

--- a/service-front/app/src/Viewer/templates/viewer/enter-code.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/enter-code.html.twig
@@ -3,6 +3,22 @@
 {% block html_title %}{% trans %}Enter LPA access code{% endtrans %} - {{ parent() }} {% endblock %}
 
 {% block content %}
+    {{
+    translate_validation_messages(form,
+        {
+            'lpa_code':
+            {
+                'isEmpty'      : 'Enter your LPA access code' | trans,
+                'regexNotMatch' : 'Enter LPA access code in the correct format' | trans
+            },
+            'donor_surname':
+            {
+                'isEmpty'     : 'Enter the donor\'s last name' | trans
+            }
+        }
+
+    )
+    }}
 <div class="govuk-width-container">
     {{ include('@partials/new-service.html.twig') }}
 

--- a/service-front/app/src/Viewer/templates/viewer/enter-code.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/enter-code.html.twig
@@ -8,7 +8,7 @@
         {
             '__csrf' :
             {
-                'notSame'       : 'As you have not used this service for over 20 minutes, the page has timed out. We\'ve now refreshed the page - please try to sign in again' | trans,
+                'notSame'       : 'Do you want to continue? You have not used this service for 30 minutes. Click continue to use any details you entered' | trans,
             },
             'lpa_code':
             {

--- a/service-front/app/test/CommonTest/Validator/EmailAddressValidatorTest.php
+++ b/service-front/app/test/CommonTest/Validator/EmailAddressValidatorTest.php
@@ -9,6 +9,12 @@ use PHPUnit\Framework\TestCase;
 
 class EmailAddressValidatorTest extends TestCase
 {
+    /**
+     * Error codes
+     * @const string
+     */
+    const INVALID_EMAIL = 'invalidEmailAddress';
+
     /** @test */
     public function correctly_validates_known_good_email()
     {
@@ -37,6 +43,6 @@ class EmailAddressValidatorTest extends TestCase
         $valid = $validator->isValid('notan@email');
 
         $this->assertEquals(false, $valid);
-        $this->assertEquals('Enter an email address in the correct format, like name@example.com', $validator->getMessages()[0]);
+        $this->assertEquals('Enter an email address in the correct format, like name@example.com', $validator->getMessages()[self::INVALID_EMAIL]);
     }
 }


### PR DESCRIPTION
# Purpose

This is a DRAFT PR that covers the translation ticket UML-1000.

There is additional code added to the error extension which maps error validation messages, that can be translated added into twig files at the top.
The format aligns roughly so far with what is seen in the error messages that come out of the `$form->getMessages` call.

I ended up writing a custom replacement function to get the strings to map over. This could possibly be improved on, but it mostly works, though YMMV, as it's incomplete, and fails 4 tests right now.

The idea is that we place the validation messages inside the twig files, so we can extract the automatically as part of the translation file generation.
 
To add validation see the example twigs. the format is roughly:

```twig
{{
translate_validation_messages(form, 
 {
            'field_name1': // fieldname
            { //all contained validation messages..
                'validation1'      :   'this is my error 1' | trans,
                'someOtherValidation' : 'this is another error' | trans
            },
            'field_name2':
            {
                'isEmpty'     : 'field 2 is empty' | trans
            }
//..etc
        }
}}
```

## Still to be done:
- fix any test breaks
- Use class constants to reference the messages  and introspection/reflection to work the keys out.
- Further work as mentioned previously to go through each form and place the validation messages in the prescribed format onto the twig files. the examples below are incomplete but should be functional enough.
- further testing on different forms.




## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
