### PR TITLE
Use new pagerduty provider path

### DIFF
--- a/terraform/account/credentials.tf
+++ b/terraform/account/credentials.tf
@@ -20,7 +20,7 @@ terraform {
       version = "~> 1.4.0"
     }
     pagerduty = {
-      source  = "terraform-providers/pagerduty"
+      source  = "PagerDuty/pagerduty"
       version = "~> 1.7.4"
     }
   }

--- a/terraform/environment/credentials.tf
+++ b/terraform/environment/credentials.tf
@@ -20,7 +20,7 @@ terraform {
       version = "~> 1.4.0"
     }
     pagerduty = {
-      source  = "terraform-providers/pagerduty"
+      source  = "PagerDuty/pagerduty"
       version = "~> 1.7.4"
     }
   }

--- a/terraform/environment/resource_group.tf
+++ b/terraform/environment/resource_group.tf
@@ -14,7 +14,7 @@ locals {
     TagFilters = [
       {
         Key    = "environment-name",
-        Values = ["${local.environment}"]
+        Values = [local.environment]
       }
     ]
   })


### PR DESCRIPTION
# Purpose

The PagerDuty provider has a new path.

```
Warning: Additional provider information from registry

The remote registry returned warnings for
registry.terraform.io/terraform-providers/pagerduty:
- For users on Terraform 0.13 or greater, this provider has moved to
PagerDuty/pagerduty. Please update your source in required_providers.
```

Fixes UML-1123

## Approach
Use the new path for PagerDuty
Use the command `terraform state replace-provider` to update the environment.

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] The product team have tested these changes
