### PR TITLE
Uml 1307 lpa already added bug fix

### DIFF
--- a/service-front/app/features/context/UI/LpaContext.php
+++ b/service-front/app/features/context/UI/LpaContext.php
@@ -1655,7 +1655,7 @@ class LpaContext implements Context
                 new Response(
                     StatusCodeInterface::STATUS_OK,
                     [],
-                    json_encode([$this->userLpaActorToken => $this->lpaData])
+                    json_encode([])
                 )
             );
 

--- a/service-front/app/features/context/UI/LpaContext.php
+++ b/service-front/app/features/context/UI/LpaContext.php
@@ -381,16 +381,6 @@ class LpaContext implements Context
     {
         $this->iAmOnTheAddAnLPAPage();
 
-        // API call for checking LPA
-        $this->apiFixtures->post('/v1/actor-codes/summary')
-            ->respondWith(
-                new Response(
-                    StatusCodeInterface::STATUS_OK,
-                    [],
-                    json_encode($this->lpaData)
-                )
-            );
-
         //API call for getting all the users added LPAs
         $this->apiFixtures->get('/v1/lpas')
             ->respondWith(
@@ -398,6 +388,16 @@ class LpaContext implements Context
                     StatusCodeInterface::STATUS_OK,
                     [],
                     json_encode([$this->userLpaActorToken => $this->lpaData])
+                )
+            );
+
+        // API call for checking LPA
+        $this->apiFixtures->post('/v1/actor-codes/summary')
+            ->respondWith(
+                new Response(
+                    StatusCodeInterface::STATUS_OK,
+                    [],
+                    json_encode($this->lpaData)
                 )
             );
 
@@ -1648,6 +1648,17 @@ class LpaContext implements Context
     {
         $this->ui->assertPageAddress('/lpa/add-by-code');
 
+        //API call for getting all the users added LPAs
+        //to check if they have already added this LPA
+        $this->apiFixtures->get('/v1/lpas')
+            ->respondWith(
+                new Response(
+                    StatusCodeInterface::STATUS_OK,
+                    [],
+                    json_encode([$this->userLpaActorToken => $this->lpaData])
+                )
+            );
+
         // API call for checking LPA
         $this->apiFixtures->post('/v1/actor-codes/summary')
             ->respondWith(
@@ -1673,6 +1684,17 @@ class LpaContext implements Context
 
         $this->ui->assertPageAddress('/lpa/add-by-code');
 
+        // API call for getting all the users added LPAs
+        // to check if they have already added the LPA
+        $this->apiFixtures->get('/v1/lpas')
+            ->respondWith(
+                new Response(
+                    StatusCodeInterface::STATUS_OK,
+                    [],
+                    json_encode([])
+                )
+            );
+
         // API call for checking LPA
         $this->apiFixtures->post('/v1/actor-codes/summary')
             ->respondWith(
@@ -1687,17 +1709,6 @@ class LpaContext implements Context
                     $params = json_decode($request->getBody()->getContents(), true);
                     assertEquals('XYUPHWQRECHV', $params['actor-code']);
                 }
-            );
-
-        // API call for getting all the users added LPAs
-        // to check if they have already added the LPA
-        $this->apiFixtures->get('/v1/lpas')
-            ->respondWith(
-                new Response(
-                    StatusCodeInterface::STATUS_OK,
-                    [],
-                    json_encode([])
-                )
             );
 
         $this->ui->fillField('passcode', $code);
@@ -1838,6 +1849,17 @@ class LpaContext implements Context
     {
         $this->ui->assertPageAddress('/lpa/add-by-code');
 
+        // API call for getting all the users added LPAs
+        // to check if they have already added the LPA
+        $this->apiFixtures->get('/v1/lpas')
+            ->respondWith(
+                new Response(
+                    StatusCodeInterface::STATUS_OK,
+                    [],
+                    json_encode([])
+                )
+            );
+
         // API call for checking LPA
         $this->apiFixtures->post('/v1/actor-codes/summary')
             ->respondWith(
@@ -1853,17 +1875,6 @@ class LpaContext implements Context
 
                     assertEquals($storedCode, $params['actor-code']);
                 }
-            );
-
-        // API call for getting all the users added LPAs
-        // to check if they have already added the LPA
-        $this->apiFixtures->get('/v1/lpas')
-            ->respondWith(
-                new Response(
-                    StatusCodeInterface::STATUS_OK,
-                    [],
-                    json_encode([])
-                )
             );
 
         $this->ui->fillField('passcode', $code);

--- a/service-front/app/src/Actor/src/Handler/CheckLpaHandler.php
+++ b/service-front/app/src/Actor/src/Handler/CheckLpaHandler.php
@@ -129,6 +129,19 @@ class CheckLpaHandler extends AbstractHandler implements CsrfGuardAware, UserAwa
         string $dob
     ): ResponseInterface {
         try {
+            $lpaAddedData = $this->lpaService->isLpaAlreadyAdded($referenceNumber, $this->identity);
+            if (!is_null($lpaAddedData)) {
+                return new HtmlResponse(
+                    $this->renderer->render(
+                        'actor::lpa-already-added',
+                        [
+                            'lpa' => $lpaAddedData['lpa'],
+                            'actorToken' => $lpaAddedData['user-lpa-actor-token']
+                        ]
+                    )
+                );
+            }
+
             $lpaData = $this->lpaService->getLpaByPasscode(
                 $this->identity,
                 $passcode,
@@ -138,18 +151,6 @@ class CheckLpaHandler extends AbstractHandler implements CsrfGuardAware, UserAwa
 
             $lpa = $lpaData['lpa'];
             $actor = $lpaData['actor']['details'];
-
-            if (false !== $lpaTokenAdded = $this->lpaService->isLpaAlreadyAdded($referenceNumber, $this->identity)) {
-                return new HtmlResponse(
-                    $this->renderer->render(
-                        'actor::lpa-already-added',
-                        [
-                            'lpa' => $lpa,
-                            'actorToken' => $lpaTokenAdded
-                        ]
-                    )
-                );
-            }
 
             $this->getLogger()->debug(
                 'Account with Id {id} has found an LPA with Id {uId} using their passcode',

--- a/service-front/app/src/Common/src/Service/Lpa/LpaService.php
+++ b/service-front/app/src/Common/src/Service/Lpa/LpaService.php
@@ -291,10 +291,11 @@ class LpaService
     /**
      * @param string $referenceNumber
      * @param string $identity
-     * @return bool|string
+     *
+     * @return ArrayObject|null
      * @throws Exception
      */
-    public function isLpaAlreadyAdded(string $referenceNumber, string $identity)
+    public function isLpaAlreadyAdded(string $referenceNumber, string $identity): ?ArrayObject
     {
         $lpasAdded = $this->getLpas($identity);
 
@@ -307,9 +308,9 @@ class LpaService
                         'uId' => $referenceNumber
                     ]
                 );
-                return $userLpaActorToken;
+                return $lpasAdded[$userLpaActorToken];
             }
         }
-        return false;
+        return null;
     }
 }

