### PR TITLE
Uml 1227 fix session redirection

### DIFF
--- a/service-front/app/features/context/UI/CommonContext.php
+++ b/service-front/app/features/context/UI/CommonContext.php
@@ -438,8 +438,8 @@ class CommonContext implements Context
             new FactoryDefinitionHelper($container->get(SessionMiddlewareFactory::class))
         );
 
-        // wait 1 to ensure we expire
-        sleep(1);
+        // wait 2 seconds to ensure we expire
+        sleep(2);
     }
 
     /**

--- a/service-front/app/src/Actor/src/Handler/ActorSessionCheckHandler.php
+++ b/service-front/app/src/Actor/src/Handler/ActorSessionCheckHandler.php
@@ -13,11 +13,11 @@ use Common\Handler\Traits\User;
 use Common\Handler\UserAware;
 use Common\Service\Session\EncryptedCookiePersistence;
 use Laminas\Diactoros\Response\JsonResponse;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use Mezzio\Authentication\AuthenticationInterface;
 use Mezzio\Helper\UrlHelper;
 use Mezzio\Template\TemplateRendererInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 
 class ActorSessionCheckHandler extends AbstractHandler implements UserAware, SessionAware, LoggerAware
@@ -62,8 +62,7 @@ class ActorSessionCheckHandler extends AbstractHandler implements UserAware, Ses
             [
                 'session_warning' => $showSessionWarning,
                 'time_remaining'  => $timeRemaining
-            ],
-            201
+            ]
         );
     }
 }

--- a/service-front/app/src/Actor/src/Handler/ActorSessionExpiredHandler.php
+++ b/service-front/app/src/Actor/src/Handler/ActorSessionExpiredHandler.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 namespace Actor\Handler;
 
 use Common\Handler\AbstractHandler;
+use Common\Handler\SessionAware;
+use Common\Handler\Traits\Session;
+use Common\Service\Session\EncryptedCookiePersistence;
 use Laminas\Diactoros\Response\HtmlResponse;
+use Mezzio\Session\SessionMiddleware;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -14,14 +18,23 @@ use Psr\Http\Message\ServerRequestInterface;
  * @package Actor\Handler
  * @codeCoverageIgnore
  */
