### PR TITLE
UML-1008 AND 1009 Accordion non unique id attributes

### DIFF
--- a/service-front/app/src/Actor/templates/actor/check-access-codes.html.twig
+++ b/service-front/app/src/Actor/templates/actor/check-access-codes.html.twig
@@ -67,7 +67,8 @@
 
                             <p class="govuk-body">{% trans %}Give an organisation their access code so they can view this LPA. They should go to www.gov.uk/view-lpa to use the code.{% endtrans %}</p>
 
-                            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default-1" data-opentext="{% trans %}Open all{% notes %}Accordion label{% endtrans%}" data-closetext="{% trans %}Close all{% notes %}Accordion label{% endtrans %}" data-sectiontext="{% trans %}section{% notes %}Accordion label{% endtrans %}">
+                            {% set accordion_counter = 1 %}
+                            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default-{{ accordion_counter }}" data-opentext="{% trans %}Open all{% notes %}Accordion label{% endtrans%}" data-closetext="{% trans %}Close all{% notes %}Accordion label{% endtrans %}" data-sectiontext="{% trans %}section{% notes %}Accordion label{% endtrans %}">
 
                                 {% for code in shareCodes %}
                                     {% set id_counter = ( id_counter | default(0) ) + 1 %}
@@ -88,7 +89,8 @@
                                 {%trans with {'%create-code-link%': path('lpa.create-code', {}, {'lpa':  actorToken })} %}If an organisation asks to see this <abbr title="lasting power of attorney">LPA</abbr> again, you can <a href="%create-code-link%">make them a new code</a>.{% endtrans %}
                             </p>
 
-                            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default-2" data-opentext="{% trans %}Open all{% notes %}Accordion label{% endtrans%}" data-closetext="{% trans %}Close all{% notes %}Accordion label{% endtrans %}" data-sectiontext="{% trans %}section{% notes %}Accordion label{% endtrans %}">
+                            {% set accordion_counter = ( accordion_counter + 1 | default(1) ) %}
+                            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default-{{ accordion_counter }}" data-opentext="{% trans %}Open all{% notes %}Accordion label{% endtrans%}" data-closetext="{% trans %}Close all{% notes %}Accordion label{% endtrans %}" data-sectiontext="{% trans %}section{% notes %}Accordion label{% endtrans %}">
 
                                 {% for code in shareCodes %}
                                     {% set id_counter = ( id_counter | default(0) ) + 1 %}

--- a/service-front/app/src/Actor/templates/actor/check-access-codes.html.twig
+++ b/service-front/app/src/Actor/templates/actor/check-access-codes.html.twig
@@ -70,9 +70,10 @@
                             <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default" data-opentext="{% trans %}Open all{% notes %}Accordion label{% endtrans%}" data-closetext="{% trans %}Close all{% notes %}Accordion label{% endtrans %}" data-sectiontext="{% trans %}section{% notes %}Accordion label{% endtrans %}">
 
                                 {% for code in shareCodes %}
+                                    {% set id_counter = ( id_counter | default(0) ) + 1 %}
                                     {% if not check_if_code_has_expired(code.Expires) %}
                                         {% if not check_if_code_is_cancelled(code) %}
-                                            {{ include('@actor/partials/check-code-details.html.twig') }}
+                                            {{ include('@actor/partials/check-code-details.html.twig', {'id_counter': id_counter }) }}
                                         {% endif %}
                                     {% endif %}
                                 {% endfor %}
@@ -90,8 +91,9 @@
                             <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default" data-opentext="{% trans %}Open all{% notes %}Accordion label{% endtrans%}" data-closetext="{% trans %}Close all{% notes %}Accordion label{% endtrans %}" data-sectiontext="{% trans %}section{% notes %}Accordion label{% endtrans %}">
 
                                 {% for code in shareCodes %}
+                                    {% set id_counter = ( id_counter | default(0) ) + 1 %}
                                     {% if check_if_code_has_expired(code.Expires) or check_if_code_is_cancelled(code) %}
-                                        {{ include('@actor/partials/check-code-details.html.twig') }}
+                                        {{ include('@actor/partials/check-code-details.html.twig', {'id_counter': id_counter }) }}
                                     {% endif %}
                                 {% endfor %}
                             </div>

--- a/service-front/app/src/Actor/templates/actor/check-access-codes.html.twig
+++ b/service-front/app/src/Actor/templates/actor/check-access-codes.html.twig
@@ -67,7 +67,7 @@
 
                             <p class="govuk-body">{% trans %}Give an organisation their access code so they can view this LPA. They should go to www.gov.uk/view-lpa to use the code.{% endtrans %}</p>
 
