### PR TITLE
UML-1273 - Permit api-app to use gov.uk Notify

### DIFF
--- a/terraform/environment/api_ecs.tf
+++ b/terraform/environment/api_ecs.tf
@@ -247,6 +247,11 @@ EOF
             "awslogs-stream-prefix": "${local.environment}.api-app.use-an-lpa"
         }
     },
+    "secrets" : [
+    {
+      "name": "NOTIFY_API_KEY",
+      "valueFrom": "${data.aws_secretsmanager_secret.notify_api_key.arn}"
+    }],
     "environment": [
     {
       "name": "DYNAMODB_TABLE_ACTOR_CODES",


### PR DESCRIPTION
# Purpose

The api-app task should be permitted to use gov.uk Notify

Fixes UML-1273

## Approach

Add notify key secret to the api-app task definition

## Learning

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
