### PR TITLE
UML-1110 - Count LPAs in each account for analysis purposes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.48.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/scripts/analysis_scripts/count_account_with_no_lpas.py
+++ b/scripts/analysis_scripts/count_account_with_no_lpas.py
@@ -3,20 +3,20 @@ import json
 
 
 def count_by_maps(actors_json_path, maps_json_path):
+    list_of_userids = []
+    indicator = 0
+    actors = []
+    maps = []
+
     with open(maps_json_path) as f:
         maps_data = json.load(f)
 
         with open(actors_json_path) as f:
             actors_data = json.load(f)
 
-            list_of_userids = []
-            indicator = 0
-
-            actors = []
             for value in actors_data['Items']:
                 actors.append(value['Id']['S'])
 
-            maps = []
             for value in maps_data['Items']:
                 maps.append(value['UserId']['S'])
 

--- a/scripts/analysis_scripts/count_account_with_no_lpas.py
+++ b/scripts/analysis_scripts/count_account_with_no_lpas.py
@@ -1,0 +1,47 @@
+import argparse
+import json
+
+
+def count_by_maps(actors_json_path, maps_json_path):
+    with open(maps_json_path) as f:
+        maps_data = json.load(f)
+
+        with open(actors_json_path) as f:
+            actors_data = json.load(f)
+
+            list_of_userids = []
+            indicator = 0
+
+            actors = []
+            for value in actors_data['Items']:
+                actors.append(value['Id']['S'])
+
+            maps = []
+            for value in maps_data['Items']:
+                maps.append(value['UserId']['S'])
+
+            for actor_id in actors_data['Items']:
+                if actor_id['Id']['S'] not in maps_data['Items']:
+                    list_of_userids.append(actor_id['Id']['S'])
+                indicator += 1
+                if indicator % 10 == 0:
+                    print("Maps processed: ", indicator)
+            print(list_of_userids)
+    print("Maps processed: ", indicator)
+
+def main():
+    arguments = argparse.ArgumentParser(
+        description="Compare JSON files to count user accounts with 0 LPAs added.")
+    arguments.add_argument("--actors_json_path",
+                        default="./actorusers_ids_only.json",
+                        help="Path to ActorUsers JSON file")
+    arguments.add_argument("--maps_json_path",
+                        default="./actormap_ids_only.json",
+                        help="Path to UserLpaActorMap JSON file")
+
+    args = arguments.parse_args()
+    count_by_maps(args.actors_json_path, args.maps_json_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis_scripts/count_lpas_per_account.py
+++ b/scripts/analysis_scripts/count_lpas_per_account.py
@@ -57,14 +57,6 @@ class AccountLookup:
                 ):
             yield from page["Items"]
 
-    def get_lpas(self):
-        paginator = self.aws_dynamodb_client.get_paginator("scan")
-        for page in paginator.paginate(
-                TableName='{}-UserLpaActorMap'.format(self.environment),
-                FilterExpression="attribute_exists(SiriusUid)",
-                ):
-            yield from page["Items"]
-
     def get_lpas_by_user_id(self, user_id):
         response = self.aws_dynamodb_client.query(
             IndexName='UserIndex',
@@ -78,19 +70,6 @@ class AccountLookup:
         for lpa in response['Items']:
             lpas.update({lpa['SiriusUid']['S']:lpa['Added']['S']})
         return lpas
-
-    def get_users_by_id(self, user_id):
-        response = self.aws_dynamodb_client.query(
-            TableName='{}-ActorUsers'.format(self.environment),
-            KeyConditionExpression='Id = :user_id',
-            ExpressionAttributeValues={
-                ':user_id': {'S': user_id}
-            }
-        )
-        if response['Items']:
-            return response['Items'][0]
-
-
 
     def count_by_user(self):
         with open('lpas_per_account.csv', 'w', newline='') as f:
@@ -112,10 +91,6 @@ def main():
     arguments.add_argument("--environment",
                         default="demo",
                         help="The environment to target. Defaults to production")
-
-    arguments.add_argument('--json', dest='output_json', action='store_const',
-                        const=True, default=False,
-                        help='Output json data instead of plaintext to terminal')
 
     args = arguments.parse_args()
     work = AccountLookup(args.environment)

--- a/scripts/analysis_scripts/count_lpas_per_account.py
+++ b/scripts/analysis_scripts/count_lpas_per_account.py
@@ -63,7 +63,7 @@ class AccountLookup:
         for lpa_map in lpa_actor_maps:
             list_of_userids.append(lpa_map['UserId']['S'])
             indicator += 1
-            if indicator % 1000 == 0:
+            if indicator % 10000 == 0:
                 print("Maps processed: ", indicator)
 
         actor_users_map_ids_series = pd.Series(list_of_userids)

--- a/scripts/analysis_scripts/count_lpas_per_account.py
+++ b/scripts/analysis_scripts/count_lpas_per_account.py
@@ -74,8 +74,8 @@ def main():
     arguments = argparse.ArgumentParser(
         description="Look up an account by email address.")
     arguments.add_argument("--environment",
-                        default="demo",
-                        help="The environment to target. Defaults to demo")
+                        default="production",
+                        help="The environment to target. Defaults to production")
 
     args = arguments.parse_args()
     work = AccountLookup(args.environment)

