### PR TITLE
UML-1191 FIXED Feature flag

### DIFF
--- a/service-front/app/config/routes.php
+++ b/service-front/app/config/routes.php
@@ -161,7 +161,7 @@ $actorRoutes = function (Application $app, MiddlewareFactory $factory, Container
     ], 'lpa.death-notification');
 
     // Older LPA journey
-    if ($container->get('config')['feature_flags']['use_older_lpa_journey']) {
+    if (filter_var($container->get('config')['feature_flags']['use_older_lpa_journey'], FILTER_VALIDATE_BOOL)) {
         // if flag true, send user to triage page as entry point
         $app->route('/lpa/add', [
             Mezzio\Authentication\AuthenticationMiddleware::class,


### PR DESCRIPTION
# Purpose

Implements the feature flag correctly this time. Creates older LPA journey routes with a feature flag to turn the journey off until we say so

Fixes UML-1191

## Approach

The issue was caused as the variable was a string eg "false" which evaluated to true and passed the if statement. I've converted the variable to a boolean to fix the issue

## Learning

- Check what the variable is i'm evaluating against rather than assuming in future
- Get static analysis setup to catch errors like this

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
