### PR TITLE
UML-1155 LPA viewed by whitespace

### DIFF
--- a/service-front/app/src/Actor/templates/actor/partials/check-code-details.html.twig
+++ b/service-front/app/src/Actor/templates/actor/partials/check-code-details.html.twig
@@ -23,9 +23,23 @@
                 <dt class="govuk-summary-list__key">{% trans %}LPA viewed{% endtrans %}</dt>
                 <dd class="govuk-summary-list__value">
                     {% if code.Viewed %}
+                        {% set allEmpty = true %}
+
                         {% for code in code.Viewed %}
-                            {{ code.ViewedBy }}<br>
+                            {% if code.ViewedBy is not empty %}
+                                {% set allEmpty = false %}
+                            {% endif %}
                         {% endfor %}
+
+                        {% if allEmpty %}
+                            {% trans %}Viewed{% endtrans %}
+                        {% else %}
+                            {% for code in code.Viewed %}
+                                {% if code.ViewedBy is not empty %}
+                                    {{ code.ViewedBy }}<br>
+                                {% endif %}
+                            {% endfor %}
+                        {% endif %}
                     {% else %}
                         {{ code.Viewed }}
                         {% trans %}Not viewed{% endtrans %}


### PR DESCRIPTION
# Purpose

In the check access codes page, there was a for loop to display all the organisations that had viewed a code. However, for codes that had been created prior to the addition of the organisation ViewedBy field in the database, this field is blank, therefore producing a list of blank data for the LPA viewed status. This ticket fixes that bug

Fixes UML-1155

## Approach

I added some more logic to the twig page to first check whether the 'ViewedBy' field for all viewer activity entires was empty, and if so, just display 'Viewed'. If not, a for loop checks each 'ViewedBy' organisation entry to see if it is empty, if it is, the for loop continues, but if it is not empty, the organisation is displayed

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] The product team have tested these changes
