### PR TITLE
Handlers send passwords to Services as HiddenString.

### DIFF
--- a/service-api/app/src/App/src/Handler/AuthHandler.php
+++ b/service-api/app/src/App/src/Handler/AuthHandler.php
@@ -10,6 +10,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Laminas\Diactoros\Response\JsonResponse;
+use ParagonIE\HiddenString\HiddenString;
 
 /**
  * Class AuthHandler
@@ -41,7 +42,7 @@ class AuthHandler implements RequestHandlerInterface
             throw new BadRequestException('Email address and password must be provided');
         }
 
-        $user = $this->userService->authenticate($params['email'], $params['password']);
+        $user = $this->userService->authenticate($params['email'], new HiddenString($params['password']));
 
         return new JsonResponse($user);
     }

--- a/service-api/app/src/App/src/Handler/ChangePasswordHandler.php
+++ b/service-api/app/src/App/src/Handler/ChangePasswordHandler.php
@@ -10,6 +10,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Diactoros\Response\JsonResponse;
+use ParagonIE\HiddenString\HiddenString;
 
 /**
  * Class ChangePasswordHandler
@@ -52,8 +53,8 @@ class ChangePasswordHandler implements RequestHandlerInterface
 
         $this->userService->completeChangePassword(
             $requestData['user-id'],
-            $requestData['password'],
-            $requestData['new-password']
+            new HiddenString($requestData['password']),
+            new HiddenString($requestData['new-password'])
         );
 
         return new JsonResponse([]);

--- a/service-api/app/src/App/src/Handler/CompletePasswordResetHandler.php
+++ b/service-api/app/src/App/src/Handler/CompletePasswordResetHandler.php
@@ -10,6 +10,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Laminas\Diactoros\Response\JsonResponse;
+use ParagonIE\HiddenString\HiddenString;
 
 /**
  * Class CompletePasswordResetHandler
@@ -46,7 +47,7 @@ class CompletePasswordResetHandler implements RequestHandlerInterface
             throw new BadRequestException('Replacement password must be provided');
         }
 
-        $this->userService->completePasswordReset($requestData['token'], $requestData['password']);
+        $this->userService->completePasswordReset($requestData['token'], new HiddenString($requestData['password']));
 
         return new JsonResponse([]);
     }

--- a/service-api/app/src/App/src/Handler/RequestChangeEmailHandler.php
+++ b/service-api/app/src/App/src/Handler/RequestChangeEmailHandler.php
@@ -12,6 +12,7 @@ use Laminas\Diactoros\Response\JsonResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use ParagonIE\HiddenString\HiddenString;
 
 /**
  * Class RequestChangeEmailHandler
@@ -54,7 +55,7 @@ class RequestChangeEmailHandler implements RequestHandlerInterface
         $user = $this->userService->requestChangeEmail(
             $requestData['user-id'],
             $requestData['new-email'],
-            $requestData['password']
+            new HiddenString($requestData['password'])
         );
 
         return new JsonResponse($user);

--- a/service-api/app/src/App/src/Handler/UserHandler.php
+++ b/service-api/app/src/App/src/Handler/UserHandler.php
@@ -13,6 +13,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Laminas\Diactoros\Response\JsonResponse;
+use ParagonIE\HiddenString\HiddenString;
 
 /**
  * Class UserHandler

--- a/service-api/app/src/App/src/Service/User/UserService.php
+++ b/service-api/app/src/App/src/Service/User/UserService.php
@@ -141,7 +141,7 @@ class UserService
     {
         $user = $this->usersRepository->getByEmail($email);
 
-        if (! password_verify($password->getString(), $user['Password'])->getString()) {
+        if (! password_verify($password->getString(), $user['Password'])) {
             throw new ForbiddenException('Authentication failed for email ' . $email, ['email' => $email ]);
         }
 

--- a/service-api/app/test/AppTest/Service/User/UserServiceTest.php
+++ b/service-api/app/test/AppTest/Service/User/UserServiceTest.php
@@ -83,7 +83,7 @@ class UserServiceTest extends TestCase
     /** @test */
     public function cannot_add_existing_user()
     {
-        $userData = ['email' => 'a@b.com', 'password' => new HiddenString(self::PASS)];
+        $userData = ['email' => 'a@b.com', 'password' => self::PASS];
 
         $repoProphecy = $this->prophesize(ActorUsersInterface::class);
         $loggerProphecy = $this->prophesize(LoggerInterface::class);
@@ -189,7 +189,7 @@ class UserServiceTest extends TestCase
         $loggerProphecy = $this->prophesize(LoggerInterface::class);
 
         $repoProphecy->getByEmail('a@b.com')
-            ->willReturn(['Email' => 'a@b.com', 'Password' => new HiddenString(self::PASS_HASH), 'ActivationToken' => 'aToken', 'Id' => '1234-1234-1234']);
+            ->willReturn(['Email' => 'a@b.com', 'Password' => self::PASS_HASH, 'ActivationToken' => 'aToken', 'Id' => '1234-1234-1234']);
 
         $us = new UserService($repoProphecy->reveal(), $loggerProphecy->reveal());
 
@@ -224,7 +224,7 @@ class UserServiceTest extends TestCase
     public function will_reset_a_password_given_a_valid_token()
     {
         $token = 'RESET_TOKEN_123';
-        $password = new HiddenString('newpassword');
+        $password = 'newpassword';
         $id = '12345-1234-1234-1234-12345';
 
         $repoProphecy = $this->prophesize(ActorUsersInterface::class);
@@ -250,7 +250,7 @@ class UserServiceTest extends TestCase
 
         $us = new UserService($repoProphecy->reveal(), $loggerProphecy->reveal());
 
-        $us->completePasswordReset($token, $password);
+        $us->completePasswordReset($token, new HiddenString($password));
     }
 
     /** @test */
@@ -280,7 +280,7 @@ class UserServiceTest extends TestCase
         $us = new UserService($repoProphecy->reveal(), $loggerProphecy->reveal());
 
         $this->expectException(BadRequestException::class);
-        $us->completePasswordReset($token, $password);
+        $us->completePasswordReset($token, new HiddenString($password));
     }
 
     /** @test */
