### PR TITLE
Upgrade docker version for circle due to deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -540,7 +540,7 @@ orbs:
           - checkout
           - install_aws_cli
           - setup_remote_docker:
-              version: 18.06.0-ce
+              version: 19.03.12
               docker_layer_caching: false
           - attach_workspace:
               at: ~/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -471,7 +471,7 @@ orbs:
           - checkout
           - install_aws_cli
           - setup_remote_docker:
-              version: 18.06.0-ce
+              version: 19.03.12
               docker_layer_caching: false
           - attach_workspace:
               at: ~/project
@@ -583,7 +583,7 @@ orbs:
           - checkout
           - install_aws_cli
           - setup_remote_docker:
-              version: 18.06.0-ce
+              version: 19.03.12
               docker_layer_caching: false
           - run:
               name: Build
@@ -653,7 +653,7 @@ orbs:
           - checkout
           - install_aws_cli
           - setup_remote_docker:
-              version: 18.06.0-ce
+              version: 19.03.12
               docker_layer_caching: false
           - run:
               name: Build
@@ -690,7 +690,7 @@ orbs:
           - checkout
           - install_aws_cli
           - setup_remote_docker:
-              version: 18.06.0-ce
+              version: 19.03.12
               docker_layer_caching: false
           - run:
               name: Build


### PR DESCRIPTION
# Purpose

Update the docker remote version due to deprecation of the current version

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] The product team have tested these changes
