### PR TITLE
Using the new localstack's single entrypoint.

### DIFF
--- a/docker-compose.dependencies.yml
+++ b/docker-compose.dependencies.yml
@@ -5,10 +5,10 @@ services:
   localstack:
     image: localstack/localstack
     ports:
-      - 4569:14569
-      - 8000:14569
+      - 4569:4566
+      - 8000:4566
     environment:
-      - SERVICES=dynamodb:14569
+      - SERVICES=dynamodb
       - DEFAULT_REGION=eu-west-1
       - HOSTNAME=gateway-localstack
     networks:
@@ -28,6 +28,8 @@ services:
       - ../opg-sirius-api-gateway/localstack-config:/config
     depends_on:
       - localstack
+    environment:
+      AWS_ENDPOINT_DYNAMODB: localstack:4566
 
   lpa-gateway:
     build:
@@ -46,7 +48,7 @@ services:
 
       PASSTHROUGH_DYNAMODB_DATA_CACHE_TABLE_NAME: opg-gateway-cache-data
       PASSTHROUGH_DYNAMODB_AUTH_CACHE_TABLE_NAME: opg-gateway-cache-auth
-      PASSTHROUGH_AWS_ENDPOINT_DYNAMODB : http://localstack:14569
+      PASSTHROUGH_AWS_ENDPOINT_DYNAMODB : http://localstack:4566
       PASSTHROUGH_URL_MEMBRANE: https://membrane
       PASSTHROUGH_CREDENTIALS: '{"email": "publicapi@opgtest.com","password": "Password1"}' # Non-secret credentials, deliberately committed.
       PASSTHROUGH_ENABLE_DEBUG: 'false'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,7 +184,7 @@ services:
 
       # Local only
       AWS_ACCESS_KEY_ID: "-"
-      AWS_ENDPOINT_DYNAMODB: http://localstack:14569
+      AWS_ENDPOINT_DYNAMODB: http://localstack:4566
       AWS_SECRET_ACCESS_KEY: "-"
       LPA_CODES_STATIC_AUTH_TOKEN: asdf1234567890
       PACT_BROKER_PUBLISH: "false"
@@ -219,5 +219,5 @@ services:
       DYNAMODB_TABLE_VIEWER_CODES: "ViewerCodes"
       DYNAMODB_TABLE_ACTOR_USERS: "ActorUsers"
       DYNAMODB_TABLE_USER_LPA_ACTOR_MAP: "UserLpaActorMap"
-      AWS_ENDPOINT_DYNAMODB: localstack:14569
+      AWS_ENDPOINT_DYNAMODB: localstack:4566
       CODES_ENDPOINT: codes-gateway:4343


### PR DESCRIPTION
# Purpose
The new version of localstack uses a single entrypoint for all it's services which means our docker-compose setup
broke as it was pointing at ports that simply don't exist anymore. This PR corrects all the environment variables to be
the right values.

Note: This PR will break your local environment *until* you update your opg-sirius-api-gateway project

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [x] I have added welsh translation tags and updated translation files
* [x] The product team have tested these changes
