### PR TITLE
Change older LPA page title that is the same as another

### DIFF
--- a/service-front/app/languages/messages.pot
+++ b/service-front/app/languages/messages.pot
@@ -1,41 +1,41 @@
 msgid ""
 msgstr ""
 "Language: en_GB\n"
-"POT-Creation-Date: 2021-02-26T16:50:53+00:00\n"
+"POT-Creation-Date: 2021-03-05T10:58:12+00:00\n"
 "X-Domain: messages\n"
 
 #: src/Actor/templates/actor/lpa-show-viewercode.html.twig:3
 msgid "Your new access code"
 msgstr ""
 
-#: src/Actor/templates/actor/lpa-show-viewercode.html.twig:14
+#: src/Actor/templates/actor/already-requested-activation-key.html.twig:22
 #: src/Actor/templates/actor/check-access-codes.html.twig:15
 #: src/Actor/templates/actor/instructions-preferences.html.twig:12
-#: src/Actor/templates/actor/already-requested-activation-key.html.twig:22
-#: src/Actor/templates/actor/send-activation-key-confirmation.html.twig:36
 #: src/Actor/templates/actor/lpa-create-viewercode.html.twig:14
+#: src/Actor/templates/actor/lpa-show-viewercode.html.twig:14
+#: src/Actor/templates/actor/send-activation-key-confirmation.html.twig:36
 msgid "Back to your LPAs"
 msgstr ""
 
-#: src/Actor/templates/actor/lpa-show-viewercode.html.twig:21
 #: src/Actor/templates/actor/check-access-codes.html.twig:26
-#: src/Actor/templates/actor/lpa-already-added.html.twig:37
-#: src/Actor/templates/actor/view-lpa-summary.html.twig:24
-#: src/Actor/templates/actor/lpa-dashboard.html.twig:64
 #: src/Actor/templates/actor/check-lpa.html.twig:29
+#: src/Actor/templates/actor/lpa-already-added.html.twig:37
 #: src/Actor/templates/actor/lpa-create-viewercode.html.twig:24
+#: src/Actor/templates/actor/lpa-dashboard.html.twig:64
+#: src/Actor/templates/actor/lpa-show-viewercode.html.twig:21
+#: src/Actor/templates/actor/view-lpa-summary.html.twig:24
 #: src/Common/templates/partials/full-lpa-display.html.twig:13
 #: src/Viewer/templates/viewer/check-code-found.html.twig:29
 msgid "Property and finance"
 msgstr ""
 
-#: src/Actor/templates/actor/lpa-show-viewercode.html.twig:21
 #: src/Actor/templates/actor/check-access-codes.html.twig:28
-#: src/Actor/templates/actor/lpa-already-added.html.twig:39
-#: src/Actor/templates/actor/view-lpa-summary.html.twig:26
-#: src/Actor/templates/actor/lpa-dashboard.html.twig:64
 #: src/Actor/templates/actor/check-lpa.html.twig:31
+#: src/Actor/templates/actor/lpa-already-added.html.twig:39
 #: src/Actor/templates/actor/lpa-create-viewercode.html.twig:24
+#: src/Actor/templates/actor/lpa-dashboard.html.twig:64
+#: src/Actor/templates/actor/lpa-show-viewercode.html.twig:21
+#: src/Actor/templates/actor/view-lpa-summary.html.twig:26
 #: src/Common/templates/partials/full-lpa-display.html.twig:15
 #: src/Viewer/templates/viewer/check-code-found.html.twig:29
 msgid "Health and welfare"
@@ -138,29 +138,29 @@ msgstr ""
 msgid "Confirm your new email address"
 msgstr ""
 
-#: src/Actor/templates/actor/request-email-change-success.html.twig:14
-#: src/Actor/templates/actor/lpa-already-added.html.twig:12
 #: src/Actor/templates/actor/activate-account.html.twig:12
