### PR TITLE
Overrides GDS accordion open all with translatable text

### DIFF
--- a/service-front/app/languages/messages.pot
+++ b/service-front/app/languages/messages.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Language: en_GB\n"
-"POT-Creation-Date: 2020-09-03T15:47:47+00:00\n"
+"POT-Creation-Date: 2020-09-04T09:59:45+00:00\n"
 "X-Domain: messages\n"
 
 #: src/Actor/templates/actor/lpa-show-viewercode.html.twig:3
@@ -95,6 +95,21 @@ msgstr ""
 
 #: src/Actor/templates/actor/check-access-codes.html.twig:66
 msgid "Give an organisation their access code so they can view this LPA. They should go to www.gov.uk/view-lpa to use the code."
+msgstr ""
+
+#. Accordion label
+#: src/Actor/templates/actor/check-access-codes.html.twig:68
+msgid "Open all"
+msgstr ""
+
+#. Accordion label
+#: src/Actor/templates/actor/check-access-codes.html.twig:68
+msgid "Close all"
+msgstr ""
+
+#. Accordion label
+#: src/Actor/templates/actor/check-access-codes.html.twig:68
+msgid "section"
 msgstr ""
 
 #: src/Actor/templates/actor/check-access-codes.html.twig:82

--- a/service-front/app/src/Actor/templates/actor/check-access-codes.html.twig
+++ b/service-front/app/src/Actor/templates/actor/check-access-codes.html.twig
@@ -65,7 +65,7 @@
 
                             <p class="govuk-body">{% trans %}Give an organisation their access code so they can view this LPA. They should go to www.gov.uk/view-lpa to use the code.{% endtrans %}</p>
 
-                            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+                            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default" data-opentext="{% trans %}Open all{% endtrans%}" data-closetext="{% trans %}Close all{% endtrans %}" data-sectiontext="{% trans %}section{% endtrans %}">
 
                                 {% for code in shareCodes %}
                                     {% if not check_if_code_has_expired(code.Expires) %}

--- a/service-front/app/src/Actor/templates/actor/check-access-codes.html.twig
+++ b/service-front/app/src/Actor/templates/actor/check-access-codes.html.twig
@@ -65,7 +65,7 @@
 
                             <p class="govuk-body">{% trans %}Give an organisation their access code so they can view this LPA. They should go to www.gov.uk/view-lpa to use the code.{% endtrans %}</p>
 
-                            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default" data-opentext="{% trans %}Open all{% endtrans%}" data-closetext="{% trans %}Close all{% endtrans %}" data-sectiontext="{% trans %}section{% endtrans %}">
+                            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default" data-opentext="{% trans %}Open all{% notes %}Accordion label{% endtrans%}" data-closetext="{% trans %}Close all{% notes %}Accordion label{% endtrans %}" data-sectiontext="{% trans %}section{% notes %}Accordion label{% endtrans %}">
 
                                 {% for code in shareCodes %}
                                     {% if not check_if_code_has_expired(code.Expires) %}

--- a/service-front/web/src/index.js
+++ b/service-front/web/src/index.js
@@ -1,11 +1,18 @@
 /* istanbul ignore file */
 import './scss.js';
-import { initAll } from 'govuk-frontend';
+import { initAll, Accordion } from 'govuk-frontend';
 import jsEnabled from './javascript/jsEnabled';
 import disableButtonOnClick from './javascript/disableButtonOnClick';
 import copyAccessCode from './javascript/copyAccessCode';
 import cookieConsent from './javascript/cookieConsent';
 import sessionDialog from './javascript/sessionDialog';
+
+Accordion.prototype.updateOpenAllButton = function (expanded) {
+    var newButtonText = expanded ? this.$module.dataset.closetext : this.$module.dataset.opentext;
+    newButtonText += `<span class="govuk-visually-hidden"> ${this.$module.dataset.sectiontext}</span>`;
+    this.$openAllButton.setAttribute('aria-expanded', expanded);
+    this.$openAllButton.innerHTML = newButtonText;
+};
 initAll();
 jsEnabled(document.body);
 disableButtonOnClick(document.getElementsByTagName('form'));


### PR DESCRIPTION
# Purpose

Accordion has Open/Close all text set in the external JS - we need to switch this to be multilinqual

Fixes UML-####

## Approach

On setup of the JS, overwrite the function that is handling this logic

## Learning

None

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