--- a/scripts/analysis_scripts/count_lpas_per_account.py
+++ b/scripts/analysis_scripts/count_lpas_per_account.py
@@ -1,5 +1,4 @@
 import argparse
-import json
 import csv
 import boto3
 
@@ -8,7 +7,6 @@ class AccountLookup:
     aws_iam_session = ''
     aws_dynamodb_client = ''
     environment = ''
-    output_json = []
 
     def __init__(self, environment):
         aws_account_ids = {
@@ -72,9 +70,9 @@ class AccountLookup:
         return lpas
 
     def count_by_user(self):
-        with open('lpas_per_account.csv', 'w', newline='') as f:
+        with open('lpas_per_account.csv', 'w', newline='') as file:
             writer = csv.writer(
-                f, quoting=csv.QUOTE_NONNUMERIC)
+                file, quoting=csv.QUOTE_NONNUMERIC)
             writer.writerow(["lpas_in_account_{}".format(self.environment)])
 
             actor_users = self.get_actor_users()

--- a/scripts/analysis_scripts/count_lpas_per_account.py
+++ b/scripts/analysis_scripts/count_lpas_per_account.py
@@ -1,0 +1,128 @@
+import argparse
+import json
+import csv
+import boto3
+
+class AccountLookup:
+    aws_account_id = ''
+    aws_iam_session = ''
+    aws_dynamodb_client = ''
+    environment = ''
+    output_json = []
+
+    def __init__(self, environment):
+        aws_account_ids = {
+            'production': "690083044361",
+            'preproduction': "888228022356",
+            'development': "367815980639",
+        }
+        self.environment = environment
+
+        self.aws_account_id = aws_account_ids.get(
+            self.environment, "367815980639")
+
+        self.set_iam_role_session()
+
+        self.aws_dynamodb_client = boto3.client(
+            'dynamodb',
+            region_name='eu-west-1',
+            aws_access_key_id=self.aws_iam_session['Credentials']['AccessKeyId'],
+            aws_secret_access_key=self.aws_iam_session['Credentials']['SecretAccessKey'],
+            aws_session_token=self.aws_iam_session['Credentials']['SessionToken'])
+
+    def set_iam_role_session(self):
+        if self.environment == "production":
+            role_arn = 'arn:aws:iam::{}:role/read-only-db'.format(
+                self.aws_account_id)
+        else:
+            role_arn = 'arn:aws:iam::{}:role/operator'.format(
+                self.aws_account_id)
+
+        sts = boto3.client(
+            'sts',
+            region_name='eu-west-1',
+        )
+        session = sts.assume_role(
+            RoleArn=role_arn,
+            RoleSessionName='getting_service_statistics',
+            DurationSeconds=900
+        )
+        self.aws_iam_session = session
+
+    def get_actor_users(self):
+        paginator = self.aws_dynamodb_client.get_paginator("scan")
+        for page in paginator.paginate(
+                TableName='{}-ActorUsers'.format(self.environment),
+                FilterExpression="attribute_exists(Email)",
+                ):
+            yield from page["Items"]
+
+    def get_lpas(self):
+        paginator = self.aws_dynamodb_client.get_paginator("scan")
+        for page in paginator.paginate(
+                TableName='{}-UserLpaActorMap'.format(self.environment),
+                FilterExpression="attribute_exists(SiriusUid)",
+                ):
+            yield from page["Items"]
+
+    def get_lpas_by_user_id(self, user_id):
+        response = self.aws_dynamodb_client.query(
+            IndexName='UserIndex',
+            TableName='{}-UserLpaActorMap'.format(self.environment),
+            KeyConditionExpression='UserId = :user_id',
+            ExpressionAttributeValues={
+                ':user_id': {'S': user_id}
+            }
+        )
+        lpas = {}
+        for lpa in response['Items']:
+            lpas.update({lpa['SiriusUid']['S']:lpa['Added']['S']})
+        return lpas
+
+    def get_users_by_id(self, user_id):
+        response = self.aws_dynamodb_client.query(
+            TableName='{}-ActorUsers'.format(self.environment),
+            KeyConditionExpression='Id = :user_id',
+            ExpressionAttributeValues={
+                ':user_id': {'S': user_id}
+            }
+        )
+        if response['Items']:
+            return response['Items'][0]
+
+
+
+    def count_by_user(self):
+        with open('lpas_per_account.csv', 'w', newline='') as f:
+            writer = csv.writer(
+                f, quoting=csv.QUOTE_NONNUMERIC)
+            writer.writerow(["lpas_in_account_{}".format(self.environment)])
+
+            actor_users = self.get_actor_users()
+
+            for user in actor_users:
+                lpas = self.get_lpas_by_user_id(user['Id']['S'])
+                count = len(lpas)
+                writer.writerow([str(count)])
+
+
+def main():
+    arguments = argparse.ArgumentParser(
+        description="Look up an account by email address.")
+    arguments.add_argument("--environment",
+                        default="demo",
+                        help="The environment to target. Defaults to production")
+
+    arguments.add_argument('--json', dest='output_json', action='store_const',
+                        const=True, default=False,
+                        help='Output json data instead of plaintext to terminal')
+
+    args = arguments.parse_args()
+    work = AccountLookup(args.environment)
+    work.count_by_user()
+
+
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analysis_scripts/count_lpas_per_account.py
+++ b/scripts/analysis_scripts/count_lpas_per_account.py
@@ -1,5 +1,4 @@
 import argparse