-#: src/Actor/templates/actor/create-account.html.twig:12
-#: src/Actor/templates/actor/password-reset.html.twig:12
-#: src/Actor/templates/actor/password-change.html.twig:13
-#: src/Actor/templates/actor/create-account-success.html.twig:12
-#: src/Actor/templates/actor/change-email.html.twig:13
-#: src/Actor/templates/actor/password-reset-request.html.twig:12
-#: src/Actor/templates/actor/death-notification.html.twig:20
 #: src/Actor/templates/actor/add-lpa-triage.html.twig:14
-#: src/Actor/templates/actor/confirm-delete-account.html.twig:13
-#: src/Actor/templates/actor/request-activation-key.html.twig:14
-#: src/Actor/templates/actor/login.html.twig:12
-#: src/Actor/templates/actor/lpa-removed.html.twig:15
+#: src/Actor/templates/actor/change-details.html.twig:20
+#: src/Actor/templates/actor/change-email.html.twig:13
 #: src/Actor/templates/actor/check-lpa.html.twig:12
 #: src/Actor/templates/actor/check-your-answers.html.twig:15
-#: src/Actor/templates/actor/password-reset-not-found.html.twig:12
-#: src/Actor/templates/actor/change-details.html.twig:20
-#: src/Actor/templates/actor/password-reset-request-done.html.twig:12
+#: src/Actor/templates/actor/confirm-delete-account.html.twig:13
+#: src/Actor/templates/actor/create-account-success.html.twig:12
+#: src/Actor/templates/actor/create-account.html.twig:12
+#: src/Actor/templates/actor/death-notification.html.twig:20
+#: src/Actor/templates/actor/login.html.twig:12
 #: src/Actor/templates/actor/lpa-add.html.twig:14
-#: src/Common/templates/partials/cookies.html.twig:19
+#: src/Actor/templates/actor/lpa-already-added.html.twig:12
+#: src/Actor/templates/actor/lpa-removed.html.twig:15
+#: src/Actor/templates/actor/password-change.html.twig:13
+#: src/Actor/templates/actor/password-reset-not-found.html.twig:12
+#: src/Actor/templates/actor/password-reset-request-done.html.twig:12
+#: src/Actor/templates/actor/password-reset-request.html.twig:12
+#: src/Actor/templates/actor/password-reset.html.twig:12
+#: src/Actor/templates/actor/request-activation-key.html.twig:14
+#: src/Actor/templates/actor/request-email-change-success.html.twig:14
 #: src/Common/templates/partials/contact-us.html.twig:17
+#: src/Common/templates/partials/cookies.html.twig:19
 #: src/Viewer/templates/viewer/check-code-found.html.twig:12
 #: src/Viewer/templates/viewer/enter-code.html.twig:12
 msgid "Back"
@@ -227,20 +227,20 @@ msgstr ""
 msgid "Confirm your password"
 msgstr ""
 
-#: src/Actor/templates/actor/create-account.html.twig:59
 #: src/Actor/templates/actor/actor-terms-of-use.html.twig:31
-#: src/Actor/templates/actor/view-lpa-summary.html.twig:245
 #: src/Actor/templates/actor/check-lpa.html.twig:68
 #: src/Actor/templates/actor/check-your-answers.html.twig:82
+#: src/Actor/templates/actor/create-account.html.twig:59
 #: src/Actor/templates/actor/lpa-create-viewercode.html.twig:62
+#: src/Actor/templates/actor/view-lpa-summary.html.twig:245
 #: src/Viewer/templates/viewer/check-code-found.html.twig:45
 #: src/Viewer/templates/viewer/viewer-terms-of-use.html.twig:45
 msgid "Warning"
 msgstr ""
 
 #: src/Actor/templates/actor/create-account.html.twig:60
-#: src/Actor/templates/actor/password-reset.html.twig:47
 #: src/Actor/templates/actor/password-change.html.twig:38
+#: src/Actor/templates/actor/password-reset.html.twig:47
 msgid "Never share your password with anyone."
 msgstr ""
 
@@ -248,34 +248,34 @@ msgstr ""
 msgid "Create account"
 msgstr ""
 
-#: src/Actor/templates/actor/password-reset.html.twig:29
 #: src/Actor/templates/actor/password-change.html.twig:25
+#: src/Actor/templates/actor/password-reset.html.twig:29
 msgid "Change your password"
 msgstr ""
 
