### PR TITLE
UML-836 DAC Invalid lists markup

### DIFF
--- a/service-front/app/src/Common/templates/partials/account-bar.html.twig
+++ b/service-front/app/src/Common/templates/partials/account-bar.html.twig
@@ -7,8 +7,10 @@
         }}
     </p>
     <nav class="navigation govuk-body-s">
-        <li><a href="{{ path('your-details') }}" class="govuk-link">{% trans %}Your details{% endtrans %}</a></li>
-        <li><a href="{{ path('lpa.dashboard') }}" class="govuk-link">{% trans %}Your LPAs{% endtrans %}</a></li>
-        <li><a href="{{ path('logout') }}">{% trans %}Sign out{% endtrans %}</a></li>
+        <ul>
+            <li><a href="{{ path('your-details') }}" class="govuk-link">{% trans %}Your details{% endtrans %}</a></li>
+            <li><a href="{{ path('lpa.dashboard') }}" class="govuk-link">{% trans %}Your LPAs{% endtrans %}</a></li>
+            <li><a href="{{ path('logout') }}" class="govuk-link">{% trans %}Sign out{% endtrans %}</a></li>
+        </ul>
     </nav>
 </div>

--- a/service-front/web/src/scss/_lpa-account-menu.scss
+++ b/service-front/web/src/scss/_lpa-account-menu.scss
@@ -25,12 +25,17 @@
         margin: govuk-spacing(0);
         padding: govuk-spacing(0);
 
-        > li {
-            list-style-position: inside;
-            list-style-type: none;
-            display: inline;
-            margin-left: govuk-spacing(0);
-            margin-right: govuk-spacing(2);
+        > ul {
+            margin: govuk-spacing(0);
+            padding: govuk-spacing(0);
+
+            > li {
+                list-style-position: inside;
+                list-style-type: none;
+                display: inline;
+                margin-left: govuk-spacing(0);
+                margin-right: govuk-spacing(2);
+            }
         }
 
         @media screen and (min-width: 769px) {
@@ -44,5 +49,3 @@
         }
     }
 }
-
-


### PR DESCRIPTION
# Purpose

Screen readers notify users when they come to a list, and tell them how many items are in a list. Announcing the number of list items and the current list item helps listeners know what they are listening to, and what to expect as they listen to it. If you don't mark up a list using proper semantic markup in a hierarchy, list items cannot inform the listener that they are listening to a list when no parent is indicating the presence of a list and the type of list. This ticket corrects the list markup for the account bar.

Fixes UML-836

## Approach

Wraps the li elements for the account bar in a ul parent element. Edited the lpa-account-menu style sheet accordingly to include the new ul element combinator and match nested structure.  

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] The product team have tested these changes
