### PR TITLE
Uml1105 head request uses activation token

### DIFF
--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -31,6 +31,7 @@ use Psr\Http\Message\RequestInterface;
  * @property $organisation
  * @property $newUserEmail
  * @property $userEmailResetToken
+ * @property $activationToken
  */
 class AccountContext implements Context
 {

--- a/service-front/app/src/Actor/src/Handler/ActivateAccountHandler.php
+++ b/service-front/app/src/Actor/src/Handler/ActivateAccountHandler.php
@@ -62,7 +62,7 @@ class ActivateAccountHandler extends AbstractHandler
     {
         $activationToken = $request->getAttribute('token');
 
-        // The implicitHeadMiddleware will attach an attribute to the request if it detects a HEAD request
+        // The ImplicitHeadMiddleware will attach an attribute to the request if it detects a HEAD request
         // We only want to continue with account activation if it is not there.
         if (
             $request->getAttribute(
@@ -70,14 +70,17 @@ class ActivateAccountHandler extends AbstractHandler
                 false
             ) === false
         ) {
+            /** @var bool|string $activated */
             $activated = $this->userService->activate($activationToken);
 
-            $loginUrl = $this->urlHelper->generate('login');
-            $signInLink = $this->serverUrlHelper->generate($loginUrl);
+            if (is_string($activated)) {
+                $loginUrl = $this->urlHelper->generate('login');
+                $signInLink = $this->serverUrlHelper->generate($loginUrl);
 
-            $this->emailClient->sendAccountActivatedConfirmationEmail($activated, $signInLink);
+                $this->emailClient->sendAccountActivatedConfirmationEmail($activated, $signInLink);
 
-            return new HtmlResponse($this->renderer->render('actor::activate-account'));
+                return new HtmlResponse($this->renderer->render('actor::activate-account'));
+            }
         }
 
         return new HtmlResponse($this->renderer->render('actor::activate-account-not-found'));

--- a/service-front/app/src/Actor/src/Handler/CompleteChangeEmailHandler.php
+++ b/service-front/app/src/Actor/src/Handler/CompleteChangeEmailHandler.php
@@ -13,6 +13,7 @@ use Common\Service\User\UserService;
 use Laminas\Diactoros\Response\HtmlResponse;
 use Mezzio\Authentication\UserInterface;
 use Mezzio\Helper\UrlHelper;
+use Mezzio\Router\Middleware\ImplicitHeadMiddleware;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -55,17 +56,26 @@ class CompleteChangeEmailHandler extends AbstractHandler implements UserAware, S
     {
         $resetToken = $request->getAttribute('token');
 
-        $tokenValid = $this->userService->canResetEmail($resetToken);
+        // The implicitHeadMiddleware will attach an attribute to the request if it detects a HEAD request
+        // We only want to continue with email changing if it is not there.
+        if (
+            $request->getAttribute(
+                ImplicitHeadMiddleware::FORWARDED_HTTP_METHOD_ATTRIBUTE,
+                false
+            ) === false
+        ) {
+            $tokenValid = $this->userService->canResetEmail($resetToken);
 
-        if (!$tokenValid) {
-            return new HtmlResponse($this->renderer->render('actor::email-reset-not-found'));
+            if (!$tokenValid) {
+                return new HtmlResponse($this->renderer->render('actor::email-reset-not-found'));
+            }
+
+            $this->userService->completeChangeEmail($resetToken);
+
+            $session = $this->getSession($request, 'session');
+            $session->unset(UserInterface::class);
+            $session->regenerate();
         }
-
-        $this->userService->completeChangeEmail($resetToken);
-
-        $session = $this->getSession($request, 'session');
-        $session->unset(UserInterface::class);
-        $session->regenerate();
 
         return $this->redirectToRoute('login');
     }

--- a/service-front/app/src/Common/src/Service/User/UserService.php
+++ b/service-front/app/src/Common/src/Service/User/UserService.php
@@ -11,9 +11,9 @@ use Exception;
 use Fig\Http\Message\StatusCodeInterface;
 use Mezzio\Authentication\UserInterface;
 use Mezzio\Authentication\UserRepositoryInterface;
+use ParagonIE\HiddenString\HiddenString;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
-use ParagonIE\HiddenString\HiddenString;
 
 /**
  * Class UserService
@@ -144,7 +144,7 @@ class UserService implements UserRepositoryInterface
 
     /**
      * @param string $activationToken
-     * @return false|mixed
+     * @return bool|string
      */
     public function activate(string $activationToken)
     {
@@ -162,7 +162,7 @@ class UserService implements UserRepositoryInterface
                     ]
                 );
 
-                return $userData['Email'];
+                return (string)$userData['Email'];
             }
         } catch (ApiException $ex) {
             if ($ex->getCode() !== StatusCodeInterface::STATUS_NOT_FOUND) {


### PR DESCRIPTION
# Purpose

The Microsoft SafeURL service sends a preemptive HEAD request to a url to check that it is "safe" before sending its users on. The previous piece of code that we had did not distinguish between HEAD and GET and so was activating the account before the user actually visited the activation url. This mean't they would get the failure message

This ensures we respond to HEAD requests appropriately.

Fixes UML-1105

## Approach

There is a Mezzio middleware that is responsible for managing head requests that this request hits. This middleware attaches and attribute to the request before forwarding it on to the handler. It then strips the body content away before allowing the final dispatch to the user. By using that attribute we can stop the service from carrying out actions when accessed with a HEAD request.

## Learning

This will likely impact any part of the application that can be deep-linked to that carries out an action (like changing of passwords. This will need fixing for all those cases.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [x] I have added welsh translation tags and updated translation files
* [ ] The product team have tested these changes