-#: src/Actor/templates/actor/password-reset.html.twig:39
 #: src/Actor/templates/actor/password-change.html.twig:32
+#: src/Actor/templates/actor/password-reset.html.twig:39
 msgid "Your password needs to have:"
 msgstr ""
 
-#: src/Actor/templates/actor/password-reset.html.twig:42
 #: src/Actor/templates/actor/password-change.html.twig:34
+#: src/Actor/templates/actor/password-reset.html.twig:42
 msgid "at least 8 characters"
 msgstr ""
 
-#: src/Actor/templates/actor/password-reset.html.twig:43
 #: src/Actor/templates/actor/password-change.html.twig:35
+#: src/Actor/templates/actor/password-reset.html.twig:43
 msgid "at least one lower-case and one capital letter"
 msgstr ""
 
-#: src/Actor/templates/actor/password-reset.html.twig:44
 #: src/Actor/templates/actor/password-change.html.twig:36
+#: src/Actor/templates/actor/password-reset.html.twig:44
 msgid "at least one number"
 msgstr ""
 
+#: src/Actor/templates/actor/login.html.twig:47
 #: src/Actor/templates/actor/password-reset.html.twig:49
 #: src/Actor/templates/actor/your-details.html.twig:37
-#: src/Actor/templates/actor/login.html.twig:45
 msgid "Password"
 msgstr ""
 
@@ -283,8 +283,8 @@ msgstr ""
 msgid "Confirm Password"
 msgstr ""
 
-#: src/Actor/templates/actor/password-reset.html.twig:53
 #: src/Actor/templates/actor/password-change.html.twig:44
+#: src/Actor/templates/actor/password-reset.html.twig:53
 msgid "Change password"
 msgstr ""
 
@@ -622,21 +622,21 @@ msgstr ""
 msgid "The donor"
 msgstr ""
 
-#: src/Actor/templates/actor/view-lpa-summary.html.twig:135
 #: src/Actor/templates/actor/check-your-answers.html.twig:40
+#: src/Actor/templates/actor/view-lpa-summary.html.twig:135
 #: src/Common/templates/partials/full-lpa-display.html.twig:162
 msgid "Name"
 msgstr ""
 
-#: src/Actor/templates/actor/view-lpa-summary.html.twig:139
 #: src/Actor/templates/actor/check-your-answers.html.twig:53
+#: src/Actor/templates/actor/view-lpa-summary.html.twig:139
 #: src/Common/templates/partials/full-lpa-display.html.twig:166
 msgid "Date of birth"
 msgstr ""
 
 #: src/Actor/templates/actor/cannot-find-lpa.html.twig:45
-#: src/Actor/templates/actor/view-lpa-summary.html.twig:143
 #: src/Actor/templates/actor/change-details.html.twig:74
+#: src/Actor/templates/actor/view-lpa-summary.html.twig:143
 #: src/Common/templates/partials/full-lpa-display.html.twig:170
 msgid "Address"
 msgstr ""
@@ -757,10 +757,10 @@ msgstr ""
 msgid "You cannot use a download or print out of this <abbr title=\"lasting power of attorney\">LPA</abbr> summary in place of the original paper <abbr title=\"lasting power of attorney\">LPA</abbr> or instead of giving someone an access code."
 msgstr ""
 
-#: src/Actor/templates/actor/layout.html.twig:5
 #: src/Actor/templates/actor/home-page.html.twig:5
-#: src/Common/templates/partials/cookies.html.twig:7
+#: src/Actor/templates/actor/layout.html.twig:5
 #: src/Common/templates/partials/contact-us.html.twig:7
+#: src/Common/templates/partials/cookies.html.twig:7
 msgid "Use a lasting power of attorney"
 msgstr ""
 
@@ -1200,9 +1200,9 @@ msgstr ""
 msgid "Enter your email address below. If there's an account associated with the address, we'll send you a link to reset your password."
 msgstr ""
 
+#: src/Actor/templates/actor/login.html.twig:43
 #: src/Actor/templates/actor/password-reset-request.html.twig:34
 #: src/Actor/templates/actor/your-details.html.twig:24
