### PR TITLE
Uml 1058 - welsh emails

### DIFF
--- a/service-front/app/src/Actor/src/Handler/CreateAccountHandler.php
+++ b/service-front/app/src/Actor/src/Handler/CreateAccountHandler.php
@@ -93,13 +93,7 @@ class CreateAccountHandler extends AbstractHandler implements CsrfGuardAware
                     $this->emailClient->sendAccountActivationEmail($emailAddress, $activateAccountUrl);
                 } catch (ApiException $ex) {
                     if ($ex->getCode() == StatusCodeInterface::STATUS_CONFLICT) {
-                        if ($ex->getMessage() === 'Another user has requested to change their email to ' . $emailAddress){
-                            // send email to inform the user who has not completed email reset saying
-                            // that someone has tried to use their email in account creation
-                            $this->emailClient->sendSomeoneTriedToUseYourEmailInEmailAccountCreation($emailAddress);
-                        } else {
-                            $this->emailClient->sendAlreadyRegisteredEmail($emailAddress);
-                        }
+                        $this->emailClient->sendAlreadyRegisteredEmail($emailAddress);
                     } else {
                         throw $ex;
                     }

--- a/service-front/app/src/Common/src/Service/Email/EmailClient.php
+++ b/service-front/app/src/Common/src/Service/Email/EmailClient.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Common\Service\Email;
 
 use Alphagov\Notifications\Client as NotifyClient;
+use Mezzio\Helper\UrlHelper;
 
 /**
  * Class EmailClient
@@ -26,7 +27,7 @@ class EmailClient
     /**
      * Welsh template IDs for the notify client
      */
-    const WELSH_TEMPLATE_ID_ACCOUNT_ACTIVATION                = '1be4d491-28df-4dfe-b90c-b285eafba05b';
+    const WELSH_TEMPLATE_ID_ACCOUNT_ACTIVATION                = 'e0933491-b9ee-4552-adb3-7775843f4d4b';
     const WELSH_TEMPLATE_ID_PASSWORD_RESET                    = 'ea7ff73a-2a43-4f7e-a1e4-3e1351ae262d';
     const WELSH_TEMPLATE_ID_PASSWORD_CHANGE                   = 'e47fdf50-d223-4f26-a12f-417bd53b03dd';
     const WELSH_TEMPLATE_ID_EMAIL_CHANGE_SENT_TO_CURRENT_EMAIL= 'f06ab05a-af11-4047-bcbb-4a33d0673829';
@@ -40,12 +41,24 @@ class EmailClient
     private $notifyClient;
 
     /**
+     * @var UrlHelper
+     */
+    private $urlHelper;
+
+    /**
      * EmailClient constructor.
      * @param NotifyClient $notifyClient
      */
-    public function __construct(NotifyClient $notifyClient)
+    public function __construct(NotifyClient $notifyClient, UrlHelper $urlHelper)
     {
         $this->notifyClient = $notifyClient;
+        $this->urlHelper = $urlHelper;
+
+        if ($this->urlHelper->getBasePath() === '/cy') {
+            $this->language = "welsh";
+        } else {
+            $this->language = "english";
+        }
     }
 
     /**
@@ -56,9 +69,15 @@ class EmailClient
      */
     public function sendAccountActivationEmail(string $recipient, string $activateAccountUrl)
     {
-        $this->notifyClient->sendEmail($recipient, self::TEMPLATE_ID_ACCOUNT_ACTIVATION, [
-            'activate-account-url' => $activateAccountUrl,
-        ]);
+        if ($this->language == "welsh") {
+            $this->notifyClient->sendEmail($recipient, self::WELSH_TEMPLATE_ID_ACCOUNT_ACTIVATION, [
+                'activate-account-url' => $activateAccountUrl,
+            ]);
+        } else {
+            $this->notifyClient->sendEmail($recipient, self::TEMPLATE_ID_ACCOUNT_ACTIVATION, [
+                'activate-account-url' => $activateAccountUrl,
+            ]);
+        }
     }
 
     /**

--- a/service-front/app/src/Common/src/Service/Email/EmailClient.php
+++ b/service-front/app/src/Common/src/Service/Email/EmailClient.php
@@ -39,6 +39,8 @@ class EmailClient
      */
     private $notifyClient;
 
+    private $locale;
+
     /**
      * EmailClient constructor.
      * @param NotifyClient $notifyClient

--- a/service-front/app/src/Common/src/Service/Email/EmailClient.php
+++ b/service-front/app/src/Common/src/Service/Email/EmailClient.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Common\Service\Email;
 
 use Alphagov\Notifications\Client as NotifyClient;
-use Mezzio\Helper\UrlHelper;
 
 /**
  * Class EmailClient
@@ -27,13 +26,13 @@ class EmailClient
     /**
      * Welsh template IDs for the notify client
      */
-    const WELSH_TEMPLATE_ID_ACCOUNT_ACTIVATION                = 'e0933491-b9ee-4552-adb3-7775843f4d4b';
-    const WELSH_TEMPLATE_ID_PASSWORD_RESET                    = 'ea7ff73a-2a43-4f7e-a1e4-3e1351ae262d';
-    const WELSH_TEMPLATE_ID_PASSWORD_CHANGE                   = 'e47fdf50-d223-4f26-a12f-417bd53b03dd';
-    const WELSH_TEMPLATE_ID_EMAIL_CHANGE_SENT_TO_CURRENT_EMAIL= 'f06ab05a-af11-4047-bcbb-4a33d0673829';
-    const WELSH_TEMPLATE_ID_EMAIL_CHANGE_SENT_TO_NEW_EMAIL    = '0034dfdc-456b-4cea-8e0e-6915efcd91b2';
-    const WELSH_TEMPLATE_ID_CONFLICT_EMAIL_CHANGE_INCOMPLETE  = '0c2acaa0-96d6-4c01-a32d-f5d8a43ce392';
-    const WELSH_TEMPLATE_ID_EMAIL_ADDRESS_ALREADY_REGISTERED  = 'b9b32dd2-67e9-45e8-a454-4301ba049a81';
+    const WELSH_TEMPLATE_ID_ACCOUNT_ACTIVATION                      = 'e0933491-b9ee-4552-adb3-7775843f4d4b';
+    const WELSH_TEMPLATE_ID_PASSWORD_RESET                          = 'ea7ff73a-2a43-4f7e-a1e4-3e1351ae262d';
+    const WELSH_TEMPLATE_ID_PASSWORD_CHANGE                         = 'e47fdf50-d223-4f26-a12f-417bd53b03dd';
+    const WELSH_TEMPLATE_ID_EMAIL_CHANGE_SENT_TO_CURRENT_EMAIL      = 'f06ab05a-af11-4047-bcbb-4a33d0673829';
+    const WELSH_TEMPLATE_ID_EMAIL_CHANGE_SENT_TO_NEW_EMAIL          = '0034dfdc-456b-4cea-8e0e-6915efcd91b2';
+    const WELSH_TEMPLATE_ID_RESET_CONFLICT_EMAIL_CHANGE_INCOMPLETE  = '0c2acaa0-96d6-4c01-a32d-f5d8a43ce392';
+    const WELSH_TEMPLATE_ID_EMAIL_ADDRESS_ALREADY_REGISTERED        = 'b9b32dd2-67e9-45e8-a454-4301ba049a81';
 
     /**
      * @var NotifyClient
@@ -41,24 +40,13 @@ class EmailClient
     private $notifyClient;
 
     /**
-     * @var UrlHelper
-     */
-    private $urlHelper;
-
-    /**
      * EmailClient constructor.
      * @param NotifyClient $notifyClient
      */
-    public function __construct(NotifyClient $notifyClient, UrlHelper $urlHelper)
+    public function __construct(NotifyClient $notifyClient, string $locale)
     {
         $this->notifyClient = $notifyClient;
-        $this->urlHelper = $urlHelper;
-
-        if ($this->urlHelper->getBasePath() === '/cy') {
-            $this->language = "welsh";
-        } else {
-            $this->language = "english";
-        }
+        $this->locale = $locale;
     }
 
     /**
@@ -69,7 +57,7 @@ class EmailClient
      */
     public function sendAccountActivationEmail(string $recipient, string $activateAccountUrl)
     {
-        if ($this->language == "welsh") {
+        if ($this->locale === "cy") {
             $this->notifyClient->sendEmail($recipient, self::WELSH_TEMPLATE_ID_ACCOUNT_ACTIVATION, [
                 'activate-account-url' => $activateAccountUrl,
             ]);
@@ -87,7 +75,11 @@ class EmailClient
      */
     public function sendAlreadyRegisteredEmail(string $recipient)
     {
-        $this->notifyClient->sendEmail($recipient, self::TEMPLATE_ID_EMAIL_ADDRESS_ALREADY_REGISTERED);
+        if ($this->locale === "cy") {
+            $this->notifyClient->sendEmail($recipient, self::WELSH_TEMPLATE_ID_EMAIL_ADDRESS_ALREADY_REGISTERED);
+        } else {
+            $this->notifyClient->sendEmail($recipient, self::TEMPLATE_ID_EMAIL_ADDRESS_ALREADY_REGISTERED);
+        }
     }
 
     /**
@@ -98,9 +90,15 @@ class EmailClient
      */
     public function sendPasswordResetEmail(string $recipient, string $passwordResetUrl)
     {
-        $this->notifyClient->sendEmail($recipient, self::TEMPLATE_ID_PASSWORD_RESET, [
-            'password-reset-url' => $passwordResetUrl,
-        ]);
+        if ($this->locale === "cy") {
+            $this->notifyClient->sendEmail($recipient, self::WELSH_TEMPLATE_ID_PASSWORD_RESET, [
+                'password-reset-url' => $passwordResetUrl,
+            ]);
+        } else {
+            $this->notifyClient->sendEmail($recipient, self::TEMPLATE_ID_PASSWORD_RESET, [
+                'password-reset-url' => $passwordResetUrl,
+            ]);
+        }
     }
 
     /**
@@ -110,7 +108,11 @@ class EmailClient
      */
     public function sendPasswordChangedEmail(string $recipient)
     {
-        $this->notifyClient->sendEmail($recipient, self::TEMPLATE_ID_PASSWORD_CHANGE);
+        if ($this->locale === "cy") {
+            $this->notifyClient->sendEmail($recipient, self::WELSH_TEMPLATE_ID_PASSWORD_CHANGE);
+        } else {
+            $this->notifyClient->sendEmail($recipient, self::TEMPLATE_ID_PASSWORD_CHANGE);
+        }
     }
 
     /**
@@ -121,9 +123,15 @@ class EmailClient
      */
     public function sendRequestChangeEmailToCurrentEmail(string $recipient, string $newEmailAddress)
     {
-        $this->notifyClient->sendEmail($recipient, self::TEMPLATE_ID_EMAIL_CHANGE_SENT_TO_CURRENT_EMAIL, [
-            'new-email-address' => $newEmailAddress,
-        ]);
+        if ($this->locale === "cy") {
+            $this->notifyClient->sendEmail($recipient, self::WELSH_TEMPLATE_ID_EMAIL_CHANGE_SENT_TO_CURRENT_EMAIL, [
+                'new-email-address' => $newEmailAddress,
+            ]);
+        } else {
+            $this->notifyClient->sendEmail($recipient, self::TEMPLATE_ID_EMAIL_CHANGE_SENT_TO_CURRENT_EMAIL, [
+                'new-email-address' => $newEmailAddress,
+            ]);
+        }
     }
 
     /**
@@ -134,9 +142,15 @@ class EmailClient
      */
     public function sendRequestChangeEmailToNewEmail(string $recipient, string $completeEmailChangeUrl)
     {
-        $this->notifyClient->sendEmail($recipient, self::TEMPLATE_ID_EMAIL_CHANGE_SENT_TO_NEW_EMAIL, [
-            'verify-new-email-url' => $completeEmailChangeUrl,
-        ]);
+        if ($this->locale === "cy") {
+            $this->notifyClient->sendEmail($recipient, self::WELSH_TEMPLATE_ID_EMAIL_CHANGE_SENT_TO_NEW_EMAIL, [
+                'verify-new-email-url' => $completeEmailChangeUrl,
+            ]);
+        } else {
+            $this->notifyClient->sendEmail($recipient, self::TEMPLATE_ID_EMAIL_CHANGE_SENT_TO_NEW_EMAIL, [
+                'verify-new-email-url' => $completeEmailChangeUrl,
+            ]);
+        }
     }
 
     /**
@@ -146,6 +160,10 @@ class EmailClient
      */
     public function sendSomeoneTriedToUseYourEmailInEmailResetRequest(string $recipient)
     {
-        $this->notifyClient->sendEmail($recipient, self::TEMPLATE_ID_RESET_CONFLICT_EMAIL_CHANGE_INCOMPLETE);
+        if ($this->locale === "cy") {
+            $this->notifyClient->sendEmail($recipient, self::WELSH_TEMPLATE_ID_RESET_CONFLICT_EMAIL_CHANGE_INCOMPLETE);
+        } else {
+            $this->notifyClient->sendEmail($recipient, self::TEMPLATE_ID_RESET_CONFLICT_EMAIL_CHANGE_INCOMPLETE);
+        }
     }
 }

--- a/service-front/app/src/Common/src/Service/Email/EmailClient.php
+++ b/service-front/app/src/Common/src/Service/Email/EmailClient.php
@@ -13,16 +13,26 @@ use Alphagov\Notifications\Client as NotifyClient;
 class EmailClient
 {
     /**
-     * Template IDs for the notify client
+     * English template IDs for the notify client
      */
     const TEMPLATE_ID_ACCOUNT_ACTIVATION                      = 'd897fe13-a0c3-4c50-aa5b-3f0efacda5dc';
-    const TEMPLATE_ID_EMAIL_ADDRESS_ALREADY_REGISTERED        = '4af9acf0-f2c1-4ecc-8441-0e2173890463';
     const TEMPLATE_ID_PASSWORD_RESET                          = 'd32af4a6-49ad-4338-a2c2-dcb5801a40fc';
     const TEMPLATE_ID_PASSWORD_CHANGE                         = '75080a89-7b22-4792-bdf6-6636467a7999';
     const TEMPLATE_ID_EMAIL_CHANGE_SENT_TO_CURRENT_EMAIL      = '19051f55-d60d-4bbc-ab49-cf85580d3102';
     const TEMPLATE_ID_EMAIL_CHANGE_SENT_TO_NEW_EMAIL          = 'bcf7e3f7-7f76-4e0a-87ee-b6722bdc223a';
     const TEMPLATE_ID_RESET_CONFLICT_EMAIL_CHANGE_INCOMPLETE  = '5a74677a-4840-49cf-a92b-f1de2b31cebb';
-    const TEMPLATE_ID_ACCOUNT_CREATION_EMAIL_CHANGE_REQUESTED = '4af9acf0-f2c1-4ecc-8441-0e2173890463';
+    const TEMPLATE_ID_EMAIL_ADDRESS_ALREADY_REGISTERED        = '4af9acf0-f2c1-4ecc-8441-0e2173890463';
+
+    /**
+     * Welsh template IDs for the notify client
+     */
+    const WELSH_TEMPLATE_ID_ACCOUNT_ACTIVATION                = '1be4d491-28df-4dfe-b90c-b285eafba05b';
+    const WELSH_TEMPLATE_ID_PASSWORD_RESET                    = 'ea7ff73a-2a43-4f7e-a1e4-3e1351ae262d';
+    const WELSH_TEMPLATE_ID_PASSWORD_CHANGE                   = 'e47fdf50-d223-4f26-a12f-417bd53b03dd';
+    const WELSH_TEMPLATE_ID_EMAIL_CHANGE_SENT_TO_CURRENT_EMAIL= 'f06ab05a-af11-4047-bcbb-4a33d0673829';
+    const WELSH_TEMPLATE_ID_EMAIL_CHANGE_SENT_TO_NEW_EMAIL    = '0034dfdc-456b-4cea-8e0e-6915efcd91b2';
+    const WELSH_TEMPLATE_ID_CONFLICT_EMAIL_CHANGE_INCOMPLETE  = '0c2acaa0-96d6-4c01-a32d-f5d8a43ce392';
+    const WELSH_TEMPLATE_ID_EMAIL_ADDRESS_ALREADY_REGISTERED  = 'b9b32dd2-67e9-45e8-a454-4301ba049a81';
 
     /**
      * @var NotifyClient
@@ -118,15 +128,5 @@ class EmailClient
     public function sendSomeoneTriedToUseYourEmailInEmailResetRequest(string $recipient)
     {
         $this->notifyClient->sendEmail($recipient, self::TEMPLATE_ID_RESET_CONFLICT_EMAIL_CHANGE_INCOMPLETE);
-    }
-
-    /**
-     * Send an email to the new email address telling the user that someone has tried to use their email to create an account
-     *
-     * @param string $recipient
-     */
-    public function sendSomeoneTriedToUseYourEmailInEmailAccountCreation(string $recipient)
-    {
-        $this->notifyClient->sendEmail($recipient, self::TEMPLATE_ID_ACCOUNT_CREATION_EMAIL_CHANGE_REQUESTED);
     }
 }

--- a/service-front/app/src/Common/src/Service/Email/EmailClientFactory.php
+++ b/service-front/app/src/Common/src/Service/Email/EmailClientFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Common\Service\Email;
 
 use Alphagov\Notifications\Client as NotifyClient;
-use Mezzio\Helper\UrlHelper;
+use Locale;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Client\ClientInterface;
 use RuntimeException;
@@ -33,8 +33,8 @@ class EmailClientFactory
             'httpClient' => $container->get(ClientInterface::class),
         ]);
 
-        $urlHelper = $container->get(UrlHelper::class);
+        $locale = Locale::getDefault();
 
-        return new EmailClient($notifyClient, $urlHelper);
+        return new EmailClient($notifyClient, $locale);
     }
 }

