### PR TITLE
Use local chrome installed in image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -767,7 +767,7 @@ orbs:
           - run:
               name: Build
               command: |
-                docker build --no-cache --target production --file service-pdf/docker/app/Dockerfile --tag pdf:latest .
+                docker build --target production --file service-pdf/docker/app/Dockerfile --tag pdf:latest .
           - ecr_login
           - run:
               name: Push container

--- a/service-pdf/docker/app/Dockerfile
+++ b/service-pdf/docker/app/Dockerfile
@@ -3,7 +3,8 @@ FROM buildkite/puppeteer:7.1.0 AS production
 WORKDIR /src/app
 COPY service-pdf/app/package.json ./package.json
 COPY service-pdf/app .
-
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable
 RUN npm install --only=production
 
 EXPOSE 80


### PR DESCRIPTION
# Purpose

Reading more into the errors in the build stage it appears to be happening around the download of local version of chromium in the npm install with timeout / connection issues

The base image we're using comes with a stable version of chrome installed, so this change sets the env flags to skip the download (which is where the fails look to be coming from) and set it to use local version

Ran the npm tests on local and they pass without issue

Fixes UML-1309 (hopefully)

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