@@ -371,7 +371,7 @@ class UserServiceTest extends TestCase
             'Id'        => $id,
             'Email'     => 'a@b.com',
             'LastLogin' => null,
-            'Password'  => new HiddenString(self::PASS_HASH)
+            'Password'  => self::PASS_HASH
         ];
 
         $repoProphecy = $this->prophesize(ActorUsersInterface::class);
@@ -460,7 +460,7 @@ class UserServiceTest extends TestCase
             'Id'        => $id,
             'Email'     => 'a@b.com',
             'LastLogin' => null,
-            'Password'  => new HiddenString(self::PASS_HASH)
+            'Password'  => self::PASS_HASH
         ];
 
         $repoProphecy = $this->prophesize(ActorUsersInterface::class);
@@ -474,7 +474,7 @@ class UserServiceTest extends TestCase
         $us = new UserService($repoProphecy->reveal(), $loggerProphecy->reveal());
 
         $this->expectException(ForbiddenException::class);
-        $us->requestChangeEmail($id, $newEmail, 'inc0rr3ct');
+        $us->requestChangeEmail($id, $newEmail, new HiddenString('inc0rr3ct'));
     }
 
     /** @test */
@@ -487,7 +487,7 @@ class UserServiceTest extends TestCase
             'Id'        => $id,
             'Email'     => 'a@b.com',
             'LastLogin' => null,
-            'Password'  => new HiddenString(self::PASS_HASH)
+            'Password'  => self::PASS_HASH
         ];
 
         $repoProphecy = $this->prophesize(ActorUsersInterface::class);
@@ -519,7 +519,7 @@ class UserServiceTest extends TestCase
             'Id'        => $id,
             'Email'     => 'a@b.com',
             'LastLogin' => null,
-            'Password'  => new HiddenString(self::PASS_HASH)
+            'Password'  => self::PASS_HASH
         ];
 
         $repoProphecy = $this->prophesize(ActorUsersInterface::class);
@@ -599,7 +599,7 @@ class UserServiceTest extends TestCase
                 'Id'               => $id,
                 'NewEmail'         => $newEmail,
                 'EmailResetToken'  => $token,
-                'Password'         => new HiddenString(self::PASS_HASH),
+                'Password'         => self::PASS_HASH,
             ])
             ->shouldBeCalled();
 

--- a/service-api/app/test/AppTest/Service/User/UserServiceTest.php
+++ b/service-api/app/test/AppTest/Service/User/UserServiceTest.php
@@ -104,13 +104,13 @@ class UserServiceTest extends TestCase
         $loggerProphecy = $this->prophesize(LoggerInterface::class);
 
         $repoProphecy->getByEmail('a@b.com')
-            ->willReturn(['Email' => 'a@b.com', 'Password' => new HiddenString(self::PASS_HASH)]);
+            ->willReturn(['Email' => 'a@b.com', 'Password' => self::PASS_HASH]);
 
         $us = new UserService($repoProphecy->reveal(), $loggerProphecy->reveal());
 
         $return = $us->getByEmail('a@b.com');
 