--- a/service-front/app/src/Common/src/Service/Email/EmailClientFactory.php
+++ b/service-front/app/src/Common/src/Service/Email/EmailClientFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Common\Service\Email;
 
 use Alphagov\Notifications\Client as NotifyClient;
+use Mezzio\Helper\UrlHelper;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Client\ClientInterface;
 use RuntimeException;
@@ -32,6 +33,8 @@ class EmailClientFactory
             'httpClient' => $container->get(ClientInterface::class),
         ]);
 
-        return new EmailClient($notifyClient);
+        $urlHelper = $container->get(UrlHelper::class);
+
+        return new EmailClient($notifyClient, $urlHelper);
     }
 }

--- a/service-front/app/test/CommonTest/Service/Email/EmailClientTest.php
+++ b/service-front/app/test/CommonTest/Service/Email/EmailClientTest.php
@@ -147,21 +147,4 @@ class EmailClientTest extends TestCase
 
         $emailClient->sendSomeoneTriedToUseYourEmailInEmailResetRequest($recipient);
     }
-
-    /** @test */
-    public function can_send_someone_tried_to_use_your_email_for_account_creation()
-    {
-        $notifyClientProphecy = $this->prophesize(NotifyClient::class);
-
-        $recipient = 'new@email.com';
-
-        $notifyClientProphecy->sendEmail(
-            $recipient,
-            EmailClient::TEMPLATE_ID_ACCOUNT_CREATION_EMAIL_CHANGE_REQUESTED
-        )->shouldBeCalledOnce();
-
-        $emailClient = new EmailClient($notifyClientProphecy->reveal());
-
-        $emailClient->sendSomeoneTriedToUseYourEmailInEmailAccountCreation($recipient);
-    }
 }

--- a/service-front/app/test/CommonTest/Service/Email/EmailClientTest.php
+++ b/service-front/app/test/CommonTest/Service/Email/EmailClientTest.php
@@ -148,4 +148,18 @@ class EmailClientTest extends TestCase
 
         $emailClient->sendSomeoneTriedToUseYourEmailInEmailResetRequest($recipient);
     }
+
+    /** @test */
+    public function its_sends_a_welsh_email_if_locale_is_cy()
+    {
+        $this->locale = "cy";
+        $recipient = 'a@b.com';
+
+        $this->notifyClientProphecy->sendEmail($recipient, EmailClient::WELSH_TEMPLATE_ID_EMAIL_ADDRESS_ALREADY_REGISTERED)
+            ->shouldBeCalledOnce();
+
+        $emailClient = new EmailClient($this->notifyClientProphecy->reveal(), $this->locale);
+
+        $emailClient->sendAlreadyRegisteredEmail($recipient);
+    }
 }

--- a/service-front/app/test/CommonTest/Service/Email/EmailClientTest.php
+++ b/service-front/app/test/CommonTest/Service/Email/EmailClientTest.php
@@ -150,7 +150,27 @@ class EmailClientTest extends TestCase
     }
 
     /** @test */
-    public function its_sends_a_welsh_email_if_locale_is_cy()
+    public function can_send_account_activation_email_if_locale_is_cy()
+    {
+        $this->locale = "cy";
+        $recipient = 'a@b.com';
+
+        $this->notifyClientProphecy->sendEmail(
+            $recipient,
+            EmailClient::WELSH_TEMPLATE_ID_ACCOUNT_ACTIVATION,
+            [
+                'activate-account-url' => 'http://localhost:9002/cy/activate-account/activateAccountAABBCCDDEE'
+            ]
+        )
+            ->shouldBeCalledOnce();
+
+        $emailClient = new EmailClient($this->notifyClientProphecy->reveal(), $this->locale);
+
+        $emailClient->sendAccountActivationEmail($recipient, 'http://localhost:9002/cy/activate-account/activateAccountAABBCCDDEE');
+    }
+
+    /** @test */
+    public function can_send_already_registered_email_if_locale_is_cy()
     {
         $this->locale = "cy";
         $recipient = 'a@b.com';
@@ -161,5 +181,102 @@ class EmailClientTest extends TestCase
         $emailClient = new EmailClient($this->notifyClientProphecy->reveal(), $this->locale);
 
         $emailClient->sendAlreadyRegisteredEmail($recipient);
+    }
+
+    /** @test */
+    public function can_send_password_reset_email_if_locale_is_cy()
+    {
+        $this->locale = "cy";
+        $recipient = 'a@b.com';
+
+        $this->notifyClientProphecy->sendEmail(
+            $recipient,
+            EmailClient::WELSH_TEMPLATE_ID_PASSWORD_RESET,
+            [
+                'password-reset-url' => 'http://localhost:9002/cy/password-reset/passwordResetAABBCCDDEE'
+            ]
+        )
+            ->shouldBeCalledOnce();
+
+        $emailClient = new EmailClient($this->notifyClientProphecy->reveal(), $this->locale);
+
+        $emailClient->sendPasswordResetEmail($recipient, 'http://localhost:9002/cy/password-reset/passwordResetAABBCCDDEE');
+    }
+
+    /** @test */
+    public function can_send_password_change_email_if_locale_is_cy()
+    {
+        $this->locale = "cy";
+        $recipient = 'a@b.com';
+
+        $this->notifyClientProphecy->sendEmail(
+            $recipient,
+            EmailClient::WELSH_TEMPLATE_ID_PASSWORD_CHANGE
+        )
+            ->shouldBeCalledOnce();
+
+        $emailClient = new EmailClient($this->notifyClientProphecy->reveal(), $this->locale);
+
+        $emailClient->sendPasswordChangedEmail($recipient);
+    }
+
+    /** @test */
+    public function can_send_change_email_to_current_email_if_locale_is_cy()
+    {
+        $this->locale = "cy";
+        $recipient = 'current@email.com';
+        $newEmail = 'new@email.com';
+
+        $this->notifyClientProphecy->sendEmail(
+            $recipient,
+            EmailClient::WELSH_TEMPLATE_ID_EMAIL_CHANGE_SENT_TO_CURRENT_EMAIL,
+            [
+                'new-email-address' => $newEmail
+            ]
+        )
+            ->shouldBeCalledOnce();
+
+        $emailClient = new EmailClient($this->notifyClientProphecy->reveal(), $this->locale);
+
+        $emailClient->sendRequestChangeEmailToCurrentEmail($recipient, $newEmail);
+    }
+
+    /** @test */
+    public function can_send_change_email_verify_to_new_email_if_locale_is_cy()
+    {
+        $this->locale = "cy";
+        $recipient = 'new@email.com';
+
+        $this->notifyClientProphecy->sendEmail(
+            $recipient,
+            EmailClient::WELSH_TEMPLATE_ID_EMAIL_CHANGE_SENT_TO_NEW_EMAIL,
+            [
+                'verify-new-email-url' => 'http://localhost:9002/cy/verify-new-email/verifyNewEmailAABBCCDDEE'
+            ]
+        )
+            ->shouldBeCalledOnce();
+
+        $emailClient = new EmailClient($this->notifyClientProphecy->reveal(), $this->locale);
+
+        $emailClient->sendRequestChangeEmailToNewEmail(
+            $recipient,
+            'http://localhost:9002/cy/verify-new-email/verifyNewEmailAABBCCDDEE'
+        );
+    }
+
+    /** @test */
+    public function can_send_someone_tried_to_use_your_email_for_email_change_if_locale_is_cy()
+    {
+        $this->locale = "cy";
+        $recipient = 'new@email.com';
+
+        $this->notifyClientProphecy->sendEmail(
+            $recipient,
+            EmailClient::WELSH_TEMPLATE_ID_RESET_CONFLICT_EMAIL_CHANGE_INCOMPLETE
+        )->shouldBeCalledOnce();
+
+        $emailClient = new EmailClient($this->notifyClientProphecy->reveal(), $this->locale);
+
+        $emailClient->sendSomeoneTriedToUseYourEmailInEmailResetRequest($recipient);
     }
 }