-#: src/Actor/templates/actor/login.html.twig:43
 msgid "Email address"
 msgstr ""
 
@@ -1255,8 +1255,8 @@ msgid "For your security, we've signed you out of this service because you did n
 msgstr ""
 
 #: src/Actor/templates/actor/actor-session-expired.html.twig:17
-#: src/Actor/templates/actor/login.html.twig:47
 #: src/Actor/templates/actor/email-reset-not-found.html.twig:22
+#: src/Actor/templates/actor/login.html.twig:52
 msgid "Sign in"
 msgstr ""
 
@@ -1264,8 +1264,8 @@ msgstr ""
 msgid "Death Notification"
 msgstr ""
 
-#: src/Actor/templates/actor/death-notification.html.twig:28
 #: src/Actor/templates/actor/change-details.html.twig:86
+#: src/Actor/templates/actor/death-notification.html.twig:28
 msgid "Let us know if a donor or attorney dies"
 msgstr ""
 
@@ -1276,8 +1276,8 @@ msgid ""
 msgstr ""
 
 #: src/Actor/templates/actor/cannot-find-lpa.html.twig:23
-#: src/Actor/templates/actor/death-notification.html.twig:34
 #: src/Actor/templates/actor/change-details.html.twig:34
+#: src/Actor/templates/actor/death-notification.html.twig:34
 msgid "You should contact us if:"
 msgstr ""
 
@@ -1330,8 +1330,8 @@ msgid "there are replacement attorneys"
 msgstr ""
 
 #: src/Actor/templates/actor/cannot-find-lpa.html.twig:31
-#: src/Actor/templates/actor/death-notification.html.twig:60
 #: src/Actor/templates/actor/change-details.html.twig:57
+#: src/Actor/templates/actor/death-notification.html.twig:60
 msgid "How to let us know"
 msgstr ""
 
@@ -1356,8 +1356,8 @@ msgid "a return address where your documents can be sent back to"
 msgstr ""
 
 #: src/Actor/templates/actor/cannot-find-lpa.html.twig:47
-#: src/Actor/templates/actor/death-notification.html.twig:71
 #: src/Actor/templates/actor/change-details.html.twig:76
+#: src/Actor/templates/actor/death-notification.html.twig:71
 msgid ""
 "Office of the Public Guardian<br>\n"
 "                            PO Box 16185<br>\n"
@@ -1365,9 +1365,9 @@ msgid ""
 "                            B2 2WH"
 msgstr ""
 
-#: src/Actor/templates/actor/your-details.html.twig:18
-#: src/Actor/templates/actor/request-activation-key.html.twig:41
 #: src/Actor/templates/actor/lpa-add.html.twig:58
+#: src/Actor/templates/actor/request-activation-key.html.twig:41
+#: src/Actor/templates/actor/your-details.html.twig:18
 #: src/Common/templates/partials/account-bar.html.twig:11
 msgid "Your details"
 msgstr ""
@@ -1608,8 +1608,8 @@ msgctxt "error"
 msgid "The emails did not match"
 msgstr ""
 
-#: src/Actor/templates/actor/lpa-dashboard.html.twig:19
 #: src/Actor/templates/actor/lpa-blank-dashboard.html.twig:16
+#: src/Actor/templates/actor/lpa-dashboard.html.twig:19
 msgid "Your lasting powers of attorney"
 msgstr ""
 
@@ -1679,8 +1679,8 @@ msgstr ""
 msgid "We could not find a lasting power of attorney with the information you entered."
 msgstr ""
 
-#: src/Actor/templates/actor/lpa-not-found.html.twig:22
 #: src/Actor/templates/actor/check-your-answers.html.twig:22
+#: src/Actor/templates/actor/lpa-not-found.html.twig:22
 msgid "Check your answers"
 msgstr ""
 
@@ -1735,7 +1735,7 @@ msgstr ""
 msgid "If you made an <abbr title=\"lasting power of attorney\"> LPA </abbr> online, you'll still need to <a href=\"%link%\" class=\"govuk-link\">create an account</a> to use this service."
 msgstr ""
 
