### PR TITLE
UML-1276 - Schedule dependabot package updates to be weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
-# https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
+# https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
 updates:
   # Enable version updates for service-front npm
   - package-ecosystem: "npm"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       day: "wednesday"
       time: "10:00"
     versioning-strategy: lockfile-only
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 3
   # Enable version updates for service-pdf npm
   - package-ecosystem: "npm"
     directory: "/service-pdf/app"
@@ -20,7 +20,7 @@ updates:
       day: "wednesday"
       time: "10:00"
     versioning-strategy: lockfile-only
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 3
 
   # Enable version updates for service-front composer
   - package-ecosystem: "composer"
@@ -31,7 +31,7 @@ updates:
       day: "wednesday"
       time: "10:00"
     versioning-strategy: lockfile-only
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 3
 
   # Enable version updates for service-api composer
   - package-ecosystem: "composer"
@@ -42,7 +42,7 @@ updates:
       day: "wednesday"
       time: "10:00"
     versioning-strategy: lockfile-only
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 3
 
     # Enable version updates for smoke tests composer
   - package-ecosystem: "composer"
@@ -53,4 +53,4 @@ updates:
       day: "wednesday"
       time: "10:00"
     versioning-strategy: lockfile-only
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,24 @@
+# https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
   # Enable version updates for service-front npm
   - package-ecosystem: "npm"
     directory: "/service-front/web"
     schedule:
-      interval: "daily"
+      # Check for updates weekly on wednesday at 10am UTC
+      interval: "weekly"
+      day: "wednesday"
+      time: "10:00"
     versioning-strategy: lockfile-only
     open-pull-requests-limit: 1
   # Enable version updates for service-pdf npm
   - package-ecosystem: "npm"
     directory: "/service-pdf/app"
     schedule:
-      interval: "daily"
+      # Check for updates weekly on wednesday at 10am UTC
+      interval: "weekly"
+      day: "wednesday"
+      time: "10:00"
     versioning-strategy: lockfile-only
     open-pull-requests-limit: 1
 
@@ -19,7 +26,10 @@ updates:
   - package-ecosystem: "composer"
     directory: "/service-front/app"
     schedule:
-      interval: "daily"
+      # Check for updates weekly on wednesday at 10am UTC
+      interval: "weekly"
+      day: "wednesday"
+      time: "10:00"
     versioning-strategy: lockfile-only
     open-pull-requests-limit: 1
 
@@ -27,7 +37,10 @@ updates:
   - package-ecosystem: "composer"
     directory: "/service-api/app"
     schedule:
-      interval: "daily"
+      # Check for updates weekly on wednesday at 10am UTC
+      interval: "weekly"
+      day: "wednesday"
+      time: "10:00"
     versioning-strategy: lockfile-only
     open-pull-requests-limit: 1
 
@@ -35,6 +48,9 @@ updates:
   - package-ecosystem: "composer"
     directory: "/tests/smoke"
     schedule:
-      interval: "daily"
+      # Check for updates weekly on wednesday at 10am UTC
+      interval: "weekly"
+      day: "wednesday"
+      time: "10:00"
     versioning-strategy: lockfile-only
     open-pull-requests-limit: 1


### PR DESCRIPTION
# Purpose

Dependabot updates PRs are too frequent and arrive at an inconvenient time.

Fixes UML-1276

## Approach

Update dependabot.yml so that Dependabot package updates run weekly on a Wednesday at 10 am.

## Learning

https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#versioning-strategy

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
