### PR TITLE
increase to 4 for the weekend

### DIFF
--- a/terraform/environment/actor_ecs.tf
+++ b/terraform/environment/actor_ecs.tf
@@ -5,7 +5,7 @@ resource "aws_ecs_service" "actor" {
   name             = "actor"
   cluster          = aws_ecs_cluster.use-an-lpa.id
   task_definition  = aws_ecs_task_definition.actor.arn
-  desired_count    = 2
+  desired_count    = 4
   launch_type      = "FARGATE"
   platform_version = "1.4.0"
 

--- a/terraform/environment/api_ecs.tf
+++ b/terraform/environment/api_ecs.tf
@@ -5,7 +5,7 @@ resource "aws_ecs_service" "api" {
   name             = "api"
   cluster          = aws_ecs_cluster.use-an-lpa.id
   task_definition  = aws_ecs_task_definition.api.arn
-  desired_count    = 2
+  desired_count    = 4
   launch_type      = "FARGATE"
   platform_version = "1.4.0"
 

--- a/terraform/environment/pdf_ecs.tf
+++ b/terraform/environment/pdf_ecs.tf
@@ -5,7 +5,7 @@ resource "aws_ecs_service" "pdf" {
   name             = "pdf"
   cluster          = aws_ecs_cluster.use-an-lpa.id
   task_definition  = aws_ecs_task_definition.pdf.arn
-  desired_count    = 2
+  desired_count    = 4
   launch_type      = "FARGATE"
   platform_version = "1.4.0"
 

--- a/terraform/environment/viewer_ecs.tf
+++ b/terraform/environment/viewer_ecs.tf
@@ -5,7 +5,7 @@ resource "aws_ecs_service" "viewer" {
   name             = "viewer"
   cluster          = aws_ecs_cluster.use-an-lpa.id
   task_definition  = aws_ecs_task_definition.viewer.arn
-  desired_count    = 2
+  desired_count    = 4
   launch_type      = "FARGATE"
   platform_version = "1.4.0"
 


### PR DESCRIPTION
# Purpose

Had a threat notification of possible attempts to disrupt gov services over the weekend


## Approach

We're currently using < 10% resources, so doubling the count for the weekend to provide lot of head room. AWS shield should counter any DDoS

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
