### PR TITLE
Add privacy notice link

### DIFF
--- a/service-front/app/features/actor-privacy-notice.feature
+++ b/service-front/app/features/actor-privacy-notice.feature
@@ -12,12 +12,6 @@ Feature: View privacy notice from the terms of use page
     Then I can see the actor privacy notice
 
   @ui
-  Scenario: The user can go back to the terms of use page from the actor privacy notice page
-    Given I am on the actor privacy notice page
-    When I request to go back to the terms of use page
-    Then I am taken back to the terms of use page
-
-  @ui
   Scenario: Actor can access the actor cookies page from the actor privacy notice page
     Given I am on the actor privacy notice page
     When I navigate to the actor cookies page

--- a/service-front/app/features/viewer-privacy-notice.feature
+++ b/service-front/app/features/viewer-privacy-notice.feature
@@ -12,13 +12,6 @@ Feature: View privacy notice from terms of use page
     Then I can see the viewer privacy notice
 
   @ui
-  Scenario: The user can go back to the terms of use page from the privacy notice page
-    Given I am on the viewer terms of use page
-    When I navigate to the viewer privacy notice page
-    Then I request to go back to the terms of use page
-    Then I am taken back to the terms of use page
-
-  @ui
   Scenario: Viewer can access the cookies page from the privacy notice page
     Given I am on the viewer privacy notice page
     When I navigate to the viewer cookies page

--- a/service-front/app/src/Actor/templates/actor/actor-privacy-notice.html.twig
+++ b/service-front/app/src/Actor/templates/actor/actor-privacy-notice.html.twig
@@ -4,11 +4,9 @@
 
 {% block content %}
 <div class="govuk-width-container">
-{{ include('@actor/partials/new-use-service.html.twig') }}
+    {{ include('@actor/partials/new-use-service.html.twig') }}
 
     {{ include('@partials/welsh-switch.html.twig') }}
-
-    <a class="govuk-link govuk-back-link" href="{{ path('terms-of-use') }}">{% trans %}Back{% endtrans %}</a>
 
     <main class="govuk-main-wrapper" id="main-content" role="main">
         <div class="govuk-grid-row">

--- a/service-front/app/src/Common/templates/layout/default.html.twig
+++ b/service-front/app/src/Common/templates/layout/default.html.twig
@@ -102,12 +102,12 @@
                 <h2 class="govuk-visually-hidden">{% trans %}Support links{% endtrans %}</h2>
                 <ul class="govuk-footer__inline-list">
                     <li class="govuk-footer__inline-list-item">
-                        <a class="govuk-footer__link" href="{{ path('terms-of-use') }}" target="_blank">
+                        <a class="govuk-footer__link" href="{{ path('terms-of-use') }}">
                             {% trans %}Terms of use{% endtrans %}
                         </a>
                     </li>
                     <li class="govuk-footer__inline-list-item">
-                        <a class="govuk-footer__link" href="{{ path('privacy-notice') }}" target="_blank">
+                        <a class="govuk-footer__link" href="{{ path('privacy-notice') }}">
                             {% trans %}Privacy notice{% endtrans %}
                         </a>
                     </li>

--- a/service-front/app/src/Common/templates/layout/default.html.twig
+++ b/service-front/app/src/Common/templates/layout/default.html.twig
@@ -107,18 +107,23 @@
                         </a>
                     </li>
                     <li class="govuk-footer__inline-list-item">
+                        <a class="govuk-footer__link" href="{{ path('privacy-notice') }}" target="_blank">
+                            {% trans %}Privacy notice{% endtrans %}
+                        </a>
+                    </li>
+                    <li class="govuk-footer__inline-list-item">
                         <a class="govuk-footer__link" href="{{ path('cookies') }}">
                             {% trans %}Cookies{% endtrans %}
                         </a>
                     </li>
                     <li class="govuk-footer__inline-list-item">
-                        <a class="govuk-footer__link" href="{{ path('contact-us') }}">
-                            {% trans %}Contact us{% endtrans %}
+                        <a class="govuk-footer__link" href="{{ path('accessibility-statement') }}">
+                            {% trans %}Accessibility statement{% endtrans %}
                         </a>
                     </li>
                     <li class="govuk-footer__inline-list-item">
-                        <a class="govuk-footer__link" href="{{ path('accessibility-statement') }}">
-                            {% trans %}Accessibility statement{% endtrans %}
+                        <a class="govuk-footer__link" href="{{ path('contact-us') }}">
+                            {% trans %}Contact us{% endtrans %}
                         </a>
                     </li>
                     <li class="govuk-footer__inline-list-item">

--- a/service-front/app/src/Viewer/templates/viewer/viewer-privacy-notice.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/viewer-privacy-notice.html.twig
@@ -8,8 +8,6 @@
 
     {{ include('@partials/welsh-switch.html.twig') }}
 
-    <a href="{{ path('terms-of-use') }}" class="govuk-back-link">{% trans %}Back{% endtrans %}</a>
-
     <main class="govuk-main-wrapper" id="main-content" role="main">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
# Purpose

Fixes UML-1087

## Approach

Add link to footer and adjust order of existing links.

## Learning

This introduces some issues with the back link on the privacy notice page (where does it go back to, it's been opened in a new tab)

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] The product team have tested these changes