-#: src/Actor/templates/actor/login.html.twig:53
+#: src/Actor/templates/actor/login.html.twig:58
 msgid "Forgotten your password?"
 msgstr ""
 
@@ -1767,14 +1767,14 @@ msgstr ""
 msgid "Is this the LPA you want to add?"
 msgstr ""
 
-#: src/Actor/templates/actor/lpa-already-added.html.twig:33
 #: src/Actor/templates/actor/check-lpa.html.twig:25
+#: src/Actor/templates/actor/lpa-already-added.html.twig:33
 #: src/Viewer/templates/viewer/check-code-found.html.twig:28
 msgid "Type of LPA"
 msgstr ""
 
-#: src/Actor/templates/actor/lpa-already-added.html.twig:25
 #: src/Actor/templates/actor/check-lpa.html.twig:37
+#: src/Actor/templates/actor/lpa-already-added.html.twig:25
 #: src/Viewer/templates/viewer/check-code-found.html.twig:32
 msgid "Donor name"
 msgstr ""
@@ -1796,7 +1796,6 @@ msgid "Donor"
 msgstr ""
 
 #: src/Actor/templates/actor/check-lpa.html.twig:69
-#: src/Viewer/templates/viewer/check-code-found.html.twig:46
 msgid "Check that these details are correct before continuing"
 msgstr ""
 
@@ -1814,12 +1813,12 @@ msgstr ""
 
 #: src/Actor/templates/actor/activate-account-not-found.html.twig:44
 #: src/Actor/templates/actor/add-lpa-triage.html.twig:65
-#: src/Actor/templates/actor/request-activation-key.html.twig:64
 #: src/Actor/templates/actor/check-lpa.html.twig:93
 #: src/Actor/templates/actor/check-your-answers.html.twig:91
 #: src/Actor/templates/actor/home-page.html.twig:46
-#: src/Actor/templates/actor/lpa-create-viewercode.html.twig:68
 #: src/Actor/templates/actor/lpa-add.html.twig:91
+#: src/Actor/templates/actor/lpa-create-viewercode.html.twig:68
+#: src/Actor/templates/actor/request-activation-key.html.twig:64
 #: src/Viewer/templates/viewer/enter-code.html.twig:60
 msgid "Continue"
 msgstr ""
@@ -1955,27 +1954,27 @@ msgstr ""
 msgid "Viewed"
 msgstr ""
 
-#: src/Actor/templates/actor/partials/check-code-details.html.twig:50
+#: src/Actor/templates/actor/partials/check-code-details.html.twig:49
 msgid "Not viewed"
 msgstr ""
 
-#: src/Actor/templates/actor/partials/check-code-details.html.twig:57
+#: src/Actor/templates/actor/partials/check-code-details.html.twig:56
 msgid "Expires"
 msgstr ""
 
-#: src/Actor/templates/actor/partials/check-code-details.html.twig:60
+#: src/Actor/templates/actor/partials/check-code-details.html.twig:59
 msgid "Expired"
 msgstr ""
 
-#: src/Actor/templates/actor/partials/check-code-details.html.twig:76
+#: src/Actor/templates/actor/partials/check-code-details.html.twig:75
 msgid "Status"
 msgstr ""
 
-#: src/Actor/templates/actor/partials/check-code-details.html.twig:78
+#: src/Actor/templates/actor/partials/check-code-details.html.twig:77
 msgid "EXPIRED"
 msgstr ""
 
-#: src/Actor/templates/actor/partials/check-code-details.html.twig:71
+#: src/Actor/templates/actor/partials/check-code-details.html.twig:70
 msgid "CANCELLED"
 msgstr ""
 
@@ -2046,8 +2045,8 @@ msgstr ""
 msgid "If you’re an attorney, you can tell us about changes to the donor’s details and your details. You cannot update another attorney’s details."
 msgstr ""
 
-#: src/Actor/templates/actor/cannot-find-lpa.html.twig:32
 #: src/Actor/templates/actor/actor-accessibility-statement.html.twig:67