-        $this->assertEquals(['Email' => 'a@b.com', 'Password' => new HiddenString(self::PASS_HASH)], $return);
+        $this->assertEquals(['Email' => 'a@b.com', 'Password' => self::PASS_HASH], $return);
     }
 
     /** @test */
@@ -135,7 +135,7 @@ class UserServiceTest extends TestCase
         $loggerProphecy = $this->prophesize(LoggerInterface::class);
 
         $repoProphecy->getByEmail('a@b.com')
-            ->willReturn(['Id' => '1234-1234-1234', 'Email' => 'a@b.com', 'Password' => new HiddenString(self::PASS_HASH), 'LastLogin' => '2020-01-01']);
+            ->willReturn(['Id' => '1234-1234-1234', 'Email' => 'a@b.com', 'Password' => self::PASS_HASH, 'LastLogin' => '2020-01-01']);
         $repoProphecy->recordSuccessfulLogin('1234-1234-1234', Argument::that(function($dateTime) {
             $this->assertIsString($dateTime);
 

--- a/service-front/app/src/Actor/src/Handler/CreateAccountHandler.php
+++ b/service-front/app/src/Actor/src/Handler/CreateAccountHandler.php
@@ -18,6 +18,7 @@ use Laminas\Diactoros\Response\HtmlResponse;
 use Mezzio\Helper\ServerUrlHelper;
 use Mezzio\Helper\UrlHelper;
 use Mezzio\Template\TemplateRendererInterface;
+use ParagonIE\HiddenString\HiddenString;
 
 /**
  * Class CreateAccountHandler
@@ -78,7 +79,7 @@ class CreateAccountHandler extends AbstractHandler implements CsrfGuardAware
                 $formData = $form->getData();
 
                 $emailAddress = $formData['email'];
-                $password = $formData['password'];
+                $password = new HiddenString($formData['password']);
 
                 try {
                     $userData = $this->userService->create($emailAddress, $password);

--- a/service-front/app/src/Actor/src/Handler/LpaAddHandler.php
+++ b/service-front/app/src/Actor/src/Handler/LpaAddHandler.php
@@ -18,6 +18,7 @@ use Laminas\Diactoros\Response\HtmlResponse;
 use Mezzio\Authentication\AuthenticationInterface;
 use Mezzio\Helper\UrlHelper;
 use Mezzio\Template\TemplateRendererInterface;
+use ParagonIE\HiddenString\HiddenString;
 
 /**
  * Class LpaAddHandler

--- a/service-front/app/src/Actor/src/Handler/PasswordResetPageHandler.php
+++ b/service-front/app/src/Actor/src/Handler/PasswordResetPageHandler.php
@@ -15,6 +15,7 @@ use Laminas\Diactoros\Response\HtmlResponse;
 use Mezzio\Helper\ServerUrlHelper;
 use Mezzio\Helper\UrlHelper;
 use Mezzio\Template\TemplateRendererInterface;
+use ParagonIE\HiddenString\HiddenString;
 
 /**
  * Class PasswordResetPageHandler
@@ -72,7 +73,7 @@ class PasswordResetPageHandler extends AbstractHandler implements CsrfGuardAware
             if ($form->isValid()) {
                 $data = $form->getData();
 
-                $this->userService->completePasswordReset($request->getAttribute('token'), $data['password']);
+                $this->userService->completePasswordReset($request->getAttribute('token'), new HiddenString($data['password']));
 
                 //  Redirect to the login screen with success flash message
                 return $this->redirectToRoute('login');

--- a/service-front/app/src/Common/src/Service/User/UserService.php
+++ b/service-front/app/src/Common/src/Service/User/UserService.php
@@ -99,11 +99,10 @@ class UserService implements UserRepositoryInterface
     public function authenticate(string $email, HiddenString $password = null): ?UserInterface
     {
         try {
-            if (is_null($password) {
-                $unhiddenPassword = null
-            }
-            else {
-                $unhiddenPassword = $password->getString()
+            if (is_null($password)) {
+                $unhiddenPassword = null;
+            } else {
+                $unhiddenPassword = $password->getString();
             }
 
             $userData = $this->apiClient->httpPatch('/v1/auth', [


### PR DESCRIPTION

# Purpose

_UML-694 To remove chance of passwords leaking into logs, they will now be passed as HiddenString when sent from Handlers to Services_

## Approach

_Update the relevant Handlers to send passwords as HiddenString to Services_
_Update the Services to get the string out of HiddenString_
_Update tests to pass in HiddenStrings_

## Learning

_to fill in_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
