### PR TITLE
UML-1230 Show/hide password on login page

### DIFF
--- a/service-front/app/src/Actor/templates/actor/login.html.twig
+++ b/service-front/app/src/Actor/templates/actor/login.html.twig
@@ -42,7 +42,13 @@
 
                         {{ govuk_form_element(form.get('email'), { 'label': 'Email address' | trans, 'attr': { 'class': 'govuk-!-width-three-quarters' } })  }}
 
-                        {{ govuk_form_element(form.get('password'), { 'label': 'Password' | trans, 'attr': { 'class': 'govuk-!-width-three-quarters', 'auto-complete': 'current-password' } })  }}
+                        <div class="js-showhidepassword">
+                            {{ govuk_form_element(form.get('password'), {
+                                'label': 'Password' | trans,
+                                'attr': { 'class': 'govuk-input--width-20 govuk-input moj-password-reveal__input', 'auto-complete': 'current-password' }
+                            })
+                            }}
+                        </div>
 
                         <button data-prevent-double-click="true" name="sign-in" type="submit" class="govuk-button">{% trans %}Sign in{% endtrans %}</button>
 

--- a/service-front/app/src/Actor/templates/actor/login.html.twig
+++ b/service-front/app/src/Actor/templates/actor/login.html.twig
@@ -46,8 +46,7 @@
                             {{ govuk_form_element(form.get('password'), {
                                 'label': 'Password' | trans,
                                 'attr': { 'class': 'govuk-input--width-20 govuk-input moj-password-reveal__input', 'auto-complete': 'current-password' }
-                            })
-                            }}
+                            })  }}
                         </div>
 
                         <button data-prevent-double-click="true" name="sign-in" type="submit" class="govuk-button">{% trans %}Sign in{% endtrans %}</button>

--- a/service-front/app/src/Common/templates/partials/govuk_form.html.twig
+++ b/service-front/app/src/Common/templates/partials/govuk_form.html.twig
@@ -225,7 +225,7 @@
     <div class="moj-password-reveal">
         {{- block('form_input') -}}
         <button class="govuk-button govuk-button--secondary moj-password-reveal__button" data-module="govuk-button" type="button"
-                data-showpassword="{% trans %}Show{% notes %}Show password label{% endtrans%}"
+                data-showpassword="{% trans %}Show{% notes %}Show password label{% endtrans %}"
                 data-hidepassword="{% trans %}Hide{% notes %}Hide password label{% endtrans %}">
         </button>
     </div>

--- a/service-front/app/src/Common/templates/partials/govuk_form.html.twig
+++ b/service-front/app/src/Common/templates/partials/govuk_form.html.twig
@@ -35,7 +35,11 @@
 
         {% endif %}
 
-        {{- block('form_input') -}}
+        {%- if attr is defined and attr['class'] is defined and 'moj-password-reveal__input' in attr['class'] -%}
+            {{- block('input_show_hide_password') -}}
+        {% else %}
+            {{- block('form_input') -}}
+        {% endif %}
 
     </div>
 {%- endblock form_element_simple -%}
@@ -217,24 +221,21 @@
     {% endif %}
 {%- endblock input_hint -%}
 
-{%- block form_input -%}
-    {% if element.getName() == 'show_hide_password' %}
-        <div class="moj-password-reveal">
-    {% endif %}
+{%- block input_show_hide_password -%}
+    <div class="moj-password-reveal">
+        {{- block('form_input') -}}
+        <button class="govuk-button govuk-button--secondary moj-password-reveal__button" data-module="govuk-button" type="button"
+                data-showpassword="{% trans %}Show{% notes %}Show password label{% endtrans%}"
+                data-hidepassword="{% trans %}Hide{% notes %}Hide password label{% endtrans %}">
+        </button>
+    </div>
+{%- endblock input_show_hide_password -%}
 
+{%- block form_input -%}
     <input class="govuk-input {{- block('input_extra_class') -}} {{- block('input_error_class') -}}"
            id="{{ element.getName() }}" name="{{ element.getName() }}" type="{{ type }}" value="{{ value }}"
             {% if inputmode is defined and inputmode is not empty %}inputmode="{{ inputmode }}"{% endif %}
             {% if pattern is defined and pattern is not empty %}pattern="{{ pattern }}"{% endif %}
             {% if spellcheck is defined and spellcheck is not empty %}spellcheck="{{ spellcheck }}"{% endif %}
-            {% if autocomplete is defined and autocomplete is not empty %}autocomplete="{{ autocomplete }}"{% endif %} />
-
-    {% if element.getName() == 'show_hide_password' %}
-        <button class="govuk-button govuk-button--secondary moj-password-reveal__button" data-module="govuk-button" type="button"
-                data-showpassword="{% trans %}Show{% notes %}Show password label{% endtrans%}"
-                data-hidepassword="{% trans %}Hide{% notes %}Hide password label{% endtrans %}">
-        </button>
-        </div>
-    {% endif %}
-
+            {% if autocomplete is defined and autocomplete is not empty %}autocomplete="{{ autocomplete }}"{% endif %}/>
 {%- endblock form_input -%}


### PR DESCRIPTION
# Purpose

Added show/hide password functionality to login page password field

Fixes UML-1230

## Approach

Made a reusable form component to add the show/hide button alongside the input box for elements containing the attribute "moj-password-reveal__input"

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
