### PR TITLE
Build better pot files

### DIFF
--- a/service-front/app/README.md
+++ b/service-front/app/README.md
@@ -1,150 +1,22 @@
-# Expressive Skeleton and Installer
+# service-front (actor & viewer)
 
-[![Build Status](https://secure.travis-ci.org/mezzio/mezzio-skeleton.svg?branch=master)](https://secure.travis-ci.org/mezzio/mezzio-skeleton)
-[![Coverage Status](https://coveralls.io/repos/github/mezzio/mezzio-skeleton/badge.svg?branch=master)](https://coveralls.io/github/mezzio/mezzio-skeleton?branch=master)
+Please see the [README.md](../../README.md) at the top level for getting started instructions
 
-*Begin developing PSR-15 middleware applications in seconds!*
+## Translation Extraction
 
-[zend-expressive](https://github.com/mezzio/mezzio) builds on
-[zend-stratigility](https://github.com/laminas/laminas-stratigility) to
-provide a minimalist PSR-15 middleware framework for PHP with routing, DI
-container, optional templating, and optional error handling capabilities.
+This is pretty much all handled by the service-front image now with a handy `composer.json` script.
 
-This installer will setup a skeleton application based on zend-expressive by
-choosing optional packages based on user input as demonstrated in the following
-screenshot:
-
-![screenshot-installer](https://cloud.githubusercontent.com/assets/459648/10410494/16bdc674-6f6d-11e5-8190-3c1466e93361.png)
-
-The user selected packages are saved into `composer.json` so that everyone else
-working on the project have the same packages installed. Configuration files and
-templates are prepared for first use. The installer command is removed from
-`composer.json` after setup succeeded, and all installer related files are
-removed.
-
-## Getting Started
-
-Start your new Expressive project with composer:
-
-```bash
-$ composer create-project mezzio/mezzio-skeleton <project-path>
+```shell script
+# in the service-front/app directory
+composer run extract
 ```
 
-After choosing and installing the packages you want, go to the
-`<project-path>` and start PHP's built-in web server to verify installation:
+If you have the appropriate tooling on your system (`php` with `gettext` and `redis` extensions) you
+can also run it locally.
 
-```bash
-$ composer run --timeout=0 serve
+```shell script
+CONTEXT=actor php console.php translation:update
 ```
 
-You can then browse to http://localhost:8080.
-
-> ### Linux users
->
-> On PHP versions prior to 7.1.14 and 7.2.2, this command might not work as
-> expected due to a bug in PHP that only affects linux environments. In such
-> scenarios, you will need to start the [built-in web
-> server](http://php.net/manual/en/features.commandline.webserver.php) yourself,
-> using the following command:
->
-> ```bash
-> $ php -S 0.0.0.0:8080 -t public/ public/index.php
-> ```
-
-> ### Setting a timeout
->
-> Composer commands time out after 300 seconds (5 minutes). On Linux-based
-> systems, the `php -S` command that `composer serve` spawns continues running
-> as a background process, but on other systems halts when the timeout occurs.
->
-> As such, we recommend running the `serve` script using a timeout. This can
-> be done by using `composer run` to execute the `serve` script, with a
-> `--timeout` option. When set to `0`, as in the previous example, no timeout
-> will be used, and it will run until you cancel the process (usually via
-> `Ctrl-C`). Alternately, you can specify a finite timeout; as an example,
-> the following will extend the timeout to a full day:
->
-> ```bash
-> $ composer run --timeout=86400 serve
-> ```
-
-## Troubleshooting
-
-If the installer fails during the ``composer create-project`` phase, please go
-through the following list before opening a new issue. Most issues we have seen
-so far can be solved by `self-update` and `clear-cache`.
-
-1. Be sure to work with the latest version of composer by running `composer self-update`.
-2. Try clearing Composer's cache by running `composer clear-cache`.
-
-If neither of the above help, you might face more serious issues:
-
-- Info about the [zlib_decode error](https://github.com/composer/composer/issues/4121).
-- Info and solutions for [composer degraded mode](https://getcomposer.org/doc/articles/troubleshooting.md#degraded-mode).
-
-## Application Development Mode Tool
-
-This skeleton comes with [laminas-development-mode](https://github.com/laminas/laminas-development-mode). 
-It provides a composer script to allow you to enable and disable development mode.
-
-### To enable development mode
-
-**Note:** Do NOT run development mode on your production server!
-
-```bash
-$ composer development-enable
-```
-
-**Note:** Enabling development mode will also clear your configuration cache, to 
-allow safely updating dependencies and ensuring any new configuration is picked 
-up by your application.
-
-### To disable development mode
-
-```bash
-$ composer development-disable
-```
-
-### Development mode status
-
-```bash
-$ composer development-status
-```
-
-## Configuration caching
-
-By default, the skeleton will create a configuration cache in
-`data/config-cache.php`. When in development mode, the configuration cache is
-disabled, and switching in and out of development mode will remove the
-configuration cache.
-
-You may need to clear the configuration cache in production when deploying if
-you deploy to the same directory. You may do so using the following:
-
-```bash
-$ composer clear-config-cache
-```
-
-You may also change the location of the configuration cache itself by editing
-the `config/config.php` file and changing the `config_cache_path` entry of the
-local `$cacheConfig` variable.
-
-## Skeleton Development
-
-This section applies only if you cloned this repo with `git clone`, not when you
-installed expressive with `composer create-project ...`.
-
-If you want to run tests against the installer, you need to clone this repo and
-setup all dependencies with composer.  Make sure you **prevent composer running
-scripts** with `--no-scripts`, otherwise it will remove the installer and all
-tests.
-
-```bash
-$ composer update --no-scripts
-$ composer test
-```
-
-Please note that the installer tests remove installed config files and templates
-before and after running the tests.
-
-Before contributing read [the contributing guide](docs/CONTRIBUTING.md).
+_Note_: due to the differences in file order on the filesystem these two commands may produce a slightly
+different POT file. It's probably best to stick to the first '_in container_' run version.

--- a/service-front/app/README.md
+++ b/service-front/app/README.md
@@ -20,3 +20,26 @@ CONTEXT=actor php console.php translation:update
 
 _Note_: due to the differences in file order on the filesystem these two commands may produce a slightly
 different POT file. It's probably best to stick to the first '_in container_' run version.
+
+## Translation Implementation
+
+At the moment the file that we get back from translation (a `.po` file) has some incorrect syntax in
+that breaks our html output. Essentially the poedit software tries to be helpful and replaces all instances
+of " with the more linguistically correct “ and ”. You'll need to reset those before moving onto the next
+step
+
+You may use a substitution like:
+```
+s/“|”/\\"/
+```
+
+Or do a find replace in the editor of your choice.
+
+Once the new `messages.po` file has been created you need to create the matching compile `.mo` file.
+This is done with the gettext tooling (which you may need to install).
+
+```shell script
+msgfmt messages.po
+```
+
+Both these files now need to go in the `LC_MESSAGES` folder of the language these files are for.

--- a/service-front/app/composer.json
+++ b/service-front/app/composer.json
@@ -112,6 +112,7 @@
         "cs-fix": "@dc-php /app/vendor/bin/phpcbf",
         "unit-test": "@dc-php /app/vendor/bin/phpunit --colors=always",
         "acc-test": "@dc-php -dapc.enable_cli=1 /app/vendor/bin/behat -p acceptance --colors",
-        "int-test": "@dc-php /app/vendor/bin/behat -p integration --colors"
+        "int-test": "@dc-php /app/vendor/bin/behat -p integration --colors",
+        "extract": "@dc-php console.php translation:update"
     }
 }

--- a/service-front/app/src/Common/src/Command/TranslationUpdateCommandFactory.php
+++ b/service-front/app/src/Common/src/Command/TranslationUpdateCommandFactory.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Common\Command;
 
+use Common\Service\I18n\CatalogueLoader;
 use Common\Service\I18n\PotGenerator;
-use Common\Service\I18n\TwigCatalogueExtractor;
+use Common\Service\I18n\TwigCatalogueExtractorFactory;
 use Psr\Container\ContainerInterface;
 
 class TranslationUpdateCommandFactory
@@ -13,13 +14,14 @@ class TranslationUpdateCommandFactory
     public function __invoke(ContainerInterface $container): TranslationUpdateCommand
     {
         return new TranslationUpdateCommand(
-            $container->get(TwigCatalogueExtractor::class),
+            $container->get(TwigCatalogueExtractorFactory::class),
+            $container->get(CatalogueLoader::class),
             $container->get(PotGenerator::class),
             [
                 'src/Actor/templates/actor/',
                 'src/Actor/templates/actor/partials/',
                 'src/Common/templates/error/',
-                'src/Common/templates/layouts/',
+                'src/Common/templates/layout/',
                 'src/Common/templates/partials/',
                 'src/Viewer/templates/viewer/'
             ]

--- a/service-front/app/src/Common/src/ConfigProvider.php
+++ b/service-front/app/src/Common/src/ConfigProvider.php
@@ -60,6 +60,7 @@ class ConfigProvider
 
                 // Language extraction
                 \Acpr\I18n\ExtractorInterface::class => \Acpr\I18n\TwigExtractor::class,
+                \Gettext\Loader\LoaderInterface::class => \Gettext\Loader\PoLoader::class,
                 \Gettext\Generator\GeneratorInterface::class => \Gettext\Generator\PoGenerator::class
             ],
 

--- a/service-front/app/src/Common/src/Service/I18n/CatalogueLoader.php
+++ b/service-front/app/src/Common/src/Service/I18n/CatalogueLoader.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Service\I18n;
+
+use Gettext\Loader\PoLoader;
+use Gettext\Translations;
+use Symfony\Component\Finder\Finder;
+
+class CatalogueLoader
+{
+    private PoLoader $loader;
+
+    public function __construct(PoLoader $loader)
+    {
+        $this->loader = $loader;
+    }
+
+    /**
+     * Reads all '.pot' files from the given directory and loads them into a domain keyed catalogue of
+     * translations.
+     *
+     * @param string $directory
+     * @return Translations[]
+     */
+    public function loadByDirectory(string $directory): array
+    {
+        $catalogues = [];
+
+        $files = $this->findPotFiles($directory);
+
+        foreach ($files as $file) {
+            $translations = $this->loader->loadFile($file->getRealPath());
+            $catalogues[$translations->getDomain()] = $translations;
+        }
+
+        return $catalogues;
+    }
+
+    private function findPotFiles(string $directory): Finder
+    {
+        $finder = new Finder();
+
+        return $finder->files()->name('*.pot')->in($directory);
+    }
+}

--- a/service-front/app/src/Common/src/Service/I18n/CatalogueLoader.php
+++ b/service-front/app/src/Common/src/Service/I18n/CatalogueLoader.php
@@ -4,17 +4,19 @@ declare(strict_types=1);
 
 namespace Common\Service\I18n;
 
-use Gettext\Loader\PoLoader;
+use Gettext\Loader\LoaderInterface;
 use Gettext\Translations;
 use Symfony\Component\Finder\Finder;
 
 class CatalogueLoader
 {
-    private PoLoader $loader;
+    private Finder $fileFinder;
+    private LoaderInterface $loader;
 
-    public function __construct(PoLoader $loader)
+    public function __construct(LoaderInterface $loader, Finder $fileFinder)
     {
         $this->loader = $loader;
+        $this->fileFinder = $fileFinder;
     }
 
     /**
@@ -40,8 +42,6 @@ class CatalogueLoader
 
     private function findPotFiles(string $directory): Finder
     {
-        $finder = new Finder();
-
-        return $finder->files()->name('*.pot')->in($directory);
+        return $this->fileFinder->files()->name('*.pot')->in($directory);
     }
 }

--- a/service-front/app/src/Common/src/Service/I18n/TwigCatalogueExtractorFactory.php
+++ b/service-front/app/src/Common/src/Service/I18n/TwigCatalogueExtractorFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Common\Service\I18n;
 
 use Acpr\I18n\ExtractorInterface;
+use Gettext\Translations;
 
 class TwigCatalogueExtractorFactory
 {
@@ -15,7 +16,13 @@ class TwigCatalogueExtractorFactory
         $this->extractor = $extractor;
     }
 
-    public function __invoke($existing): TwigCatalogueExtractor
+    /**
+     * Allows the creation of an extractor that is aware of previous extractions.
+     *
+     * @param Translations[] $existing
+     * @return TwigCatalogueExtractor
+     */
+    public function __invoke(array $existing): TwigCatalogueExtractor
     {
         return new TwigCatalogueExtractor(
             $this->extractor,

--- a/service-front/app/src/Common/src/Service/I18n/TwigCatalogueExtractorFactory.php
+++ b/service-front/app/src/Common/src/Service/I18n/TwigCatalogueExtractorFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Service\I18n;
+
+use Acpr\I18n\ExtractorInterface;
+
+class TwigCatalogueExtractorFactory
+{
+    private ExtractorInterface $extractor;
+
+    public function __construct(ExtractorInterface $extractor)
+    {
+        $this->extractor = $extractor;
+    }
+
+    public function __invoke($existing): TwigCatalogueExtractor
+    {
+        return new TwigCatalogueExtractor(
+            $this->extractor,
+            $existing
+        );
+    }
+}

--- a/service-front/app/test/CommonTest/Command/TranslationUpdateCommandFactoryTest.php
+++ b/service-front/app/test/CommonTest/Command/TranslationUpdateCommandFactoryTest.php
@@ -6,8 +6,9 @@ namespace CommonTest\Command;
 
 use Common\Command\TranslationUpdateCommand;
 use Common\Command\TranslationUpdateCommandFactory;
+use Common\Service\I18n\CatalogueLoader;
 use Common\Service\I18n\PotGenerator;
-use Common\Service\I18n\TwigCatalogueExtractor;
+use Common\Service\I18n\TwigCatalogueExtractorFactory;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
@@ -17,8 +18,10 @@ class TranslationUpdateCommandFactoryTest extends TestCase
     public function it_creates_a_translation_update_command(): void
     {
         $containerProphecy = $this->prophesize(ContainerInterface::class);
-        $containerProphecy->get(TwigCatalogueExtractor::class)
-            ->willReturn($this->prophesize(TwigCatalogueExtractor::class)->reveal());
+        $containerProphecy->get(TwigCatalogueExtractorFactory::class)
+            ->willReturn($this->prophesize(TwigCatalogueExtractorFactory::class)->reveal());
+        $containerProphecy->get(CatalogueLoader::class)
+            ->willReturn($this->prophesize(CatalogueLoader::class)->reveal());
         $containerProphecy->get(PotGenerator::class)
             ->willReturn($this->prophesize(PotGenerator::class)->reveal());
 

--- a/service-front/app/test/CommonTest/Service/I18n/CatalogueLoaderTest.php
+++ b/service-front/app/test/CommonTest/Service/I18n/CatalogueLoaderTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommonTest\Service\I18n;
+
+use Common\Service\I18n\CatalogueLoader;
+use Gettext\Loader\LoaderInterface;
+use Gettext\Translations;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+class CatalogueLoaderTest extends TestCase
+{
+    public function getMockFileFinder(array $files): ObjectProphecy
+    {
+        $finderProphecy = $this->prophesize(Finder::class);
+        $finderProphecy->files()->willReturn($finderProphecy->reveal());
+        $finderProphecy->name('*.pot')->willReturn($finderProphecy->reveal());
+        $finderProphecy->in('/')->willReturn($finderProphecy->reveal());
+        $finderProphecy
+            ->getIterator()
+            ->willReturn(new \ArrayObject($files));
+
+        return $finderProphecy;
+    }
+
+    public function getMockFile(string $path): ObjectProphecy
+    {
+        $fileProphecy = $this->prophesize(SplFileInfo::class);
+        $fileProphecy->getRealPath()->willReturn($path);
+
+        return $fileProphecy;
+    }
+
+    public function getMockTranslations(string $domain): ObjectProphecy
+    {
+        $translations = $this->prophesize(Translations::class);
+        $translations->getDomain()->willReturn($domain);
+
+        return $translations;
+    }
+
+    /** @test */
+    public function it_will_load_all_pot_files_in_a_folder(): void
+    {
+        $poloaderProphecy = $this->prophesize(LoaderInterface::class);
+        $poloaderProphecy
+            ->loadFile('/messages.pot')
+            ->willReturn($this->getMockTranslations('messages'));
+        $poloaderProphecy
+            ->loadFile('/errors.pot')
+            ->willReturn($this->getMockTranslations('errors'));
+
+        $files = [
+            $this->getMockFile('/messages.pot')->reveal(),
+            $this->getMockFile('/errors.pot')->reveal(),
+        ];
+
+        $loader = new CatalogueLoader(
+            $poloaderProphecy->reveal(),
+            $this->getMockFileFinder($files)->reveal()
+        );
+
+        $translations = $loader->loadByDirectory('/');
+
+        $this->assertArrayHasKey('messages', $translations);
+        $this->assertArrayHasKey('errors', $translations);
+    }
+}

--- a/service-front/app/test/CommonTest/Service/I18n/TwigCatalogueExtractorFactoryTest.php
+++ b/service-front/app/test/CommonTest/Service/I18n/TwigCatalogueExtractorFactoryTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommonTest\Service\I18n;
+
+use Acpr\I18n\ExtractorInterface;
+use Common\Service\I18n\TwigCatalogueExtractor;
+use Common\Service\I18n\TwigCatalogueExtractorFactory;
+use PHPUnit\Framework\TestCase;
+
+class TwigCatalogueExtractorFactoryTest extends TestCase
+{
+    /** @test */
+    public function it_returns_an_extractor(): void
+    {
+        $factory = new TwigCatalogueExtractorFactory(
+            $this->prophesize(ExtractorInterface::class)->reveal()
+        );
+
+        $extractor = $factory([]);
+
+        $this->assertInstanceOf(TwigCatalogueExtractor::class, $extractor);
+    }
+}

--- a/service-front/app/test/CommonTest/Service/I18n/TwigCatalogueExtractorTest.php
+++ b/service-front/app/test/CommonTest/Service/I18n/TwigCatalogueExtractorTest.php
@@ -80,7 +80,10 @@ class TwigCatalogueExtractorTest extends TestCase
             'rootDir',
             null,
             [
-                'home.html.twig' => '<h1>{%trans%}Some translated twig content{%endtrans%}</h1>'
+                'home.html.twig' => '<h1>{%trans%}Some translated twig content{%endtrans%}</h1>',
+                'partials' => [
+                    'page.html.twig' => '<h1>{%trans%}Some translated twig content{%endtrans%}</h1>'
+                ]
             ]
         );
 
@@ -96,7 +99,7 @@ class TwigCatalogueExtractorTest extends TestCase
         /** @var TwigExtractor|ObjectProphecy $extractorProphecy */
         $extractorProphecy = $this->prophesize(ExtractorInterface::class);
         $extractorProphecy
-            ->extract($vfs->url())
+            ->extract(Argument::type('string'))
             ->shouldBeCalled()
             ->willReturn(
                 [ 'messages' => $translationsProphecy->reveal() ]
@@ -104,10 +107,7 @@ class TwigCatalogueExtractorTest extends TestCase
 
         $extractor = new TwigCatalogueExtractor($extractorProphecy->reveal());
 
-        $translations = $extractor->extract([$vfs->url()]);
-        $this->assertEquals(['messages' => $translationsProphecy->reveal()], $translations);
-
-        $translations = $extractor->extract([$vfs->url()]);
+        $translations = $extractor->extract([$vfs->url(), $vfs->getChild('partials')->url()]);
         $this->assertEquals(['messages' => $translationsProphecy->reveal()], $translations);
     }
 }


### PR DESCRIPTION
# Purpose

Improvements to the way the POT files are generated so that the work Lewis has to do is less fraught with errors and repetition.

## Approach

The new extractor code takes into account the current POT file when running so that the new/changed translations are placed appropriately within the new file.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes
