### PR TITLE
UML-1270 - Address missing security.txt file

### DIFF
--- a/service-api/docker/web/etc/confd/templates/nginx.conf
+++ b/service-api/docker/web/etc/confd/templates/nginx.conf
@@ -59,6 +59,6 @@ server {
         deny  all;
     }
 
-    # Compley with https://ministryofjustice.github.io/security-guidance/contact/implement-security-txt/#implementing-securitytxt
-    rewrite ^/.well_known/security.txt$ https://raw.githubusercontent.com/ministryofjustice/security-guidance/master/contact/vulnerability-disclosure-security.txt permanent;
+    # Comply with https://ministryofjustice.github.io/security-guidance/contact/implement-security-txt/#implementing-securitytxt
+    rewrite ^/.well-known/security.txt$ https://raw.githubusercontent.com/ministryofjustice/security-guidance/master/contact/vulnerability-disclosure-security.txt permanent;
 }

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -69,6 +69,6 @@ server {
         deny  all;
     }
 
-    # Compley with https://ministryofjustice.github.io/security-guidance/contact/implement-security-txt/#implementing-securitytxt
-    rewrite ^/.well_known/security.txt$ https://raw.githubusercontent.com/ministryofjustice/security-guidance/master/contact/vulnerability-disclosure-security.txt permanent;
+    # Comply with https://ministryofjustice.github.io/security-guidance/contact/implement-security-txt/#implementing-securitytxt
+    rewrite ^/.well-known/security.txt$ https://raw.githubusercontent.com/ministryofjustice/security-guidance/master/contact/vulnerability-disclosure-security.txt permanent;
 }


### PR DESCRIPTION
# Purpose

NCSC Webcheck is reporting that security.txt cannot be found.

Fixes UML-1270

## Approach

The error here is that redirect should be configured for /.well-known/security.txt and we are redirecting /.well_known/security.txt (underscore should be a hyphen).

Update nginx configuration to correct error.

This is fixed when 
https://783uml1270.view-lasting-power-of-attorney.service.gov.uk/.well-known/security.txt
https://783uml1270.use-lasting-power-of-attorney.service.gov.uk/.well-known/security.txt
redirects to the common security.txt file.

## Learning

https://www.nginx.com/blog/creating-nginx-rewrite-rules/

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
