### PR TITLE
UML-1320 - Create a queue to push metrics to

### DIFF
--- a/terraform/account/locals.tf
+++ b/terraform/account/locals.tf
@@ -8,11 +8,11 @@ variable "account_mapping" {
 variable "accounts" {
   type = map(
     object({
-      account_id             = string
-      is_production          = bool
-      retention_in_days      = number
-      pagerduty_service_name = string
-      has_metrics_queue      = bool
+      account_id                 = string
+      is_production              = bool
+      retention_in_days          = number
+      pagerduty_service_name     = string
+      ship_metrics_queue_enabled = bool
     })
   )
 }

--- a/terraform/account/locals.tf
+++ b/terraform/account/locals.tf
@@ -12,6 +12,7 @@ variable "accounts" {
       is_production          = bool
       retention_in_days      = number
       pagerduty_service_name = string
+      has_metrics_queue      = bool
     })
   )
 }

--- a/terraform/account/ship_metrics_queue.tf
+++ b/terraform/account/ship_metrics_queue.tf
@@ -1,5 +1,6 @@
 
 resource "aws_sqs_queue" "ship_to_opg_metrics" {
+  count                     = local.account.ship_metrics_queue_enabled == true ? 1 : 0
   name                      = "${local.environment}-ship-to-opg-metrics"
   delay_seconds             = 90
   max_message_size          = 2048
@@ -9,14 +10,16 @@ resource "aws_sqs_queue" "ship_to_opg_metrics" {
 }
 
 resource "aws_sqs_queue_policy" "ship_to_opg_metrics" {
-  queue_url = aws_sqs_queue.ship_to_opg_metrics.id
-  policy    = data.aws_iam_policy_document.ship_to_opg_metrics.json
+  count     = local.account.ship_metrics_queue_enabled == true ? 1 : 0
+  queue_url = aws_sqs_queue.ship_to_opg_metrics[0].id
+  policy    = data.aws_iam_policy_document.ship_to_opg_metrics[0].json
 }
 
 data "aws_iam_policy_document" "ship_to_opg_metrics" {
+  count = local.account.ship_metrics_queue_enabled == true ? 1 : 0
   statement {
     effect    = "Allow"
-    resources = [aws_sqs_queue.ship_to_opg_metrics.arn]
+    resources = [aws_sqs_queue.ship_to_opg_metrics[0].arn]
     actions = [
       "sqs:ChangeMessageVisibility",
       "sqs:DeleteMessage",

--- a/terraform/account/ship_metrics_queue.tf
+++ b/terraform/account/ship_metrics_queue.tf
@@ -1,0 +1,34 @@
+
+resource "aws_sqs_queue" "ship_to_opg_metrics" {
+  name                      = "${local.environment}-ship-to-opg-metrics"
+  delay_seconds             = 90
+  max_message_size          = 2048
+  message_retention_seconds = 86400
+  receive_wait_time_seconds = 10
+  tags                      = local.default_tags
+}
+
+resource "aws_sqs_queue_policy" "ship_to_opg_metrics" {
+  queue_url = aws_sqs_queue.ship_to_opg_metrics.id
+  policy    = data.aws_iam_policy_document.ship_to_opg_metrics.json
+}
+
+data "aws_iam_policy_document" "ship_to_opg_metrics" {
+  statement {
+    effect    = "Allow"
+    resources = [aws_sqs_queue.ship_to_opg_metrics.arn]
+    actions = [
+      "sqs:ChangeMessageVisibility",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+      "sqs:GetQueueUrl",
+      "sqs:ListQueueTags",
+      "sqs:ReceiveMessage",
+      "sqs:SendMessage",
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = [local.account.account_id]
+    }
+  }
+}

--- a/terraform/account/terraform.tfvars.json
+++ b/terraform/account/terraform.tfvars.json
@@ -9,19 +9,22 @@
       "account_id": "367815980639",
       "is_production": false,
       "retention_in_days": 7,
-      "pagerduty_service_name": "Use a Lasting Power of Attorney Non-Production"
+      "pagerduty_service_name": "Use a Lasting Power of Attorney Non-Production",
+      "ship_metrics_queue_enabled": true
     },
     "preproduction": {
       "account_id": "888228022356",
       "is_production": false,
       "retention_in_days": 7,
-      "pagerduty_service_name": "Use a Lasting Power of Attorney Non-Production"
+      "pagerduty_service_name": "Use a Lasting Power of Attorney Non-Production",
+      "ship_metrics_queue_enabled": false
     },
     "production": {
       "account_id": "690083044361",
       "is_production": true,
       "retention_in_days": 120,
-      "pagerduty_service_name": "Use a Lasting Power of Attorney Production"
+      "pagerduty_service_name": "Use a Lasting Power of Attorney Production",
+      "ship_metrics_queue_enabled": false
     }
   }
 


### PR DESCRIPTION
# Purpose

Sending metrics should be resilient to the failure of upstream services, therefore shipping metrics with be mediated by a queue. This first implementation is a simple queue.

Later iteration will introduce FIFO and Dead Letter processing.

Fixes UML-1320

## Approach

Create a simple queue with a broad access policy
Only create a queue in the development account

## Learning


## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