+#: src/Actor/templates/actor/cannot-find-lpa.html.twig:32
 #: src/Actor/templates/actor/change-details.html.twig:59
 #: src/Viewer/templates/viewer/viewer-accessibility-statement.html.twig:71
 msgid "Telephone"
@@ -2065,14 +2064,14 @@ msgid ""
 msgstr ""
 
 #: src/Actor/templates/actor/cannot-find-lpa.html.twig:37
-#: src/Actor/templates/actor/send-activation-key-confirmation.html.twig:30
 #: src/Actor/templates/actor/change-details.html.twig:66
+#: src/Actor/templates/actor/send-activation-key-confirmation.html.twig:30
 #: src/Common/templates/partials/contact-us.html.twig:36
 msgid "Find out about call charges"
 msgstr ""
 
-#: src/Actor/templates/actor/cannot-find-lpa.html.twig:40
 #: src/Actor/templates/actor/actor-accessibility-statement.html.twig:61
+#: src/Actor/templates/actor/cannot-find-lpa.html.twig:40
 #: src/Actor/templates/actor/change-details.html.twig:69
 #: src/Common/templates/partials/contact-us.html.twig:40
 #: src/Viewer/templates/viewer/viewer-accessibility-statement.html.twig:65
@@ -2133,18 +2132,18 @@ msgstr ""
 msgid "Any lasting power of attorney (LPA) you add to your account will show on this page."
 msgstr ""
 
-#: src/Actor/templates/actor/lpa-dashboard.html.twig:38
 #: src/Actor/templates/actor/lpa-blank-dashboard.html.twig:35
+#: src/Actor/templates/actor/lpa-dashboard.html.twig:38
 msgid "give organisations access to an online summary of an <abbr title=\"lasting power of attorney\">LPA</abbr> by making a secure access code"
 msgstr ""
 
-#: src/Actor/templates/actor/lpa-dashboard.html.twig:39
 #: src/Actor/templates/actor/lpa-blank-dashboard.html.twig:36
+#: src/Actor/templates/actor/lpa-dashboard.html.twig:39
 msgid "keep track of the organisations that have online access to an <abbr title=\"lasting power of attorney\">LPA</abbr>"
 msgstr ""
 
-#: src/Actor/templates/actor/lpa-dashboard.html.twig:40
 #: src/Actor/templates/actor/lpa-blank-dashboard.html.twig:37
+#: src/Actor/templates/actor/lpa-dashboard.html.twig:40
 msgid "view an <abbr title=\"lasting power of attorney\">LPA</abbr> summary"
 msgstr ""
 
@@ -2213,13 +2212,13 @@ msgid ""
 "                                Monday to Friday, 9:30 to 5pm, except Wednesdays 10am to 5pm."
 msgstr ""
 
-#: src/Actor/templates/actor/request-activation-key.html.twig:54
 #: src/Actor/templates/actor/lpa-add.html.twig:87
+#: src/Actor/templates/actor/request-activation-key.html.twig:54
 msgid "What is your date of birth?"
 msgstr ""
 
-#: src/Actor/templates/actor/request-activation-key.html.twig:55
 #: src/Actor/templates/actor/lpa-add.html.twig:88
+#: src/Actor/templates/actor/request-activation-key.html.twig:55
 msgid "For example, 31 03 1980"
 msgstr ""
 
@@ -2357,15 +2356,15 @@ msgstr ""
 msgid "I want to check another LPA"
 msgstr ""
 
-#: src/Common/templates/partials/govuk_form.html.twig:140
+#: src/Common/templates/partials/govuk_form.html.twig:144
 msgid "Day"
 msgstr ""
 
-#: src/Common/templates/partials/govuk_form.html.twig:150
+#: src/Common/templates/partials/govuk_form.html.twig:154
 msgid "Month"
 msgstr ""
 
-#: src/Common/templates/partials/govuk_form.html.twig:160
+#: src/Common/templates/partials/govuk_form.html.twig:164
 msgid "Year"
 msgstr ""
 
@@ -2382,8 +2381,8 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
-#: src/Common/templates/partials/cookies.html.twig:9
 #: src/Common/templates/partials/contact-us.html.twig:9