-import csv
 import boto3
 import pandas as pd
 
@@ -61,18 +60,15 @@ class AccountLookup:
         indicator = 0
         lpa_actor_maps = self.get_lpa_actor_maps()
 
-        try:
-          for lpa_map in lpa_actor_maps:
+        for lpa_map in lpa_actor_maps:
             list_of_userids.append(lpa_map['UserId']['S'])
             indicator += 1
             if indicator % 1000 == 0:
                 print("Maps processed: ", indicator)
-        except:
-          print("An exception occurred")
 
-        lpa_counts_series = pd.Series(list_of_userids)
-        s = lpa_counts_series.value_counts()
-        print(s.value_counts())
+        actor_users_map_ids_series = pd.Series(list_of_userids)
+        lpas_per_account_series = actor_users_map_ids_series.value_counts()
+        print(lpas_per_account_series.value_counts())
 
 def main():
     arguments = argparse.ArgumentParser(

--- a/scripts/analysis_scripts/count_lpas_per_account.py
+++ b/scripts/analysis_scripts/count_lpas_per_account.py
@@ -1,6 +1,8 @@
 import argparse
 import csv
 import boto3
+import numpy as np
+import pandas as pd
 
 class AccountLookup:
     aws_account_id = ''
@@ -70,6 +72,7 @@ class AccountLookup:
         return lpas
 
     def count_by_user(self):
+        list_of_counts = []
         with open('lpas_per_account.csv', 'w', newline='') as file:
             writer = csv.writer(
                 file, quoting=csv.QUOTE_NONNUMERIC)
@@ -80,7 +83,12 @@ class AccountLookup:
             for user in actor_users:
                 lpas = self.get_lpas_by_user_id(user['Id']['S'])
                 count = len(lpas)
+                print(count)
+                list_of_counts.append(count)
                 writer.writerow([str(count)])
+
+        lpa_counts_series = pd.Series(list_of_counts)
+        print(lpa_counts_series.value_counts())
 
 
 def main():

--- a/scripts/analysis_scripts/count_lpas_per_account.py
+++ b/scripts/analysis_scripts/count_lpas_per_account.py
@@ -1,7 +1,6 @@
 import argparse
 import csv
 import boto3
-import numpy as np
 import pandas as pd
 
 class AccountLookup:
@@ -45,64 +44,46 @@ class AccountLookup:
         session = sts.assume_role(
             RoleArn=role_arn,
             RoleSessionName='getting_service_statistics',
-            DurationSeconds=900
+            DurationSeconds=3600
         )
         self.aws_iam_session = session
 
-    def get_actor_users(self):
+    def get_lpa_actor_maps(self):
         paginator = self.aws_dynamodb_client.get_paginator("scan")
         for page in paginator.paginate(
-                TableName='{}-ActorUsers'.format(self.environment),
-                FilterExpression="attribute_exists(Email)",
+                TableName='{}-UserLpaActorMap'.format(self.environment),
                 ):
             yield from page["Items"]
 
-    def get_lpas_by_user_id(self, user_id):
-        response = self.aws_dynamodb_client.query(
-            IndexName='UserIndex',
-            TableName='{}-UserLpaActorMap'.format(self.environment),
-            KeyConditionExpression='UserId = :user_id',
-            ExpressionAttributeValues={
-                ':user_id': {'S': user_id}
-            }
-        )
-        lpas = {}
-        for lpa in response['Items']:
-            lpas.update({lpa['SiriusUid']['S']:lpa['Added']['S']})
-        return lpas
+    def count_by_maps(self):
+        print("counting lpas per account...")
+        list_of_userids = []
+        indicator = 0
+        lpa_actor_maps = self.get_lpa_actor_maps()
 
-    def count_by_user(self):
-        list_of_counts = []
-        with open('lpas_per_account.csv', 'w', newline='') as file:
-            writer = csv.writer(
-                file, quoting=csv.QUOTE_NONNUMERIC)
-            writer.writerow(["lpas_in_account_{}".format(self.environment)])
+        try:
+          for lpa_map in lpa_actor_maps:
+            list_of_userids.append(lpa_map['UserId']['S'])
+            indicator += 1
+            if indicator % 1000 == 0:
+                print("Maps processed: ", indicator)
+        except:
+          print("An exception occurred")
 
-            actor_users = self.get_actor_users()
-
-            for user in actor_users:
-                lpas = self.get_lpas_by_user_id(user['Id']['S'])
-                count = len(lpas)
-                print(count)
-                list_of_counts.append(count)
-                writer.writerow([str(count)])
-
-        lpa_counts_series = pd.Series(list_of_counts)
-        print(lpa_counts_series.value_counts())
-
+        lpa_counts_series = pd.Series(list_of_userids)
+        s = lpa_counts_series.value_counts()
+        print(s.value_counts())
 
 def main():
     arguments = argparse.ArgumentParser(
         description="Look up an account by email address.")
     arguments.add_argument("--environment",
                         default="demo",
-                        help="The environment to target. Defaults to production")
+                        help="The environment to target. Defaults to demo")
 
     args = arguments.parse_args()
     work = AccountLookup(args.environment)
-    work.count_by_user()
-
-
+    work.count_by_maps()
 
 
 if __name__ == "__main__":

--- a/scripts/analysis_scripts/count_lpas_per_account.py
+++ b/scripts/analysis_scripts/count_lpas_per_account.py
@@ -68,6 +68,7 @@ class AccountLookup:
 
         actor_users_map_ids_series = pd.Series(list_of_userids)
         lpas_per_account_series = actor_users_map_ids_series.value_counts()
+        print("Maps processed: ", indicator)
         print(lpas_per_account_series.value_counts())
 
 def main():


### PR DESCRIPTION
# Purpose
**_As a user researcher,
I want to know how many cases have how many LPAs
Where results are a count of cases grouped by LPA count
so that user behaviour can be better understood_**

Fixes UML-1110

## Approach

Paginate UserLpaActorMap table
List UserIds
Use Pandas to group and count UserId series

## Learning

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#paginators
https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.value_counts.html
https://pandas.pydata.org/docs/user_guide/10min.html

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
