### PR TITLE
UML-1325 - Scheduled stats posting job not running

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,6 @@ workflows:
     jobs:
       - slack_notify_stats:
           name: slack_notify_stats
-          filters: { branches: { ignore: [master] } }
 
   pr_build:
       jobs:


### PR DESCRIPTION
# Purpose

The post stats job is useful to the team to see usage of the service. The job that posts the stats automatically has not been running.

Fixes UML-1325

## Approach

Remove a filter parameter in the scheduled job specification that prevented the job from running against the master branch.

## Learning

https://circleci.com/docs/2.0/configuration-reference/#schedule

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