--- a/service-front/app/test/CommonTest/Service/Email/EmailClientTest.php
+++ b/service-front/app/test/CommonTest/Service/Email/EmailClientTest.php
@@ -10,14 +10,27 @@ use PHPUnit\Framework\TestCase;
 
 class EmailClientTest extends TestCase
 {
+    /**
+     * @var NotifyClient
+     */
+    private $notifyClientProphecy;
+    /**
+     * @var string
+     */
+    private $locale;
+
+    public function setUp()
+    {
+        $this->notifyClientProphecy = $this->prophesize(NotifyClient::class);
+        $this->locale = "en_GB";
+    }
+
     /** @test */
     public function can_send_account_activation_email()
     {
-        $notifyClientProphecy = $this->prophesize(NotifyClient::class);
-
         $recipient = 'a@b.com';
 
-        $notifyClientProphecy->sendEmail(
+        $this->notifyClientProphecy->sendEmail(
             $recipient,
             EmailClient::TEMPLATE_ID_ACCOUNT_ACTIVATION,
             [
@@ -26,7 +39,7 @@ class EmailClientTest extends TestCase
         )
             ->shouldBeCalledOnce();
 
-        $emailClient = new EmailClient($notifyClientProphecy->reveal());
+        $emailClient = new EmailClient($this->notifyClientProphecy->reveal(), $this->locale);
 
         $emailClient->sendAccountActivationEmail($recipient, 'http://localhost:9002/activate-account/activateAccountAABBCCDDEE');
     }
@@ -34,14 +47,12 @@ class EmailClientTest extends TestCase
     /** @test */
     public function can_send_already_registered_email()
     {
-        $notifyClientProphecy = $this->prophesize(NotifyClient::class);
-
         $recipient = 'a@b.com';
 
-        $notifyClientProphecy->sendEmail($recipient, EmailClient::TEMPLATE_ID_EMAIL_ADDRESS_ALREADY_REGISTERED)
+        $this->notifyClientProphecy->sendEmail($recipient, EmailClient::TEMPLATE_ID_EMAIL_ADDRESS_ALREADY_REGISTERED)
             ->shouldBeCalledOnce();
 
-        $emailClient = new EmailClient($notifyClientProphecy->reveal());
+        $emailClient = new EmailClient($this->notifyClientProphecy->reveal(), $this->locale);
 
         $emailClient->sendAlreadyRegisteredEmail($recipient);
     }
@@ -49,11 +60,9 @@ class EmailClientTest extends TestCase
     /** @test */
     public function can_send_password_reset_email()
     {
-        $notifyClientProphecy = $this->prophesize(NotifyClient::class);
-
         $recipient = 'a@b.com';
 
-        $notifyClientProphecy->sendEmail(
+        $this->notifyClientProphecy->sendEmail(
             $recipient,
             EmailClient::TEMPLATE_ID_PASSWORD_RESET,
             [
@@ -62,7 +71,7 @@ class EmailClientTest extends TestCase
         )
             ->shouldBeCalledOnce();
 
-        $emailClient = new EmailClient($notifyClientProphecy->reveal());
+        $emailClient = new EmailClient($this->notifyClientProphecy->reveal(), $this->locale);
 
         $emailClient->sendPasswordResetEmail($recipient, 'http://localhost:9002/password-reset/passwordResetAABBCCDDEE');
     }
@@ -70,17 +79,15 @@ class EmailClientTest extends TestCase
     /** @test */
     public function can_send_password_change_email()
     {
-        $notifyClientProphecy = $this->prophesize(NotifyClient::class);
-
         $recipient = 'a@b.com';
 
-        $notifyClientProphecy->sendEmail(
+        $this->notifyClientProphecy->sendEmail(
             $recipient,
             EmailClient::TEMPLATE_ID_PASSWORD_CHANGE
         )
             ->shouldBeCalledOnce();
 
-        $emailClient = new EmailClient($notifyClientProphecy->reveal());
+        $emailClient = new EmailClient($this->notifyClientProphecy->reveal(), $this->locale);
 
         $emailClient->sendPasswordChangedEmail($recipient);
     }
@@ -88,12 +95,10 @@ class EmailClientTest extends TestCase
     /** @test */
     public function can_send_change_email_to_current_email()
     {
-        $notifyClientProphecy = $this->prophesize(NotifyClient::class);
-
         $recipient = 'current@email.com';
         $newEmail = 'new@email.com';
 
-        $notifyClientProphecy->sendEmail(
+        $this->notifyClientProphecy->sendEmail(
             $recipient,
             EmailClient::TEMPLATE_ID_EMAIL_CHANGE_SENT_TO_CURRENT_EMAIL,
             [
@@ -102,7 +107,7 @@ class EmailClientTest extends TestCase
         )
             ->shouldBeCalledOnce();
 
-        $emailClient = new EmailClient($notifyClientProphecy->reveal());
+        $emailClient = new EmailClient($this->notifyClientProphecy->reveal(), $this->locale);
 
         $emailClient->sendRequestChangeEmailToCurrentEmail($recipient, $newEmail);
     }
@@ -110,11 +115,9 @@ class EmailClientTest extends TestCase
     /** @test */
     public function can_send_change_email_verify_to_new_email()
     {
-        $notifyClientProphecy = $this->prophesize(NotifyClient::class);
-
         $recipient = 'new@email.com';
 
-        $notifyClientProphecy->sendEmail(
+        $this->notifyClientProphecy->sendEmail(
             $recipient,
             EmailClient::TEMPLATE_ID_EMAIL_CHANGE_SENT_TO_NEW_EMAIL,
             [
@@ -123,7 +126,7 @@ class EmailClientTest extends TestCase
         )
             ->shouldBeCalledOnce();
 
-        $emailClient = new EmailClient($notifyClientProphecy->reveal());
+        $emailClient = new EmailClient($this->notifyClientProphecy->reveal(), $this->locale);
 
         $emailClient->sendRequestChangeEmailToNewEmail(
             $recipient,
@@ -134,16 +137,14 @@ class EmailClientTest extends TestCase
     /** @test */
     public function can_send_someone_tried_to_use_your_email_for_email_change()
     {
-        $notifyClientProphecy = $this->prophesize(NotifyClient::class);
-
         $recipient = 'new@email.com';
 
-        $notifyClientProphecy->sendEmail(
+        $this->notifyClientProphecy->sendEmail(
             $recipient,
             EmailClient::TEMPLATE_ID_RESET_CONFLICT_EMAIL_CHANGE_INCOMPLETE
         )->shouldBeCalledOnce();
 
-        $emailClient = new EmailClient($notifyClientProphecy->reveal());
+        $emailClient = new EmailClient($this->notifyClientProphecy->reveal(), $this->locale);
 
         $emailClient->sendSomeoneTriedToUseYourEmailInEmailResetRequest($recipient);
     }


### PR DESCRIPTION
# Purpose

Sends emails in welsh if locale is set to cy

Fixes UML-1058

## Approach

Injected locale into EmailClient constructor and used if statements within each send email function to send the email in english or welsh

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes
