### PR TITLE
add docker auth to circleci image pulls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,6 +306,7 @@ orbs:
                 sudo ln -sf /usr/bin/python3-config python-config
       dockerhub_login:
         steps:
+          - docker/install-docker-credential-helper
           - docker/check:
               docker-password: DOCKER_ACCESS_TOKEN
               docker-username: DOCKER_USER

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,22 +316,46 @@ orbs:
 
     executors:
       puppeteer:
-        docker: [image: buildkite/puppeteer]
+        docker:
+          - image: buildkite/puppeteer
+            auth:
+              username: $DOCKER_USER
+              password: $DOCKER_ACCESS_TOKEN
         resource_class: small
       php:
-        docker: [image: circleci/php:7-cli]
+        docker:
+          - image: circleci/php:7-cli
+            auth:
+              username: $DOCKER_USER
+              password: $DOCKER_ACCESS_TOKEN
         resource_class: small
       php-browsers:
-        docker: [image: circleci/php:7-cli-browsers]
+        docker:
+          - image: circleci/php:7-cli-browsers
+            auth:
+              username: $DOCKER_USER
+              password: $DOCKER_ACCESS_TOKEN
         resource_class: small
       node-browsers:
-        docker: [image: circleci/node:14.0-browsers]
+        docker:
+          - image: circleci/node:14.0-browsers
+            auth:
+              username: $DOCKER_USER
+              password: $DOCKER_ACCESS_TOKEN
         resource_class: small
       python:
-        docker: [image: circleci/python]
+        docker:
+          - image: circleci/python
+            auth:
+              username: $DOCKER_USER
+              password: $DOCKER_ACCESS_TOKEN
         resource_class: small
       terraform:
-        docker: [image: hashicorp/terraform:latest]
+        docker:
+          - image: hashicorp/terraform:latest
+            auth:
+              username: $DOCKER_USER
+              password: $DOCKER_ACCESS_TOKEN
         resource_class: small
 
     jobs:
@@ -1001,6 +1025,9 @@ jobs:
   slack_environment_redeploy:
     docker:
       - image: circleci/python
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_ACCESS_TOKEN
     resource_class: small
     parameters:
       environment:
@@ -1019,6 +1046,9 @@ jobs:
   slack_notify_domain:
     docker:
       - image: circleci/python
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_ACCESS_TOKEN
     resource_class: small
     steps:
       - checkout
@@ -1037,6 +1067,9 @@ jobs:
   slack_notify_production_release:
     docker:
       - image: circleci/python
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_ACCESS_TOKEN
     resource_class: small
     steps:
       - checkout
@@ -1056,6 +1089,9 @@ jobs:
   ecr_scan_results:
     docker:
       - image: circleci/python
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_ACCESS_TOKEN
     resource_class: small
     steps:
       - checkout
@@ -1070,6 +1106,9 @@ jobs:
   workspace_cleanup:
     docker:
       - image: hashicorp/terraform:latest
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_ACCESS_TOKEN
     resource_class: small
     steps:
       - checkout
@@ -1083,6 +1122,9 @@ jobs:
   cancel_redundant_builds:
     docker:
       - image: circleci/python
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_ACCESS_TOKEN
     resource_class: small
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,6 +284,8 @@ workflows:
 orbs:
   slack: circleci/slack@3.3.0
   use-my-lpa:
+    orbs:
+      docker: circleci/docker@1.4.0
     commands:
       install_aws_cli:
         steps:
@@ -302,6 +304,11 @@ orbs:
                 sudo ln -sf /usr/bin/pydoc3 pydoc
                 sudo ln -sf /usr/bin/python3 python
                 sudo ln -sf /usr/bin/python3-config python-config
+      dockerhub_login:
+        steps:
+          - docker/check:
+              docker-password: DOCKER_ACCESS_TOKEN
+              docker-username: DOCKER_USER
       ecr_login:
         steps:
           - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -506,6 +506,7 @@ orbs:
               docker_layer_caching: false
           - attach_workspace:
               at: ~/project
+          - dockerhub_login
           - run:
               name: Build
               command: |
@@ -575,6 +576,7 @@ orbs:
               docker_layer_caching: false
           - attach_workspace:
               at: ~/project
+          - dockerhub_login
           - run:
               name: Build
               command: |
@@ -616,6 +618,7 @@ orbs:
           - setup_remote_docker:
               version: 19.03.12
               docker_layer_caching: false
+          - dockerhub_login
           - run:
               name: Build
               command: |
@@ -686,6 +689,7 @@ orbs:
           - setup_remote_docker:
               version: 19.03.12
               docker_layer_caching: false
+          - dockerhub_login
           - run:
               name: Build
               command: |
@@ -723,6 +727,7 @@ orbs:
           - setup_remote_docker:
               version: 19.03.12
               docker_layer_caching: false
+          - dockerhub_login
           - run:
               name: Build
               command: |


### PR DESCRIPTION
# Purpose

The introduction of limits for anonymous docker image pulls from docker hub requires us to add authentication for all docker commands.

There are 2 sets of docker commands that have to be authorised on our CircleCI pipelines.

Pulls of CircleCI images as the executors of our jobs.
Pullls of images from docker hub as the base for our build artifacts.

Fixes UML-1106

## Approach

Add authentication to executor definitions. ( https://circleci.com/docs/2.0/private-images/)
Add authentication to docker pull commands using the CircleCI Docker orb.

## Learning


## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] The product team have tested these changes