+#: src/Common/templates/partials/cookies.html.twig:9
 #: src/Viewer/templates/viewer/layout.html.twig:5
 msgid "View a lasting power of attorney"
 msgstr ""
@@ -2464,8 +2463,8 @@ msgstr ""
 msgid "Your LPAs"
 msgstr ""
 
-#: src/Actor/templates/actor/cannot-find-lpa.html.twig:55
 #: src/Actor/templates/actor/already-have-activation-key.html.twig:25
+#: src/Actor/templates/actor/cannot-find-lpa.html.twig:55
 #: src/Actor/templates/actor/cannot-send-activation-key.html.twig:25
 #: src/Actor/templates/actor/partials/use-session-dialog.html.twig:15
 #: src/Common/templates/partials/account-bar.html.twig:13
@@ -2497,35 +2496,35 @@ msgid "in %count% day, on %date%"
 msgid_plural "in %count% days, on %date%"
 msgstr[0] ""
 
-#: src/Viewer/templates/viewer/check-code-found.html.twig:51
+#: src/Viewer/templates/viewer/check-code-found.html.twig:46
 msgid "If this is not the right LPA, ask the donor or attorney to check the access code."
 msgstr ""
 
-#: src/Viewer/templates/viewer/check-code-found.html.twig:57
+#: src/Viewer/templates/viewer/check-code-found.html.twig:53
 msgid "If you need to see this <abbr title=\"lasting power of attorney\">LPA</abbr> after %date%"
 msgstr ""
 
-#: src/Viewer/templates/viewer/check-code-found.html.twig:62
+#: src/Viewer/templates/viewer/check-code-found.html.twig:58
 msgid "You can see an online summary of this <abbr title='lasting power of attorney'> LPA </abbr>until %date%. After this date, the access code will expire."
 msgstr ""
 
-#: src/Viewer/templates/viewer/check-code-found.html.twig:64
+#: src/Viewer/templates/viewer/check-code-found.html.twig:60
 msgid "Ask the donor or attorney for a new access code if your organisation:"
 msgstr ""
 
-#: src/Viewer/templates/viewer/check-code-found.html.twig:66
+#: src/Viewer/templates/viewer/check-code-found.html.twig:62
 msgid "needs more time to process this LPA"
 msgstr ""
 
-#: src/Viewer/templates/viewer/check-code-found.html.twig:67
+#: src/Viewer/templates/viewer/check-code-found.html.twig:63
 msgid "need to see this LPA at a later date"
 msgstr ""
 
-#: src/Viewer/templates/viewer/check-code-found.html.twig:82
+#: src/Viewer/templates/viewer/check-code-found.html.twig:78
 msgid "View this LPA"
 msgstr ""
 
-#: src/Viewer/templates/viewer/check-code-found.html.twig:85
+#: src/Viewer/templates/viewer/check-code-found.html.twig:81
 msgid "Try another access code"
 msgstr ""
 
@@ -2999,12 +2998,12 @@ msgid "Cancelled on %cancellationDate%"
 msgstr ""
 
 #. Show password label
-#: src/Common/templates/partials/govuk_form.html.twig:234
+#: src/Common/templates/partials/govuk_form.html.twig:228
 msgid "Show"
 msgstr ""
 
 #. Hide password label
-#: src/Common/templates/partials/govuk_form.html.twig:235
+#: src/Common/templates/partials/govuk_form.html.twig:229
 msgid "Hide"
 msgstr ""
 
@@ -3333,8 +3332,8 @@ msgstr ""
 msgid "Back to GOV.UK"
 msgstr ""
 
-#: src/Actor/templates/actor/create-account.html.twig:43
 #: src/Actor/templates/actor/change-email.html.twig:33
+#: src/Actor/templates/actor/create-account.html.twig:43
 msgid "Check that your email address is spelt correctly"
 msgstr ""
 
@@ -3376,11 +3375,11 @@ msgstr ""
 msgid "If you're named on more than one <abbr title=\"lasting power of attorney\">LPA</abbr>, you can add all those <abbr title=\"lasting powers of attorney\">LPAs</abbr> to your account"
 msgstr ""
 