--- a/service-front/app/test/CommonTest/Service/Lpa/LpaServiceTest.php
+++ b/service-front/app/test/CommonTest/Service/Lpa/LpaServiceTest.php
@@ -474,7 +474,7 @@ class LpaServiceTest extends TestCase
     }
 
     /** @test */
-    public function it_returns_userLpaToken_if_an_lpa_is_already_added()
+    public function it_returns_lpa_data_if_an_lpa_is_already_added()
     {
         $token = '01234567-01234-01234-01234-012345678901';
 

--- a/service-front/app/test/CommonTest/Service/Lpa/LpaServiceTest.php
+++ b/service-front/app/test/CommonTest/Service/Lpa/LpaServiceTest.php
@@ -445,7 +445,7 @@ class LpaServiceTest extends TestCase
     }
 
     /** @test */
-    public function it_returns_false_if_an_lpa_is_not_already_added()
+    public function it_returns_null_if_an_lpa_is_not_already_added()
     {
         $token = '01234567-01234-01234-01234-012345678901';
 
@@ -470,7 +470,7 @@ class LpaServiceTest extends TestCase
 
         $lpaAdded = $this->lpaService->isLpaAlreadyAdded('333333333333', $token);
 
-        $this->assertFalse($lpaAdded);
+        $this->assertNull($lpaAdded);
     }
 
     /** @test */
@@ -478,16 +478,25 @@ class LpaServiceTest extends TestCase
     {
         $token = '01234567-01234-01234-01234-012345678901';
 
-        $lpaData = [
-            '0123-01-01-01-012345' => []
-        ];
-
         $lpa = new Lpa();
         $lpa->setUId('123456789012');
 
+        $lpaData = [
+            '0123-01-01-01-012345' => [
+                'user-lpa-actor-token' => '0123-01-01-01-012345',
+                'lpa' => $lpa
+            ]
+        ];
+
         $parsedLpaData = new ArrayObject(
             [
-                '0123-01-01-01-012345' => new ArrayObject(['lpa' => $lpa], ArrayObject::ARRAY_AS_PROPS),
+                '0123-01-01-01-012345' =>  new ArrayObject(
+                    [
+                        'user-lpa-actor-token' => '0123-01-01-01-012345',
+                        'lpa' => $lpa,
+                    ],
+                    ArrayObject::ARRAY_AS_PROPS
+                ),
             ],
             ArrayObject::ARRAY_AS_PROPS
         );
@@ -499,6 +508,9 @@ class LpaServiceTest extends TestCase
 
         $lpaAdded = $this->lpaService->isLpaAlreadyAdded('123456789012', $token);
 
-        $this->assertEquals(array_key_first($lpaData), $lpaAdded);
+        $this->assertArrayHasKey('user-lpa-actor-token', $lpaAdded);
+        $this->assertArrayHasKey('lpa', $lpaAdded);
+        $this->assertEquals('0123-01-01-01-012345', $lpaAdded['user-lpa-actor-token']);
+        $this->assertEquals($lpa, $lpaAdded['lpa']);
     }
 }


### PR DESCRIPTION
# Purpose

The "LPA already added" page was not displayed when users were attempting to add the same LPA again by entering the same details. This was due to the order of the checks performed in the code, as validating the code was the first step and this of course failed because the code had just been used to add the LPA, resulting in the "LPA not found" page being displayed. 

Fixes UML-1307

## Approach

The check to see if the user has already added the LPA had been moved up as the first check performed in the handler. Tests were amended to reflect the changes.

NOTE: This logic is due be moved into the API as part of ticket UML-1218

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