-class ActorSessionExpiredHandler extends AbstractHandler
+class ActorSessionExpiredHandler extends AbstractHandler implements SessionAware
 {
+    use Session;
+
     /**
      * @param ServerRequestInterface $request
      * @return ResponseInterface
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        // If we're viewing this page then ensure our session is always expired.
+        // This effectively makes this page acts to logout the user but ensures that we don't end up in
+        // redirect loops around the session handling code.
+        $this
+            ->getSession($request, SessionMiddleware::SESSION_ATTRIBUTE)
+            ->set(EncryptedCookiePersistence::SESSION_EXPIRED_KEY, true);
+
         return new HtmlResponse($this->renderer->render('actor::actor-session-expired'));
     }
 }

--- a/service-front/app/src/Common/src/ConfigProvider.php
+++ b/service-front/app/src/Common/src/ConfigProvider.php
@@ -35,8 +35,9 @@ class ConfigProvider
         return [
 
             'aliases' => [
-
                 \Psr\Http\Client\ClientInterface::class => \Http\Adapter\Guzzle6\Client::class,
+                Service\Session\Encryption\EncryptInterface::class
+                    => Service\Session\Encryption\KmsEncryptedCookie::class,
                 \Mezzio\Session\SessionPersistenceInterface::class => Service\Session\EncryptedCookiePersistence::class,
 
                 // Custom Guard factory to handle multiple forms per page
@@ -62,7 +63,6 @@ class ConfigProvider
             ],
 
             'factories'  => [
-
                 // Services
                 Service\ApiClient\Client::class => Service\ApiClient\ClientFactory::class,
                 Service\Pdf\PdfService::class => Service\Pdf\PdfServiceFactory::class,

--- a/service-front/app/src/Common/src/ConfigProvider.php
+++ b/service-front/app/src/Common/src/ConfigProvider.php
@@ -72,6 +72,8 @@ class ConfigProvider
                 Service\Email\EmailClient::class => Service\Email\EmailClientFactory::class,
                 Service\User\UserService::class => Service\User\UserServiceFactory::class,
                 Service\Features\FeatureEnabled::class => Service\Features\FeatureEnabledFactory::class,
+                Service\Session\Encryption\KmsEncryptedCookie::class
+                    => Service\Session\Encryption\KmsEncryptedCookieFactory::class,
 
                 \Aws\Sdk::class => Service\Aws\SdkFactory::class,
                 \Aws\Kms\KmsClient::class => Service\Aws\KmsFactory::class,

--- a/service-front/app/src/Common/src/Middleware/Session/SessionExpiredAttributeAllowlistMiddleware.php
+++ b/service-front/app/src/Common/src/Middleware/Session/SessionExpiredAttributeAllowlistMiddleware.php
@@ -52,7 +52,7 @@ class SessionExpiredAttributeAllowlistMiddleware implements MiddlewareInterface
         if ($session !== null && $session->has(EncryptedCookiePersistence::SESSION_EXPIRED_KEY)) {
             $this->stripSession($session);
 
-            // TODO logs incorrect time value as seconds should equal time() - TIME_KEY + Session Length
+            // TODO: UML-1449 logs incorrect time value as seconds should equal time() - TIME_KEY + Session Length
             $this->logger->info(
                 'User session expired approx {seconds} seconds ago',
                 [

--- a/service-front/app/src/Common/src/Service/Security/UserIdentificationService.php
+++ b/service-front/app/src/Common/src/Service/Security/UserIdentificationService.php
@@ -31,7 +31,6 @@ class UserIdentificationService
     public function id(\Psr\Http\Message\ServerRequestInterface $request): string
     {
         $headersToHash = [
-            'accept' => '',
             'accept-encoding' => '',
             'accept-language' => '',
             'user-agent' => '',

--- a/service-front/app/src/Common/src/Service/Session/EncryptedCookiePersistenceFactory.php
+++ b/service-front/app/src/Common/src/Service/Session/EncryptedCookiePersistenceFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Common\Service\Session;
 
-use Common\Service\Session\KeyManager\KeyManagerInterface;
+use Common\Service\Session\Encryption\EncryptInterface;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
 
@@ -14,7 +14,7 @@ use RuntimeException;
  */
 class EncryptedCookiePersistenceFactory
 {
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container): EncryptedCookiePersistence
     {
         $config = $container->get('config');
 
@@ -23,43 +23,43 @@ class EncryptedCookiePersistenceFactory
         }
 
         if (!array_key_exists('cookie_name', $config['session'])) {
-            throw new RuntimeException("Missing session configuration: cookie_name");
+            throw new RuntimeException('Missing session configuration: cookie_name');
         }
 
         if (!array_key_exists('cookie_path', $config['session'])) {
-            throw new RuntimeException("Missing session configuration: cookie_path");
+            throw new RuntimeException('Missing session configuration: cookie_path');
         }
 
         if (!array_key_exists('cache_limiter', $config['session'])) {
-            throw new RuntimeException("Missing session configuration: cache_limiter");
+            throw new RuntimeException('Missing session configuration: cache_limiter');
         }
 
         if (!array_key_exists('expires', $config['session'])) {
-            throw new RuntimeException("Missing session configuration: expires");
+            throw new RuntimeException('Missing session configuration: expires');
         }
 
         if (!array_key_exists('last_modified', $config['session'])) {
-            throw new RuntimeException("Missing session configuration: last_modified");
+            throw new RuntimeException('Missing session configuration: last_modified');
         }
 
         if (!array_key_exists('cookie_ttl', $config['session'])) {
-            throw new RuntimeException("Missing session configuration: cookie_ttl");
+            throw new RuntimeException('Missing session configuration: cookie_ttl');
         }
 
         if (!array_key_exists('cookie_domain', $config['session'])) {
-            throw new RuntimeException("Missing session configuration: cookie_domain");
+            throw new RuntimeException('Missing session configuration: cookie_domain');
         }
 
         if (!array_key_exists('cookie_secure', $config['session'])) {
-            throw new RuntimeException("Missing session configuration: cookie_secure");
+            throw new RuntimeException('Missing session configuration: cookie_secure');
         }
 
         if (!array_key_exists('cookie_http_only', $config['session'])) {
-            throw new RuntimeException("Missing session configuration: cookie_http_only");
+            throw new RuntimeException('Missing session configuration: cookie_http_only');
         }
 
         return new EncryptedCookiePersistence(
-            $container->get(KeyManagerInterface::class),
+            $container->get(EncryptInterface::class),
             $config['session']['cookie_name'],
             $config['session']['cookie_path'],
             $config['session']['cache_limiter'],

--- a/service-front/app/src/Common/src/Service/Session/Encryption/EncryptInterface.php
+++ b/service-front/app/src/Common/src/Service/Session/Encryption/EncryptInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Service\Session\Encryption;
+
+interface EncryptInterface
+{
+    /**
+     * Encrypts the session payload
+     *
+     * @param array $data Key/value components of the session
+     * @return string An encrypted string ready to be used as a raw cookie value
+     */
+    public function encodeCookieValue(array $data): string;
+
+    /**
+     * Decrypt the session value.
+     *
+     * @param string $data The raw cookie value
+     * @return array Key/value components of the session
+     */
+    public function decodeCookieValue(string $data): array;
+}

--- a/service-front/app/src/Common/src/Service/Session/Encryption/KmsEncryptedCookie.php
+++ b/service-front/app/src/Common/src/Service/Session/Encryption/KmsEncryptedCookie.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Service\Session\Encryption;
+
+use Common\Service\Session\KeyManager\KeyManagerInterface;
+use Common\Service\Session\KeyManager\KeyNotFoundException;
+use Laminas\Crypt\BlockCipher;
+use ParagonIE\ConstantTime\Base64UrlSafe;
+
+class KmsEncryptedCookie implements EncryptInterface
+{
+    /** @var KeyManagerInterface */
+    private KeyManagerInterface $keyManager;
+
+    public function __construct(KeyManagerInterface $keyManager)
+    {
+        $this->keyManager = $keyManager;
+    }
+
+    /**
+     * Returns the configured Block Cipher to be used within this class.
+     *
+     * @return BlockCipher
+     */
+    private function getBlockCipher(): BlockCipher
+    {
+        return BlockCipher::factory('openssl', [
+            'algo' => 'aes',
+            'mode' => 'gcm'
+        ])->setBinaryOutput(true);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function encodeCookieValue(array $data): string
+    {
+        if (empty($data)) {
+            return '';
+        }
+
+        $plaintext = json_encode($data);
+
+        $key = $this->keyManager->getEncryptionKey();
+
+        $ciphertext = $this->getBlockCipher()
+            ->setKey($key->getKeyMaterial())
+            ->encrypt($plaintext);
+
+        return $key->getId() . '.' . Base64UrlSafe::encode($ciphertext);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function decodeCookieValue(string $data): array
+    {
+        if (empty($data)) {
+            return [];
+        }
+
+        // Separate out the key ID and the data
+        [$keyId, $payload] = explode('.', $data, 2);
+
+        try {
+            $key = $this->keyManager->getDecryptionKey($keyId);
+
+            $ciphertext = Base64UrlSafe::decode($payload);
+
+            $plaintext = $this->getBlockCipher()
+                ->setKey($key->getKeyMaterial())
+                ->decrypt($ciphertext);
+
+            return json_decode($plaintext, true);
+        } catch (KeyNotFoundException $e) {
+            # TODO: add logging
+        }
+
+        // Something went wrong. Restart the session.
+        return [];
+    }
+}

--- a/service-front/app/src/Common/src/Service/Session/Encryption/KmsEncryptedCookie.php
+++ b/service-front/app/src/Common/src/Service/Session/Encryption/KmsEncryptedCookie.php
@@ -11,25 +11,13 @@ use ParagonIE\ConstantTime\Base64UrlSafe;
 
 class KmsEncryptedCookie implements EncryptInterface
 {
-    /** @var KeyManagerInterface */
     private KeyManagerInterface $keyManager;
+    private BlockCipher $blockCipher;
 
-    public function __construct(KeyManagerInterface $keyManager)
+    public function __construct(KeyManagerInterface $keyManager, BlockCipher $blockCipher)
     {
         $this->keyManager = $keyManager;
-    }
-
-    /**
-     * Returns the configured Block Cipher to be used within this class.
-     *
-     * @return BlockCipher
-     */
-    private function getBlockCipher(): BlockCipher
-    {
-        return BlockCipher::factory('openssl', [
-            'algo' => 'aes',
-            'mode' => 'gcm'
-        ])->setBinaryOutput(true);
+        $this->blockCipher = $blockCipher;
     }
 
     /**
@@ -45,7 +33,7 @@ class KmsEncryptedCookie implements EncryptInterface
 
         $key = $this->keyManager->getEncryptionKey();
 
-        $ciphertext = $this->getBlockCipher()
+        $ciphertext = $this->blockCipher
             ->setKey($key->getKeyMaterial())
             ->encrypt($plaintext);
 
@@ -69,7 +57,7 @@ class KmsEncryptedCookie implements EncryptInterface
 
             $ciphertext = Base64UrlSafe::decode($payload);
 
-            $plaintext = $this->getBlockCipher()
+            $plaintext = $this->blockCipher
                 ->setKey($key->getKeyMaterial())
                 ->decrypt($ciphertext);
 

--- a/service-front/app/src/Common/src/Service/Session/Encryption/KmsEncryptedCookieFactory.php
+++ b/service-front/app/src/Common/src/Service/Session/Encryption/KmsEncryptedCookieFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Service\Session\Encryption;
+
+use Common\Service\Session\KeyManager\KeyManagerInterface;
+use Laminas\Crypt\BlockCipher;
+use Psr\Container\ContainerInterface;
+
+class KmsEncryptedCookieFactory
+{
+    public function __invoke(ContainerInterface $container)
+    {
+        return new KmsEncryptedCookie(
+            $container->get(KeyManagerInterface::class),
+            BlockCipher::factory(
+                'openssl',
+                [
+                    'algo' => 'aes',
+                    'mode' => 'gcm'
+                ]
+            )->setBinaryOutput(true)
+        );
+    }
+}

--- a/service-front/app/src/Common/src/Service/Session/Encryption/UnencryptedCookie.php
+++ b/service-front/app/src/Common/src/Service/Session/Encryption/UnencryptedCookie.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Service\Session\Encryption;
+
+use ParagonIE\ConstantTime\Base64UrlSafe;
+
+class UnencryptedCookie implements EncryptInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function encodeCookieValue(array $data): string
+    {
+        if (empty($data)) {
+            return '';
+        }
+
+        $plaintext = json_encode($data);
+
+        return Base64UrlSafe::encode($plaintext);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function decodeCookieValue(string $data): array
+    {
+        if (empty($data)) {
+            return [];
+        }
+
+        $plaintext = Base64UrlSafe::decode($data);
+
+        return json_decode($plaintext, true);
+    }
+}

--- a/service-front/app/src/Common/src/Service/Session/Encryption/UnencryptedCookie.php
+++ b/service-front/app/src/Common/src/Service/Session/Encryption/UnencryptedCookie.php
@@ -5,9 +5,17 @@ declare(strict_types=1);
 namespace Common\Service\Session\Encryption;
 
 use ParagonIE\ConstantTime\Base64UrlSafe;
+use Psr\Log\LoggerInterface;
 
 class UnencryptedCookie implements EncryptInterface
 {
+    public function __construct(LoggerInterface $logger)
+    {
+        $logger->critical(
+            '----- WARNING ----- Service is currently operating with unencrypted cookies ----- WARNING -----'
+        );
+    }
+
     /**
      * @inheritDoc
      */

--- a/service-front/app/src/Viewer/src/Handler/ViewerSessionCheckHandler.php
+++ b/service-front/app/src/Viewer/src/Handler/ViewerSessionCheckHandler.php
@@ -13,11 +13,11 @@ use Common\Handler\Traits\User;
 use Common\Handler\UserAware;
 use Common\Service\Session\EncryptedCookiePersistence;
 use Laminas\Diactoros\Response\JsonResponse;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use Mezzio\Authentication\AuthenticationInterface;
 use Mezzio\Helper\UrlHelper;
 use Mezzio\Template\TemplateRendererInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -68,8 +68,7 @@ class ViewerSessionCheckHandler extends AbstractHandler implements UserAware, Se
             [
                 'session_warning' => $showSessionWarning,
                 'time_remaining'  => $timeRemaining
-            ],
-            201
+            ]
         );
     }
 }

--- a/service-front/app/src/Viewer/src/Handler/ViewerSessionExpiredHandler.php
+++ b/service-front/app/src/Viewer/src/Handler/ViewerSessionExpiredHandler.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 namespace Viewer\Handler;
 
 use Common\Handler\AbstractHandler;
+use Common\Handler\SessionAware;
+use Common\Handler\Traits\Session;
+use Common\Service\Session\EncryptedCookiePersistence;
 use Laminas\Diactoros\Response\HtmlResponse;
+use Mezzio\Session\SessionMiddleware;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -14,14 +18,23 @@ use Psr\Http\Message\ServerRequestInterface;
  * @package Viewer\Handler
  * @codeCoverageIgnore
  */
-class ViewerSessionExpiredHandler extends AbstractHandler
+class ViewerSessionExpiredHandler extends AbstractHandler implements SessionAware
 {
+    use Session;
+
     /**
      * @param ServerRequestInterface $request
      * @return ResponseInterface
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        // If we're viewing this page then ensure our session is always expired.
+        // This effectively makes this page acts to logout the user but ensures that we don't end up in
+        // redirect loops around the session handling code.
+        $this
+            ->getSession($request, SessionMiddleware::SESSION_ATTRIBUTE)
+            ->set(EncryptedCookiePersistence::SESSION_EXPIRED_KEY, true);
+
         return new HtmlResponse($this->renderer->render('viewer::viewer-session-expired'));
     }
 }

--- a/service-front/app/test/CommonTest/Middleware/Session/SessionExpiredAttributeAllowlistMiddlewareTest.php
+++ b/service-front/app/test/CommonTest/Middleware/Session/SessionExpiredAttributeAllowlistMiddlewareTest.php
@@ -45,9 +45,9 @@ class SessionExpiredAttributeAllowlistMiddlewareTest extends TestCase
     {
         $sessionProphecy = $this->prophesize(Session::class);
         $sessionProphecy
-            ->get(EncryptedCookiePersistence::SESSION_EXPIRED_KEY)
+            ->has(EncryptedCookiePersistence::SESSION_EXPIRED_KEY)
             ->shouldBeCalled()
-            ->willReturn(null);
+            ->willReturn(false);
 
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy
@@ -81,7 +81,7 @@ class SessionExpiredAttributeAllowlistMiddlewareTest extends TestCase
 
         $sessionProphecy = $this->prophesize(Session::class);
         $sessionProphecy
-            ->get(EncryptedCookiePersistence::SESSION_EXPIRED_KEY)
+            ->has(EncryptedCookiePersistence::SESSION_EXPIRED_KEY)
             ->shouldBeCalled()
             ->willReturn(true);
         $sessionProphecy
@@ -94,7 +94,7 @@ class SessionExpiredAttributeAllowlistMiddlewareTest extends TestCase
             ->willReturn($sessionData);
         $sessionProphecy
             ->unset(Argument::type('string'))
-            ->shouldBeCalledTimes(3); // SESSION_TIME_KEY is allowed
+            ->shouldBeCalledTimes(4); // SESSION_TIME_KEY is allowed
 
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy

--- a/service-front/app/test/CommonTest/Middleware/Session/SessionExpiredRedirectMiddlewareTest.php
+++ b/service-front/app/test/CommonTest/Middleware/Session/SessionExpiredRedirectMiddlewareTest.php
@@ -57,7 +57,7 @@ class SessionExpiredRedirectMiddlewareTest extends TestCase
             ->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE)
             ->shouldBeCalled()
             ->willReturn($sessionProphecy->reveal());
-        
+
         $sessionProphecy
             ->has(EncryptedCookiePersistence::SESSION_EXPIRED_KEY)
             ->shouldBeCalled()
@@ -99,72 +99,12 @@ class SessionExpiredRedirectMiddlewareTest extends TestCase
             ->willReturn($sessionProphecy->reveal());
 
         $sessionProphecy
-            ->get(EncryptedCookiePersistence::SESSION_TIME_KEY)
-            ->shouldBeCalled()
-            ->willReturn($sessionData[EncryptedCookiePersistence::SESSION_TIME_KEY]);
-
-        $sessionProphecy
             ->has(EncryptedCookiePersistence::SESSION_EXPIRED_KEY)
             ->shouldBeCalled()
             ->willReturn(true);
-
-        $sessionProphecy
-            ->unset(EncryptedCookiePersistence::SESSION_EXPIRED_KEY)
-            ->shouldBeCalled();
 
         $helperProphecy
             ->generate('session-expired')
-            ->willReturn($uri);
-
-        $request = new SessionExpiredRedirectMiddleware(
-            $helperProphecy->reveal()
-        );
-
-        $redirect = $request->process($requestProphecy->reveal(), $delegateProphecy->reveal());
-
-        $this->assertInstanceOf(RedirectResponse::class, $redirect);
-        $this->assertEquals($uri, $redirect->getHeader('location')[0]);
-    }
-
-    /** @test */
-    public function it_correctly_redirects_to_home_page_when_session_expires(): void
-    {
-        $sessionData = [
-            'string' => 'one',
-            'bool' => true,
-            'DateTime' => new DateTime(),
-            EncryptedCookiePersistence::SESSION_TIME_KEY => time() - 24*60*60, // session expired 1 day before current time ago
-            EncryptedCookiePersistence::SESSION_EXPIRED_KEY => true
-        ];
-
-        $uri = 'https://localhost:9002/home';
-
-        $sessionProphecy = $this->prophesize(Session::class);
-        $helperProphecy = $this->prophesize(UrlHelper::class);
-        $delegateProphecy = $this->prophesize(RequestHandlerInterface::class);
-        $requestProphecy = $this->prophesize(ServerRequestInterface::class);
-
-        $requestProphecy
-            ->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE)
-            ->shouldBeCalled()
-            ->willReturn($sessionProphecy->reveal());
-
-        $sessionProphecy
-            ->get(EncryptedCookiePersistence::SESSION_TIME_KEY)
-            ->shouldBeCalled()
-            ->willReturn($sessionData[EncryptedCookiePersistence::SESSION_TIME_KEY]);
-
-        $sessionProphecy
-            ->has(EncryptedCookiePersistence::SESSION_EXPIRED_KEY)
-            ->shouldBeCalled()
-            ->willReturn(true);
-
-        $sessionProphecy
-            ->unset(EncryptedCookiePersistence::SESSION_EXPIRED_KEY)
-            ->shouldBeCalled();
-
-        $helperProphecy
-            ->generate('home')
             ->willReturn($uri);
 
         $request = new SessionExpiredRedirectMiddleware(

--- a/service-front/app/test/CommonTest/Service/Security/UserIdentificationServiceTest.php
+++ b/service-front/app/test/CommonTest/Service/Security/UserIdentificationServiceTest.php
@@ -28,7 +28,7 @@ class UserIdentificationServiceTest extends TestCase
 
         $id = $service->id($requestProphecy->reveal());
 
-        $this->assertEquals('224fb6e8b478de4a0d10bbeb92a07ffe095df3f9e1b1b50197d88f4c48192025', $id);
+        $this->assertEquals('d3b534a6cf6e6e4f5bb7ba3442ef239f3d632a11d0f1a50a42bf0f271ffce331', $id);
     }
 
     /**
@@ -57,11 +57,11 @@ class UserIdentificationServiceTest extends TestCase
     public function headerCombinations(): array
     {
         return [
-            [ # the realistic bare minimum unique thing to track
+            'the realistic bare minimum unique thing to track' => [
                 ['x-forwarded-for'],
-                'c6f41b7d23a875f6b1ba03cea0207c8340563e2df9fc43cb1b331717b999d099'
+                '597967406e7009e87bfa34db426f795fc9248dd12af70290385fded6e46443a9'
             ],
-            [ # the complete set
+            'the complete set' => [
                 [
                     'accept',
                     'accept-encoding',
@@ -69,24 +69,24 @@ class UserIdentificationServiceTest extends TestCase
                     'user-agent',
                     'x-forwarded-for'
                 ],
-                '3afdc96b35e60a6c3d98fc06ca8647ad5a106c862503cb64f982d260928c7285'
+                '92e7dd7306dbdd412c8d6b626b7c808f0c3fc692c9297aedf047ae918b11be58'
             ],
-            [ # not a complete set
+            'not a complete set' => [
                 [
                     'accept',
                     'user-agent',
                     'x-forwarded-for'
                 ],
-                'f2978681b9f61976090c88df4dfce164513606996cf4d5c4203121a14eec13f9'
+                '833dccbeb6f8d0fea36924bafa0e3eaa8c4d565a36ed8742321e39bc5981ab61'
             ],
-            [ # only use specified headers
+            'only use specified headers' => [
                 [
                     'accept',
                     'user-agent',
                     'not-a-real-header',
                     'x-forwarded-for'
                 ],
-                'f2978681b9f61976090c88df4dfce164513606996cf4d5c4203121a14eec13f9'
+                '833dccbeb6f8d0fea36924bafa0e3eaa8c4d565a36ed8742321e39bc5981ab61'
             ],
         ];
     }

--- a/service-front/app/test/CommonTest/Service/Session/EncryptedCookiePersistenceFactoryTest.php
+++ b/service-front/app/test/CommonTest/Service/Session/EncryptedCookiePersistenceFactoryTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommonTest\Service\Session;
+
+use Common\Service\Session\EncryptedCookiePersistence;
+use Common\Service\Session\EncryptedCookiePersistenceFactory;
+use Common\Service\Session\Encryption\EncryptInterface;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+
+/**
+ * Class EncryptedCookiePersistenceFactoryTest
+ *
+ * @package CommonTest\Service\Session
+ * @coversDefaultClass \Common\Service\Session\EncryptedCookiePersistenceFactory
+ */
+class EncryptedCookiePersistenceFactoryTest extends TestCase
+{
+    /**
+     * @test
+     * @covers ::__invoke
+     */
+    public function it_will_create_an_instance_when_given_correct_configuration(): void
+    {
+        $config = [
+            'session' => [
+                'cookie_name' => 'session',
+                'cookie_path' => '/',
+                'cache_limiter' => 'nocache',
+                'expires' => 1200,
+                'last_modified' => null,
+                'cookie_ttl' => 86400,
+                'cookie_domain' => null,
+                'cookie_secure' => true,
+                'cookie_http_only' => true,
+            ]
+        ];
+
+        $containerProphecy = $this->prophesize(ContainerInterface::class);
+        $containerProphecy->get('config')->willReturn($config);
+        $containerProphecy
+            ->get(EncryptInterface::class)
+            ->willReturn(
+                $this->prophesize(EncryptInterface::class)->reveal()
+            );
+
+        $sut = new EncryptedCookiePersistenceFactory();
+        $ecp = $sut($containerProphecy->reveal());
+
+        $this->assertInstanceOf(EncryptedCookiePersistence::class, $ecp);
+    }
+
+    /**
+     * @test
+     * @covers ::__invoke
+     */
+    public function it_will_throw_runtime_exceptions_if_session_configuration_is_missing(): void
+    {
+        $containerProphecy = $this->prophesize(ContainerInterface::class);
+        $containerProphecy->get('config')->willReturn([]);
+        $containerProphecy
+            ->get(EncryptInterface::class)
+            ->willReturn(
+                $this->prophesize(EncryptInterface::class)->reveal()
+            );
+
+        $sut = new EncryptedCookiePersistenceFactory();
+
+        $this->expectException(RuntimeException::class);
+        $ecp = $sut($containerProphecy->reveal());
+    }
+
+    /**
+     * @test
+     * @covers ::__invoke
+     */
+    public function it_will_throw_runtime_exceptions_if_necessary_configuration_is_missing(): void
+    {
+        $config = [
+            'session' => [
+                'cookie_name' => 'session',
+                'cookie_path' => '/',
+                'cache_limiter' => 'nocache',
+                'expires' => 1200,
+                'last_modified' => null,
+                'cookie_ttl' => 86400,
+                'cookie_domain' => null,
+                'cookie_secure' => true,
+                'cookie_http_only' => true,
+            ]
+        ];
+
+        $containerProphecy = $this->prophesize(ContainerInterface::class);
+
+        // this code removes one configuration value and attempts the operation, it should result
+        // in an exception, which we count as a good thing. It then loops around and repeats for
+        // all the configured values.
+        for ($i = 0; $i < count($config['session']); $i++) {
+            $value = array_keys($config['session'])[$i];
+            $badConfig = $config;
+            unset($badConfig['session'][$value]);
+
+            $containerProphecy->get('config')->willReturn($badConfig);
+            $containerProphecy
+                ->get(EncryptInterface::class)
+                ->willReturn(
+                    $this->prophesize(EncryptInterface::class)->reveal()
+                );
+
+            $sut = new EncryptedCookiePersistenceFactory();
+
+            try {
+                $ecp = $sut($containerProphecy->reveal());
+            } catch (\RuntimeException $re) {
+                $this->addToAssertionCount(1);
+                continue;
+            }
+
+            throw new ExpectationFailedException("Failed to throw exception when $value was removed");
+        }
+    }
+}

--- a/service-front/app/test/CommonTest/Service/Session/EncryptedCookiePersistenceTest.php
+++ b/service-front/app/test/CommonTest/Service/Session/EncryptedCookiePersistenceTest.php
@@ -72,10 +72,6 @@ class EncryptedCookiePersistenceTest extends TestCase
         $this->testKey = new Key('test-id', new EncryptionKey(new HiddenString(random_bytes(32))));
 
         $this->encrypterProphecy = $this->prophesize(EncryptInterface::class);
-
-        // Setup the key manager mock
-        //$this->keyManagerProphecy->getEncryptionKey()->willReturn($this->testKey);
-        //$this->keyManagerProphecy->getDecryptionKey($this->testKey->getId())->willReturn($this->testKey);
     }
 
     /** @test */

--- a/service-front/app/test/CommonTest/Service/Session/Encryption/KmsEncryptedCookieTest.php
+++ b/service-front/app/test/CommonTest/Service/Session/Encryption/KmsEncryptedCookieTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommonTest\Service\Session\Encryption;
+
+use Common\Service\Session\Encryption\KmsEncryptedCookie;
+use Common\Service\Session\KeyManager\Key;
+use Common\Service\Session\KeyManager\KeyManagerInterface;
+use Common\Service\Session\KeyManager\KeyNotFoundException;
+use Laminas\Crypt\BlockCipher;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+
+class KmsEncryptedCookieTest extends TestCase
+{
+    /** @test */
+    public function it_can_be_instantiated(): void
+    {
+        $keyManagerProphecy = $this->prophesize(KeyManagerInterface::class);
+        $blockCipherProphecy = $this->prophesize(BlockCipher::class);
+
+        $sut = new KmsEncryptedCookie($keyManagerProphecy->reveal(), $blockCipherProphecy->reveal());
+
+        $this->assertInstanceOf(KmsEncryptedCookie::class, $sut);
+    }
+
+    /** @test */
+    public function it_encodes_a_session_array(): void
+    {
+        $data = [
+            'session' => 'data'
+        ];
+
+        $keyProphecy = $this->prophesize(Key::class);
+        $keyProphecy->getKeyMaterial()->willReturn('encryptionKey');
+        $keyProphecy->getId()->willReturn('1');
+
+        $keyManagerProphecy = $this->prophesize(KeyManagerInterface::class);
+        $keyManagerProphecy->getEncryptionKey()->willReturn($keyProphecy->reveal());
+
+        $blockCipherProphecy = $this->prophesize(BlockCipher::class);
+        $blockCipherProphecy->setKey('encryptionKey')->willReturn($blockCipherProphecy->reveal());
+        $blockCipherProphecy->encrypt(Argument::type('string'))->willReturn('encryptedString');
+
+        $sut = new KmsEncryptedCookie($keyManagerProphecy->reveal(), $blockCipherProphecy->reveal());
+
+        $encoded = $sut->encodeCookieValue($data);
+
+        $this->assertEquals('1.ZW5jcnlwdGVkU3RyaW5n', $encoded);
+    }
+
+    /** @test */
+    public function it_encodes_an_empty_array_of_data_to_a_blank_string(): void
+    {
+        $data = [];
+
+        $keyManagerProphecy = $this->prophesize(KeyManagerInterface::class);
+        $blockCipherProphecy = $this->prophesize(BlockCipher::class);
+
+        $sut = new KmsEncryptedCookie($keyManagerProphecy->reveal(), $blockCipherProphecy->reveal());
+
+        $cookieValue = $sut->encodeCookieValue($data);
+
+        $this->assertEquals('', $cookieValue);
+    }
+
+    /** @test */
+    public function it_decodes_a_string_into_session_data(): void
+    {
+        $data = [
+            'session' => 'data'
+        ];
+
+        $keyProphecy = $this->prophesize(Key::class);
+        $keyProphecy->getKeyMaterial()->willReturn('encryptionKey');
+
+        $keyManagerProphecy = $this->prophesize(KeyManagerInterface::class);
+        $keyManagerProphecy->getDecryptionKey('1')->willReturn($keyProphecy->reveal());
+
+        $blockCipherProphecy = $this->prophesize(BlockCipher::class);
+        $blockCipherProphecy->setKey('encryptionKey')->willReturn($blockCipherProphecy->reveal());
+        $blockCipherProphecy->decrypt(Argument::type('string'))->willReturn('{"session":"data"}');
+
+        $sut = new KmsEncryptedCookie($keyManagerProphecy->reveal(), $blockCipherProphecy->reveal());
+
+        $decoded = $sut->decodeCookieValue('1.ZW5jcnlwdGVkU3RyaW5n');
+
+        $this->assertEquals($data, $decoded);
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_key_id_not_matched_and_returns_new_session(): void
+    {
+        $keyProphecy = $this->prophesize(Key::class);
+
+        $keyManagerProphecy = $this->prophesize(KeyManagerInterface::class);
+        $keyManagerProphecy->getDecryptionKey('1')->willThrow(new KeyNotFoundException());
+
+        $blockCipherProphecy = $this->prophesize(BlockCipher::class);
+
+        $sut = new KmsEncryptedCookie($keyManagerProphecy->reveal(), $blockCipherProphecy->reveal());
+
+        $decoded = $sut->decodeCookieValue('1.ZW5jcnlwdGVkU3RyaW5n');
+
+        $this->assertEquals([], $decoded);
+    }
+
+    /** @test */
+    public function it_decodes_an_empty_string_into_an_empty_array(): void
+    {
+        $data = [];
+
+        $keyManagerProphecy = $this->prophesize(KeyManagerInterface::class);
+        $blockCipherProphecy = $this->prophesize(BlockCipher::class);
+
+        $sut = new KmsEncryptedCookie($keyManagerProphecy->reveal(), $blockCipherProphecy->reveal());
+
+        $sessionData = $sut->decodeCookieValue('');
+
+        $this->assertEquals($data, $sessionData);
+    }
+}

--- a/service-front/app/test/CommonTest/Service/Session/Encryption/UnencryptedCookieTest.php
+++ b/service-front/app/test/CommonTest/Service/Session/Encryption/UnencryptedCookieTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommonTest\Service\Session\Encryption;
+
+use Common\Service\Session\Encryption\UnencryptedCookie;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
+
+class UnencryptedCookieTest extends TestCase
+{
+    /** @test */
+    public function usage_logs_critical_error(): void
+    {
+        $loggerProphecy = $this->prophesize(LoggerInterface::class);
+        $loggerProphecy
+            ->critical(Argument::type('string'))
+            ->shouldBeCalled();
+
+        $sut = new UnencryptedCookie($loggerProphecy->reveal());
+    }
+
+    /** @test */
+    public function it_base64_encodes_an_array_of_data(): void
+    {
+        $data = [
+            'session' => 'data'
+        ];
+
+        $loggerProphecy = $this->prophesize(LoggerInterface::class);
+
+        $sut = new UnencryptedCookie($loggerProphecy->reveal());
+
+        $cookieValue = $sut->encodeCookieValue($data);
+
+        $this->assertEquals('eyJzZXNzaW9uIjoiZGF0YSJ9', $cookieValue);
+    }
+
+    /** @test */
+    public function it_base64_encodes_an_empty_array_of_data_to_a_blank_string(): void
+    {
+        $data = [];
+
+        $loggerProphecy = $this->prophesize(LoggerInterface::class);
+
+        $sut = new UnencryptedCookie($loggerProphecy->reveal());
+
+        $cookieValue = $sut->encodeCookieValue($data);
+
+        $this->assertEquals('', $cookieValue);
+    }
+
+    /** @test */
+    public function it_decodes_base64_data_into_an_array(): void
+    {
+        $data = [
+            'session' => 'data'
+        ];
+
+        $loggerProphecy = $this->prophesize(LoggerInterface::class);
+
+        $sut = new UnencryptedCookie($loggerProphecy->reveal());
+
+        $sessionData = $sut->decodeCookieValue('eyJzZXNzaW9uIjoiZGF0YSJ9');
+
+        $this->assertEquals($data, $sessionData);
+    }
+
+    /** @test */
+    public function it_base64_decodes_an_empty_string_into_a_blank_array(): void
+    {
+        $data = [];
+
+        $loggerProphecy = $this->prophesize(LoggerInterface::class);
+
+        $sut = new UnencryptedCookie($loggerProphecy->reveal());
+
+        $sessionData = $sut->decodeCookieValue('');
+
+        $this->assertEquals($data, $sessionData);
+    }
+}


### PR DESCRIPTION
# Purpose

Attempts to fix our session handling by reworking the logic flow around our various middlewares.

Fixes UML-1227

## Approach

Because we use a redirect to bring the user to a session-expired page we need to ensure that upon re-entry to the site (from the redirect) the users session is still marked as expired even though it wouldn't technically be.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [ ] ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* [x] I have added tests to prove my work
* [ ] ~I have added welsh translation tags and updated translation files~
* [ ] ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* [x] The product team have tested these changes