-#: src/Viewer/templates/viewer/check-code-found.html.twig:77
+#: src/Viewer/templates/viewer/check-code-found.html.twig:73
 msgid "Your organisation name"
 msgstr ""
 
-#: src/Viewer/templates/viewer/check-code-found.html.twig:78
+#: src/Viewer/templates/viewer/check-code-found.html.twig:74
 msgid "This will be displayed to the attorneys and donor on the LPA"
 msgstr ""
 
@@ -3390,18 +3389,18 @@ msgctxt "error"
 msgid "Enter your organisation name"
 msgstr ""
 
-#: src/Actor/templates/actor/lpa-dashboard.html.twig:27
 #: src/Actor/templates/actor/lpa-blank-dashboard.html.twig:24
+#: src/Actor/templates/actor/lpa-dashboard.html.twig:27
 msgid "Find out about <a href=\"https://www.gov.uk/lasting-power-attorney-duties\" class=\"govuk-link\">the role of an attorney</a> and how to support the donor <a href=\"https://www.gov.uk/make-decisions-for-someone/making-decisions\" class=\"govuk-link\">to make decisions</a>."
 msgstr ""
 
-#: src/Actor/templates/actor/lpa-dashboard.html.twig:32
 #: src/Actor/templates/actor/lpa-blank-dashboard.html.twig:29
+#: src/Actor/templates/actor/lpa-dashboard.html.twig:32
 msgid "What can I do with this service?"
 msgstr ""
 
-#: src/Actor/templates/actor/lpa-dashboard.html.twig:36
 #: src/Actor/templates/actor/lpa-blank-dashboard.html.twig:33
+#: src/Actor/templates/actor/lpa-dashboard.html.twig:36
 msgid "Use this service to:"
 msgstr ""
 
@@ -3536,8 +3535,8 @@ msgstr ""
 msgid "Find out what to do if you've <a href=\"%link%\" class=\"govuk-link\">changed address and not told us</a>."
 msgstr ""
 
-#: src/Actor/templates/actor/request-activation-key.html.twig:34
 #: src/Actor/templates/actor/check-your-answers.html.twig:27
+#: src/Actor/templates/actor/request-activation-key.html.twig:34
 msgid "OPG reference number"
 msgstr ""
 
@@ -3553,8 +3552,8 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: src/Actor/templates/actor/request-activation-key.html.twig:59
 #: src/Actor/templates/actor/check-your-answers.html.twig:66
+#: src/Actor/templates/actor/request-activation-key.html.twig:59
 msgid "Postcode"
 msgstr ""
 
@@ -3622,7 +3621,6 @@ msgstr ""
 msgid "If the LPA was registered before this date, you need to use the paper LPA with people and organisations."
 msgstr ""
 
-#: src/Actor/templates/actor/already-have-activation-key.html.twig:3
 #: src/Actor/templates/actor/cannot-send-activation-key.html.twig:3
 msgid "Cannot send an activation key"
 msgstr ""
@@ -3759,6 +3757,6 @@ msgstr ""
 msgid "You can only use this service if your LPA was registered on or after 1 September 2019."
 msgstr ""
 
-#: src/Actor/templates/actor/partials/check-code-details.html.twig:44
+#: src/Actor/templates/actor/partials/check-code-details.html.twig:43
 msgid "%organisation% on %date%"
 msgstr ""

--- a/service-front/app/src/Actor/templates/actor/already-have-activation-key.html.twig
+++ b/service-front/app/src/Actor/templates/actor/already-have-activation-key.html.twig
@@ -1,6 +1,6 @@
 {% extends '@actor/layout.html.twig' %}
 
-{% block html_title %}{% trans %}Cannot send an activation key{% endtrans %} - {{ parent() }}{% endblock %}
+{% block html_title %}{% trans %}You have an activation key for this LPA{% endtrans %} - {{ parent() }}{% endblock %}
 
 {% block content %}
     <div class="govuk-width-container">


### PR DESCRIPTION
# Purpose

Changed page title that is the same as the registration date fail page

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
