### PR TITLE
Implement new feature flagging method

### DIFF
--- a/service-front/app/config/routes.php
+++ b/service-front/app/config/routes.php
@@ -161,7 +161,7 @@ $actorRoutes = function (Application $app, MiddlewareFactory $factory, Container
     ], 'lpa.death-notification');
 
     // Older LPA journey
-    if ($container->get('config')['feature_flags']['use_older_lpa_journey']) {
+    if (($container->get(Common\Service\Features\FeatureEnabled::class))('use_older_lpa_journey')) {
         // if flag true, send user to triage page as entry point
         $app->route('/lpa/add', [
             Mezzio\Authentication\AuthenticationMiddleware::class,

--- a/service-front/app/src/Actor/templates/actor/check-lpa.html.twig
+++ b/service-front/app/src/Actor/templates/actor/check-lpa.html.twig
@@ -9,7 +9,7 @@
         {{ include('@partials/welsh-switch.html.twig') }}
 
         <div role="navigation" aria-labelledby="back-link-navigation">
-            <a href="{{ path('lpa.add-by-code') }}" class="govuk-back-link" id="back-link-navigation">{% trans %}Back{% endtrans %}</a>
+            <a href="{{ feature_enabled('use_older_lpa_journey') ? path('lpa.add-by-code') : path('lpa.add') }}" class="govuk-back-link" id="back-link-navigation">{% trans %}Back{% endtrans %}</a>
         </div>
 
         <main class="govuk-main-wrapper" id="main-content" role="main">

--- a/service-front/app/src/Actor/templates/actor/lpa-add.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-add.html.twig
@@ -11,7 +11,7 @@
     {{ include('@partials/welsh-switch.html.twig') }}
 
     <div role="navigation" aria-labelledby="back-link-navigation">
-        <a href="{{ path('lpa.add') }}" class="govuk-back-link" id="back-link-navigation">{% trans %}Back{% endtrans %}</a>
+        <a href="{{ feature_enabled('use_older_lpa_journey') ? path('lpa.add') : path('lpa.dashboard') }}" class="govuk-back-link" id="back-link-navigation">{% trans %}Back{% endtrans %}</a>
     </div>
 
     <main class="govuk-main-wrapper" id="main-content" role="main">

--- a/service-front/app/src/Common/src/ConfigProvider.php
+++ b/service-front/app/src/Common/src/ConfigProvider.php
@@ -71,6 +71,7 @@ class ConfigProvider
                 Service\Session\KeyManager\KmsManager::class => Service\Session\KeyManager\KmsManagerFactory::class,
                 Service\Email\EmailClient::class => Service\Email\EmailClientFactory::class,
                 Service\User\UserService::class => Service\User\UserServiceFactory::class,
+                Service\Features\FeatureEnabled::class => Service\Features\FeatureEnabledFactory::class,
 
                 \Aws\Sdk::class => Service\Aws\SdkFactory::class,
                 \Aws\Kms\KmsClient::class => Service\Aws\KmsFactory::class,
@@ -134,7 +135,8 @@ class ConfigProvider
                 View\Twig\GovUKLaminasFormExtension::class,
                 View\Twig\JavascriptVariablesExtension::class,
                 View\Twig\GenericGlobalVariableExtension::class,
-                View\Twig\TranslationSwitchExtension::class
+                View\Twig\TranslationSwitchExtension::class,
+                View\Twig\FeatureFlagExtension::class
             ]
         ];
     }

--- a/service-front/app/src/Common/src/Service/Features/FeatureEnabled.php
+++ b/service-front/app/src/Common/src/Service/Features/FeatureEnabled.php
@@ -10,6 +10,13 @@ class FeatureEnabled
 {
     private array $featureFlags;
 
+    /**
+     * FeatureEnabled constructor.
+     *
+     * @param array $featureFlags An key value map of feature names to boolean values
+     *
+     * @codeCoverageIgnore
+     */
     public function __construct(array $featureFlags)
     {
         $this->featureFlags = $featureFlags;
@@ -19,6 +26,10 @@ class FeatureEnabled
     {
         if (!array_key_exists($featureName, $this->featureFlags)) {
             throw new RuntimeException('Feature flag "' . $featureName . '" is not currently configured');
+        }
+
+        if (!is_bool($this->featureFlags[$featureName])) {
+            throw new RuntimeException('Feature flag "' . $featureName . '" is not a boolean value');
         }
 
         return  $this->featureFlags[$featureName];

--- a/service-front/app/src/Common/src/Service/Features/FeatureEnabled.php
+++ b/service-front/app/src/Common/src/Service/Features/FeatureEnabled.php
@@ -8,12 +8,13 @@ use RuntimeException;
 
 class FeatureEnabled
 {
+    /** @var array<string, mixed> */
     private array $featureFlags;
 
     /**
      * FeatureEnabled constructor.
      *
-     * @param array $featureFlags An key value map of feature names to boolean values
+     * @param array<string, mixed> $featureFlags An key value map of feature names to boolean values
      *
      * @codeCoverageIgnore
      */

--- a/service-front/app/src/Common/src/Service/Features/FeatureEnabled.php
+++ b/service-front/app/src/Common/src/Service/Features/FeatureEnabled.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Service\Features;
+
+use RuntimeException;
+
+class FeatureEnabled
+{
+    private array $featureFlags;
+
+    public function __construct(array $featureFlags)
+    {
+        $this->featureFlags = $featureFlags;
+    }
+
+    public function __invoke(string $featureName): bool
+    {
+        if (!array_key_exists($featureName, $this->featureFlags)) {
+            throw new RuntimeException('Feature flag "' . $featureName . '" is not currently configured');
+        }
+
+        return  $this->featureFlags[$featureName];
+    }
+}

--- a/service-front/app/src/Common/src/Service/Features/FeatureEnabledFactory.php
+++ b/service-front/app/src/Common/src/Service/Features/FeatureEnabledFactory.php
@@ -5,15 +5,16 @@ declare(strict_types=1);
 namespace Common\Service\Features;
 
 use Psr\Container\ContainerInterface;
+use UnexpectedValueException;
 
 class FeatureEnabledFactory
 {
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container): FeatureEnabled
     {
         $config = $container->get('config');
 
         if (!isset($config['feature_flags']) || !is_array($config['feature_flags'])) {
-            throw new \UnexpectedValueException('Missing feature flags configuration');
+            throw new UnexpectedValueException('Missing feature flags configuration');
         }
 
         return new FeatureEnabled(

--- a/service-front/app/src/Common/src/Service/Features/FeatureEnabledFactory.php
+++ b/service-front/app/src/Common/src/Service/Features/FeatureEnabledFactory.php
@@ -12,7 +12,7 @@ class FeatureEnabledFactory
     {
         $config = $container->get('config');
 
-        if (!isset($config['feature_flags']) && !is_array($config['feature_flags'])) {
+        if (!isset($config['feature_flags']) || !is_array($config['feature_flags'])) {
             throw new \UnexpectedValueException('Missing feature flags configuration');
         }
 

--- a/service-front/app/src/Common/src/Service/Features/FeatureEnabledFactory.php
+++ b/service-front/app/src/Common/src/Service/Features/FeatureEnabledFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Service\Features;
+
+use Psr\Container\ContainerInterface;
+
+class FeatureEnabledFactory
+{
+    public function __invoke(ContainerInterface $container)
+    {
+        $config = $container->get('config');
+
+        if (!isset($config['feature_flags']) && !is_array($config['feature_flags'])) {
+            throw new \UnexpectedValueException('Missing feature flags configuration');
+        }
+
+        return new FeatureEnabled(
+            $config['feature_flags']
+        );
+    }
+}

--- a/service-front/app/src/Common/src/View/Twig/FeatureFlagExtension.php
+++ b/service-front/app/src/Common/src/View/Twig/FeatureFlagExtension.php
@@ -12,13 +12,20 @@ class FeatureFlagExtension extends AbstractExtension
 {
     private FeatureEnabled $featureEnabled;
 
+    /**
+     * FeatureFlagExtension constructor.
+     *
+     * @param FeatureEnabled $featureEnabled
+     *
+     * @codeCoverageIgnore
+     */
     public function __construct(FeatureEnabled $featureEnabled)
     {
         $this->featureEnabled = $featureEnabled;
     }
 
     /**
-     * @return array
+     * @return array<TwigFunction>
      */
     public function getFunctions(): array
     {
@@ -27,6 +34,13 @@ class FeatureFlagExtension extends AbstractExtension
         ];
     }
 
+    /**
+     * Returns the enabled state of a feature
+     *
+     * @param string $featureName The name of a feature configured in features.php
+     *
+     * @return bool
+     */
     public function featureEnabled(string $featureName): bool
     {
         return ($this->featureEnabled)($featureName);

--- a/service-front/app/src/Common/src/View/Twig/FeatureFlagExtension.php
+++ b/service-front/app/src/Common/src/View/Twig/FeatureFlagExtension.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\View\Twig;
+
+use Common\Service\Features\FeatureEnabled;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class FeatureFlagExtension extends AbstractExtension
+{
+    private FeatureEnabled $featureEnabled;
+
+    public function __construct(FeatureEnabled $featureEnabled)
+    {
+        $this->featureEnabled = $featureEnabled;
+    }
+
+    /**
+     * @return array
+     */
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('feature_enabled', [$this, 'featureEnabled'])
+        ];
+    }
+
+    public function featureEnabled(string $featureName): bool
+    {
+        return ($this->featureEnabled)($featureName);
+    }
+}

--- a/service-front/app/test/CommonTest/Service/Features/FeatureEnabledFactoryTest.php
+++ b/service-front/app/test/CommonTest/Service/Features/FeatureEnabledFactoryTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommonTest\Service\Features;
+
+use Common\Service\Features\FeatureEnabled;
+use Common\Service\Features\FeatureEnabledFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use UnexpectedValueException;
+
+/**
+ * Class FeatureEnabledFactoryTest
+ *
+ * @package CommonTest\Service\Features
+ *
+ * @coversDefaultClass \Common\Service\Features\FeatureEnabledFactory
+ */
+class FeatureEnabledFactoryTest extends TestCase
+{
+    /**
+     * @test
+     * @covers ::__invoke
+     */
+    public function it_creates_a_featureenabled_service_instance(): void
+    {
+        $containerProphecy = $this->prophesize(ContainerInterface::class);
+        $containerProphecy
+            ->get('config')
+            ->willReturn(
+                [
+                    'feature_flags' => [],
+                ]
+            );
+
+        $factory = new FeatureEnabledFactory();
+
+        $instance = $factory($containerProphecy->reveal());
+
+        $this->assertInstanceOf(FeatureEnabled::class, $instance);
+    }
+
+    /**
+     * @test
+     * @covers ::__invoke
+     */
+    public function it_will_throw_an_exception_if_not_configured(): void
+    {
+        $containerProphecy = $this->prophesize(ContainerInterface::class);
+        $containerProphecy
+            ->get('config')
+            ->willReturn([]);
+
+        $factory = new FeatureEnabledFactory();
+
+        $this->expectException(UnexpectedValueException::class);
+        $instance = $factory($containerProphecy->reveal());
+    }
+
+    /**
+     * @test
+     * @covers ::__invoke
+     */
+    public function it_will_throw_an_exception_if_badly_configured(): void
+    {
+        $containerProphecy = $this->prophesize(ContainerInterface::class);
+        $containerProphecy
+            ->get('config')
+            ->willReturn(
+                [
+                    'feature_flags' => 'not an array',
+                ]
+            );
+
+        $factory = new FeatureEnabledFactory();
+
+        $this->expectException(UnexpectedValueException::class);
+        $instance = $factory($containerProphecy->reveal());
+    }
+}

--- a/service-front/app/test/CommonTest/Service/Features/FeatureEnabledTest.php
+++ b/service-front/app/test/CommonTest/Service/Features/FeatureEnabledTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommonTest\Service\Features;
+
+use Common\Service\Features\FeatureEnabled;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Class FeatureEnabledTest
+ *
+ * @package CommonTest\Service\Features
+ * @coversDefaultClass \Common\Service\Features\FeatureEnabled
+ */
+class FeatureEnabledTest extends TestCase
+{
+    /**
+     * @test
+     * @covers ::__invoke
+     */
+    public function it_correctly_returns_feature_value_from_configuration(): void
+    {
+        $flags = [
+            'feature_name' => true
+        ];
+
+        $sut = new FeatureEnabled($flags);
+
+        $enabled = $sut('feature_name');
+
+        $this->assertTrue($enabled);
+    }
+
+    /**
+     * @test
+     * @covers ::__invoke
+     */
+    public function it_throws_an_exception_when_not_finding_a_feature_value(): void
+    {
+        $flags = [
+            'feature_name' => true
+        ];
+
+        $sut = new FeatureEnabled($flags);
+
+        $this->expectException(RuntimeException::class);
+        $enabled = $sut('other_feature_name');
+    }
+
+    /**
+     * @test
+     * @covers ::__invoke
+     */
+    public function it_throws_an_exception_when_not_finding_badly_configured_feature_value(): void
+    {
+        $flags = [
+            'feature_name' => 'True'
+        ];
+
+        $sut = new FeatureEnabled($flags);
+
+        $this->expectException(RuntimeException::class);
+        $enabled = $sut('other_feature_name');
+    }
+}

--- a/service-front/app/test/CommonTest/Service/Features/FeatureEnabledTest.php
+++ b/service-front/app/test/CommonTest/Service/Features/FeatureEnabledTest.php
@@ -56,12 +56,12 @@ class FeatureEnabledTest extends TestCase
     public function it_throws_an_exception_when_not_finding_badly_configured_feature_value(): void
     {
         $flags = [
-            'feature_name' => 'True'
+            'feature_name' => 'Yes'
         ];
 
         $sut = new FeatureEnabled($flags);
 
         $this->expectException(RuntimeException::class);
-        $enabled = $sut('other_feature_name');
+        $enabled = $sut('feature_name');
     }
 }

--- a/service-front/app/test/CommonTest/View/Twig/FeatureFlagExtensionTest.php
+++ b/service-front/app/test/CommonTest/View/Twig/FeatureFlagExtensionTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommonTest\View\Twig;
+
+use Common\Service\Features\FeatureEnabled;
+use Common\View\Twig\FeatureFlagExtension;
+use PHPUnit\Framework\TestCase;
+use Twig\TwigFunction;
+
+/**
+ * Class FeatureFlagExtensionTest
+ *
+ * @package CommonTest\View\Twig
+ *
+ * @coversDefaultClass \Common\View\Twig\FeatureFlagExtension
+ */
+class FeatureFlagExtensionTest extends TestCase
+{
+    /**
+     * @test
+     * @covers ::featureEnabled
+     */
+    public function it_returns_an_array_of_exported_twig_functions(): void
+    {
+        $extension = new FeatureFlagExtension(
+            $this->prophesize(FeatureEnabled::class)->reveal()
+        );
+
+        $functions = $extension->getFunctions();
+
+        $this->assertIsArray($functions);
+
+        $expectedFunctions = [
+            'feature_enabled' => 'featureEnabled',
+        ];
+        $this->assertEquals(count($expectedFunctions), count($functions));
+
+        //  Check each function
+        foreach ($functions as $function) {
+            $this->assertInstanceOf(TwigFunction::class, $function);
+            $this->assertArrayHasKey($function->getName(), $expectedFunctions);
+
+            $functionCallable = $function->getCallable();
+            $this->assertInstanceOf(FeatureFlagExtension::class, $functionCallable[0]);
+            $this->assertEquals($expectedFunctions[$function->getName()], $functionCallable[1]);
+        }
+    }
+
+    /**
+     * @test
+     * @covers ::featureEnabled
+     * @dataProvider configuredFeatures
+     *
+     * @param string $featureName
+     * @param bool   $enabled
+     */
+    public function it_returns_the_features_configured_status(string $featureName, bool $enabled): void
+    {
+        $service = $this->prophesize(FeatureEnabled::class);
+        $service
+            ->__invoke($featureName)
+            ->willReturn($enabled);
+
+        $extension = new FeatureFlagExtension($service->reveal());
+
+        $result = $extension->featureEnabled($featureName);
+
+        $this->assertEquals($enabled, $result);
+    }
+
+    /**
+     * @return array<array<mixed>>
+     */
+    public function configuredFeatures(): array
+    {
+        return [
+            'feature enabled' =>
+                [
+                    'test_feature',
+                    false
+                ],
+            'feature disabled' =>
+                [
+                    'test_feature',
+                    true
+                ]
+        ];
+    }
+
+}

--- a/service-front/app/test/CommonTest/View/Twig/FeatureFlagExtensionTest.php
+++ b/service-front/app/test/CommonTest/View/Twig/FeatureFlagExtensionTest.php
@@ -20,7 +20,7 @@ class FeatureFlagExtensionTest extends TestCase
 {
     /**
      * @test
-     * @covers ::featureEnabled
+     * @covers ::getFunctions
      */
     public function it_returns_an_array_of_exported_twig_functions(): void
     {


### PR DESCRIPTION
# Purpose

Creation of a service and twig extension which more easily allows us to query for feature flagging needs.

## Approach

Simple invokable service and associated twig extension that makes it available in templates. This lets us use a twig function to find out if we should be doing one thing or another.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
