### PR TITLE
Check uids list for donor if it exists

### DIFF
--- a/service-api/app/src/App/src/Service/Lpa/LpaService.php
+++ b/service-api/app/src/App/src/Service/Lpa/LpaService.php
@@ -284,7 +284,9 @@ class LpaService
         if (
             is_null($actor) &&
             isset($lpa['donor']) && is_array($lpa['donor']) &&
-            ((string)$lpa['donor']['id'] === $actorId || $lpa['donor']['uId'] === $actorId)
+            (isset($lpa['donor']['uids'])
+             ? array_search($actorId, $lpa['donor']['uids']) !== false
+             : ((string)$lpa['donor']['id'] === $actorId || $lpa['donor']['uId'] === $actorId))
         ) {
             $actor = $lpa['donor'];
             $actorType = 'donor';

--- a/service-api/app/test/AppTest/Service/Lpa/LpaServiceTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/LpaServiceTest.php
@@ -531,6 +531,30 @@ class LpaServiceTest extends TestCase
     }
 
     /** @test */
+    public function can_find_actor_who_is_a_donor_by_child_uid()
+    {
+        $lpa = [
+            'donor' => [
+                'id'  => 1,
+                'uId' => '123456789013',
+                'uids' => ['123456789013', '123456789012'],
+            ]
+        ];
+
+        $service = $this->getLpaService();
+
+        $result = $service->lookupActiveActorInLpa($lpa, '123456789012');
+
+        $this->assertEquals(
+            [
+                'type' => 'donor',
+                'details' => $lpa['donor'],
+            ],
+            $result
+        );
+    }
+
+    /** @test */
     public function can_find_actor_who_is_an_attorney()
     {
         $lpa = [


### PR DESCRIPTION
# Purpose

Fixes [VEGA-239](https://opgtransform.atlassian.net/browse/VEGA-239)

## Approach

The API will be changed to have a `donor.uids` property listing the UIDs for the (parent) donor and any children. If this is sent back we check this list for the actor on the code, as the code could have been created with either the parent or a child donor. All other information in `donor` will relate to the parent, for DOB matching.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
