### PR TITLE
UML-1086-Display-co-actors-access-codes

### DIFF
--- a/service-api/app/features/actor-check-access-codes.feature
+++ b/service-api/app/features/actor-check-access-codes.feature
@@ -21,3 +21,10 @@ Feature: The user is able to check the access codes they have created
     Given I have created an access code
     When I click to check my access code now expired
     Then I should be shown the details of the viewer code with status "EXPIRED"
+
+  @integration @acceptance
+  Scenario: As a user I can see all the access codes for the LPA I have added to my account
+    Given I have created an access code
+    And Co-actors have also created access codes for the same LPA
+    When I click to check the access codes
+    Then I can see all of the access codes and their details

--- a/service-api/app/src/App/src/DataAccess/DynamoDb/ViewerCodes.php
+++ b/service-api/app/src/App/src/DataAccess/DynamoDb/ViewerCodes.php
@@ -58,7 +58,7 @@ class ViewerCodes implements ViewerCodesInterface
     /**
      * @inheritDoc
      */
-    public function getCodesByUserLpaActorId(string $siriusUid, string $userLpaActor): array
+    public function getCodesByLpaId(string $siriusUid): array
     {
         $marshaler = new Marshaler();
 
@@ -66,10 +66,8 @@ class ViewerCodes implements ViewerCodesInterface
             'TableName' => $this->viewerCodesTable,
             'IndexName' => 'SiriusUidIndex',
             'KeyConditionExpression' => 'SiriusUid = :uId',
-            'FilterExpression' => 'UserLpaActor = :actor',
             'ExpressionAttributeValues' => $marshaler->marshalItem([
                 ':uId' => $siriusUid,
-                ':actor' => $userLpaActor
             ]),
         ]);
 

--- a/service-api/app/src/App/src/DataAccess/Repository/ViewerCodesInterface.php
+++ b/service-api/app/src/App/src/DataAccess/Repository/ViewerCodesInterface.php
@@ -21,10 +21,9 @@ interface ViewerCodesInterface
      * Gets a list of viewer codes for a given LPA
      *
      * @param string $siriusUid
-     * @param string $userLpaActorId
      * @return array
      */
