### PR TITLE
UML-1112 - Fix ECR scan results message in Slack posts

### DIFF
--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -93,11 +93,10 @@ class ECRScanChecker:
 
                     for finding in findings["findings"]:
                         cve = finding["name"]
-                        description = finding["description"]
                         severity = finding["severity"]
                         link = finding["uri"]
-                        result = "*Image:* {0} \n**Tag:* {1} \n*Severity:* {2} \n*CVE:* {3} \n*Description:* {4} \n*Link:* {5}\n\n".format(
-                            image, tag, severity, cve, description, link)
+                        result = "*Image:* {0} \n**Tag:* {1} \n*Severity:* {2} \n*CVE:* {3} \n*Link:* {4}\n\n".format(
+                            image, tag, severity, cve, link)
                         self.report += result
                     print(self.report)
             except:

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -94,9 +94,14 @@ class ECRScanChecker:
                     for finding in findings["findings"]:
                         cve = finding["name"]
                         severity = finding["severity"]
+
+                        description = "None"
+                        if "description" in findings:
+                            description = finding["description"]
+
                         link = finding["uri"]
-                        result = "*Image:* {0} \n**Tag:* {1} \n*Severity:* {2} \n*CVE:* {3} \n*Link:* {4}\n\n".format(
-                            image, tag, severity, cve, link)
+                        result = "*Image:* {0} \n**Tag:* {1} \n*Severity:* {2} \n*CVE:* {3} \n*Description:* {4} \n*Link:* {5}\n\n".format(
+                            image, tag, severity, cve, description, link)
                         self.report += result
                     print(self.report)
             except:

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -96,7 +96,7 @@ class ECRScanChecker:
                         severity = finding["severity"]
 
                         description = "None"
-                        if "description" in findings:
+                        if "description" in finding:
                             description = finding["description"]
 
                         link = finding["uri"]


### PR DESCRIPTION
# Purpose

Provide information to developers about any vulnerabilities found in ECR image scans.
The script had stopped providing a report when posting to slack.

Fixes UML-1112

## Approach

A description is no longer part of the response for ECR scan findings. This has been removed and the content of the report updated.

Checking an older tag that has since been patched
```
aws-vault exec identity -- python aws_ecr_scan_results.py --search use_an_lpa --tag master-f46db60
Waiting for ECR scans to complete...
ECR image scans complete
Checking ECR scan results...
:warning: *AWS ECR Scan found results for use_an_lpa/front_app:* 
Severity finding counts:
{'UNDEFINED': 2}
Displaying the first 5 in order of severity

*Image:* use_an_lpa/front_app 
**Tag:* master-f46db60 
*Severity:* UNDEFINED 
*CVE:* CVE-2020-8177 
*Link:* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8177

*Image:* use_an_lpa/front_app 
**Tag:* master-f46db60 
*Severity:* UNDEFINED 
*CVE:* CVE-2020-8169 
*Link:* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8169

:warning: *AWS ECR Scan found results for use_an_lpa/api_app:* 
Severity finding counts:
{'UNDEFINED': 2}
Displaying the first 5 in order of severity

*Image:* use_an_lpa/api_app 
**Tag:* master-f46db60 
*Severity:* UNDEFINED 
*CVE:* CVE-2020-8177 
*Link:* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8177

*Image:* use_an_lpa/api_app 
**Tag:* master-f46db60 
*Severity:* UNDEFINED 
*CVE:* CVE-2020-8169 
*Link:* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8169

No slack webhook provided, skipping post of results to slack
```

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] The product team have tested these changes