-                            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default" data-opentext="{% trans %}Open all{% notes %}Accordion label{% endtrans%}" data-closetext="{% trans %}Close all{% notes %}Accordion label{% endtrans %}" data-sectiontext="{% trans %}section{% notes %}Accordion label{% endtrans %}">
+                            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default-1" data-opentext="{% trans %}Open all{% notes %}Accordion label{% endtrans%}" data-closetext="{% trans %}Close all{% notes %}Accordion label{% endtrans %}" data-sectiontext="{% trans %}section{% notes %}Accordion label{% endtrans %}">
 
                                 {% for code in shareCodes %}
                                     {% set id_counter = ( id_counter | default(0) ) + 1 %}
@@ -88,7 +88,7 @@
                                 {%trans with {'%create-code-link%': path('lpa.create-code', {}, {'lpa':  actorToken })} %}If an organisation asks to see this <abbr title="lasting power of attorney">LPA</abbr> again, you can <a href="%create-code-link%">make them a new code</a>.{% endtrans %}
                             </p>
 
-                            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default" data-opentext="{% trans %}Open all{% notes %}Accordion label{% endtrans%}" data-closetext="{% trans %}Close all{% notes %}Accordion label{% endtrans %}" data-sectiontext="{% trans %}section{% notes %}Accordion label{% endtrans %}">
+                            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default-2" data-opentext="{% trans %}Open all{% notes %}Accordion label{% endtrans%}" data-closetext="{% trans %}Close all{% notes %}Accordion label{% endtrans %}" data-sectiontext="{% trans %}section{% notes %}Accordion label{% endtrans %}">
 
                                 {% for code in shareCodes %}
                                     {% set id_counter = ( id_counter | default(0) ) + 1 %}

--- a/service-front/app/src/Actor/templates/actor/check-access-codes.html.twig
+++ b/service-front/app/src/Actor/templates/actor/check-access-codes.html.twig
@@ -67,8 +67,7 @@
 
                             <p class="govuk-body">{% trans %}Give an organisation their access code so they can view this LPA. They should go to www.gov.uk/view-lpa to use the code.{% endtrans %}</p>
 
-                            {% set accordion_counter = 1 %}
-                            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default-{{ accordion_counter }}" data-opentext="{% trans %}Open all{% notes %}Accordion label{% endtrans%}" data-closetext="{% trans %}Close all{% notes %}Accordion label{% endtrans %}" data-sectiontext="{% trans %}section{% notes %}Accordion label{% endtrans %}">
+                            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default-1" data-opentext="{% trans %}Open all{% notes %}Accordion label{% endtrans%}" data-closetext="{% trans %}Close all{% notes %}Accordion label{% endtrans %}" data-sectiontext="{% trans %}section{% notes %}Accordion label{% endtrans %}">
 
                                 {% for code in shareCodes %}
                                     {% set id_counter = ( id_counter | default(0) ) + 1 %}
@@ -90,7 +89,7 @@
                             </p>
 
                             {% set accordion_counter = ( accordion_counter + 1 | default(1) ) %}
-                            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default-{{ accordion_counter }}" data-opentext="{% trans %}Open all{% notes %}Accordion label{% endtrans%}" data-closetext="{% trans %}Close all{% notes %}Accordion label{% endtrans %}" data-sectiontext="{% trans %}section{% notes %}Accordion label{% endtrans %}">
+                            <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default-2" data-opentext="{% trans %}Open all{% notes %}Accordion label{% endtrans%}" data-closetext="{% trans %}Close all{% notes %}Accordion label{% endtrans %}" data-sectiontext="{% trans %}section{% notes %}Accordion label{% endtrans %}">
 
                                 {% for code in shareCodes %}
                                     {% set id_counter = ( id_counter | default(0) ) + 1 %}

--- a/service-front/app/src/Actor/templates/actor/partials/check-code-details.html.twig
+++ b/service-front/app/src/Actor/templates/actor/partials/check-code-details.html.twig
@@ -1,12 +1,12 @@
 <div class="govuk-accordion__section ">
     <div class="govuk-accordion__section-header">
         <h3 class="govuk-accordion__section-heading">
-        <span class="govuk-accordion__section-button" id="accordion-default-heading-4" aria-controls="accordion-default-content-4">
+        <span class="govuk-accordion__section-button" id="accordion-default-heading-{{ id_counter }}" aria-controls="accordion-default-content-{{ id_counter }}">
           {{ code.Organisation }}
         </span>
         </h3>
     </div>
-    <div id="accordion-default-content-4" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-4">
+    <div id="accordion-default-content-{{ id_counter }}" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-{{ id_counter }}">
         <dl class="govuk-summary-list govuk-summary-list--no-border govuk-!-margin-bottom-4">
 
             <div class="govuk-summary-list__row">


### PR DESCRIPTION
# Purpose

In the accordion we have 2 attributes, id and aria-controls that have static values of accordion-default-heading-4 and accordion-default-content-4. These need to be incremented to help screen readers navigate and be able to distinguish between them

Fixes UML-1008

## Approach

I created a counter in the check-access-codes.html.twig file for both active and inactive codes. The counter is then included in the check-code-details.html.twig file and appended to the relevant id's.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] The product team have tested these changes