-    public function getCodesByUserLpaActorId(string $siriusUid, string $userLpaActorId): array;
+    public function getCodesByLpaId(string $siriusUid): array;
 
     /**
      * Adds a code to the database.

--- a/service-api/app/src/App/src/Handler/LpasResourceCodesCollectionHandler.php
+++ b/service-api/app/src/App/src/Handler/LpasResourceCodesCollectionHandler.php
@@ -17,6 +17,7 @@ use RuntimeException;
 /**
  * Class LpasResourceCodesCollectionHandler
  * @package App\Handler
+ * @codeCoverageIgnore
  */
 class LpasResourceCodesCollectionHandler implements RequestHandlerInterface
 {

--- a/service-api/app/src/App/src/Handler/LpasResourceCodesCollectionHandler.php
+++ b/service-api/app/src/App/src/Handler/LpasResourceCodesCollectionHandler.php
@@ -154,13 +154,12 @@ class LpasResourceCodesCollectionHandler implements RequestHandlerInterface
         if (!empty($viewerCodes)) {
             $viewerCodesAndStatuses = $this->viewerCodeActivityRepository->getStatusesForViewerCodes($viewerCodes);
 
-            //gets the LPA in question
-            $lpa = $this->userLpaActorMap->get($request->getAttribute('user-lpa-actor-token'));
-
-            //adds the same actorId for each code in the array
-            //the actorId value is that of the LPA data returned for the given user token
-            foreach ($viewerCodesAndStatuses as $key => $code){
-                $viewerCodesAndStatuses[$key]['ActorId'] = $lpa['ActorId'];
+            // Get the actor id for the respective sharecode by UserLpaActor
+            foreach ($viewerCodesAndStatuses as $key => $viewerCode) {
+                if (!empty($viewerCode['UserLpaActor'])) {
+                    $codeOwner = $this->userLpaActorMap->get($viewerCode['UserLpaActor']);
+                    $viewerCodesAndStatuses[$key]['ActorId'] = $codeOwner['ActorId'];
+                }
             }
 
             return new JsonResponse($viewerCodesAndStatuses);

--- a/service-api/app/src/App/src/Service/ViewerCodes/ViewerCodeService.php
+++ b/service-api/app/src/App/src/Service/ViewerCodes/ViewerCodeService.php
@@ -94,7 +94,7 @@ class ViewerCodeService
 
         $siriusUid = $map['SiriusUid'];
 
-        return $this->viewerCodesRepository->getCodesByUserLpaActorId($siriusUid, $token);
+        return $this->viewerCodesRepository->getCodesByLpaId($siriusUid);
     }
 
     /**

--- a/service-api/app/test/AppTest/DataAccess/DynamoDb/ViewerCodesTest.php
+++ b/service-api/app/test/AppTest/DataAccess/DynamoDb/ViewerCodesTest.php
@@ -98,25 +98,21 @@ class ViewerCodesTest extends TestCase
     }
 
     /** @test */
-    public function can_query_by_user_lpa_actor_id(){
+    public function can_query_by_lpa_id(){
 
         $testSiriusUid = '98765-43210';
-        $testActorId = '12345-67891';
 
-        $this->dynamoDbClientProphecy->query(Argument::that(function(array $data) use ($testSiriusUid, $testActorId) {
+        $this->dynamoDbClientProphecy->query(Argument::that(function(array $data) use ($testSiriusUid) {
             $this->assertArrayHasKey('TableName', $data);
             $this->assertEquals(self::TABLE_NAME, $data['TableName']);
 
             $this->assertArrayHasKey('IndexName', $data);
             $this->assertEquals('SiriusUidIndex', $data['IndexName']);
 
-            $this->assertArrayHasKey('FilterExpression', $data);
             $this->assertArrayHasKey('ExpressionAttributeValues', $data);
             $this->assertArrayHasKey(':uId', $data['ExpressionAttributeValues']);
-            $this->assertArrayHasKey(':actor', $data['ExpressionAttributeValues']);
 
             $this->assertEquals(['S' => $testSiriusUid], $data['ExpressionAttributeValues'][':uId']);
-            $this->assertEquals(['S' => $testActorId], $data['ExpressionAttributeValues'][':actor']);
 
             return true;
         }))
@@ -126,9 +122,6 @@ class ViewerCodesTest extends TestCase
                         'SiriusUid' => [
                             'S' => $testSiriusUid,
                         ],
-                        'UserLpaActor' => [
-                            'S' => $testActorId,
-                        ],
                     ]
                 ],
                 'Count' => 1
@@ -136,32 +129,27 @@ class ViewerCodesTest extends TestCase
 
         $repo = new ViewerCodes($this->dynamoDbClientProphecy->reveal(), self::TABLE_NAME);
 
-        $result = $repo->getCodesByUserLpaActorId($testSiriusUid, $testActorId);
+        $result = $repo->getCodesByLpaId($testSiriusUid);
 
         $this->assertEquals($testSiriusUid, $result[0]['SiriusUid']);
-        $this->assertEquals($testActorId, $result[0]['UserLpaActor']);
     }
 
     /** @test */
     public function lpa_with_no_generated_codes_returns_empty_array(){
 
         $testSiriusUid = '98765-43210';
-        $testActorId = '12345-67891';
 
-        $this->dynamoDbClientProphecy->query(Argument::that(function(array $data) use ($testSiriusUid, $testActorId) {
+        $this->dynamoDbClientProphecy->query(Argument::that(function(array $data) use ($testSiriusUid) {
             $this->assertArrayHasKey('TableName', $data);
             $this->assertEquals(self::TABLE_NAME, $data['TableName']);
 
             $this->assertArrayHasKey('IndexName', $data);
             $this->assertEquals('SiriusUidIndex', $data['IndexName']);
 
-            $this->assertArrayHasKey('FilterExpression', $data);
             $this->assertArrayHasKey('ExpressionAttributeValues', $data);
             $this->assertArrayHasKey(':uId', $data['ExpressionAttributeValues']);
-            $this->assertArrayHasKey(':actor', $data['ExpressionAttributeValues']);
 
             $this->assertEquals(['S' => $testSiriusUid], $data['ExpressionAttributeValues'][':uId']);
-            $this->assertEquals(['S' => $testActorId], $data['ExpressionAttributeValues'][':actor']);
 
             return true;
         }))
@@ -172,7 +160,7 @@ class ViewerCodesTest extends TestCase
 
         $repo = new ViewerCodes($this->dynamoDbClientProphecy->reveal(), self::TABLE_NAME);
 
-        $result = $repo->getCodesByUserLpaActorId($testSiriusUid, $testActorId);
+        $result = $repo->getCodesByLpaId($testSiriusUid);
 
         $this->assertEmpty($result);
     }

--- a/service-api/app/test/AppTest/Service/ViewerCodes/ViewerCodeServiceTest.php
+++ b/service-api/app/test/AppTest/Service/ViewerCodes/ViewerCodeServiceTest.php
@@ -165,7 +165,7 @@ class ViewerCodeServiceTest extends TestCase
     {
         $viewerCodeRepoProphecy = $this->prophesize(ViewerCodesInterface::class);
         $viewerCodeRepoProphecy
-            ->getCodesByUserLpaActorId('700000000047', 'user_actor_lpa_token')
+            ->getCodesByLpaId('700000000047')
             ->shouldBeCalled()
             ->willReturn(['some_lpa_code_data']);
 


### PR DESCRIPTION
# Purpose

Allows user to see viewer codes created by other actors on the same LPA. The active codes count on the dashboard will also reflect a total of the current users viewer codes and those created by other actors

Fixes UML-1086

## Approach

Renamed the viewer code function getCodesByUserLpaActorId to getCodesByLpaId and removed the UserLpaActor filter. I changed the for loop inside the LpasResourceCodesCollectionHandler to get use the userLpaActorMap of each viewer code. This is then used to get the actor id of the user who created that code and set that actor id as a new key/value on the viewer code data. I added a behat test and updated existing check access codes/ dashboard tests to reflect the new expected behaviour

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] The product team have tested these changes
