### PR TITLE
UML-1347 - Dependabot Update PRs run Monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,6 @@ updates:
       day: "wednesday"
       time: "10:00"
     versioning-strategy: lockfile-only
-    open-pull-requests-limit: 3
   # Enable version updates for service-pdf npm
   - package-ecosystem: "npm"
     directory: "/service-pdf/app"
@@ -20,7 +19,6 @@ updates:
       day: "wednesday"
       time: "10:00"
     versioning-strategy: lockfile-only
-    open-pull-requests-limit: 3
 
   # Enable version updates for service-front composer
   - package-ecosystem: "composer"
@@ -31,7 +29,6 @@ updates:
       day: "wednesday"
       time: "10:00"
     versioning-strategy: lockfile-only
-    open-pull-requests-limit: 3
 
   # Enable version updates for service-api composer
   - package-ecosystem: "composer"
@@ -42,7 +39,6 @@ updates:
       day: "wednesday"
       time: "10:00"
     versioning-strategy: lockfile-only
-    open-pull-requests-limit: 3
 
     # Enable version updates for smoke tests composer
   - package-ecosystem: "composer"
@@ -53,4 +49,3 @@ updates:
       day: "wednesday"
       time: "10:00"
     versioning-strategy: lockfile-only
-    open-pull-requests-limit: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,18 +5,16 @@ updates:
   - package-ecosystem: "npm"
     directory: "/service-front/web"
     schedule:
-      # Check for updates weekly on wednesday at 10am UTC
-      interval: "weekly"
-      day: "wednesday"
+      # Check for updates on the first of each month at 10am UTC
+      interval: "monthly"
       time: "10:00"
     versioning-strategy: lockfile-only
   # Enable version updates for service-pdf npm
   - package-ecosystem: "npm"
     directory: "/service-pdf/app"
     schedule:
-      # Check for updates weekly on wednesday at 10am UTC
-      interval: "weekly"
-      day: "wednesday"
+      # Check for updates on the first of each month at 10am UTC
+      interval: "monthly"
       time: "10:00"
     versioning-strategy: lockfile-only
 
@@ -24,9 +22,8 @@ updates:
   - package-ecosystem: "composer"
     directory: "/service-front/app"
     schedule:
-      # Check for updates weekly on wednesday at 10am UTC
-      interval: "weekly"
-      day: "wednesday"
+      # Check for updates on the first of each month at 10am UTC
+      interval: "monthly"
       time: "10:00"
     versioning-strategy: lockfile-only
 
@@ -34,9 +31,8 @@ updates:
   - package-ecosystem: "composer"
     directory: "/service-api/app"
     schedule:
-      # Check for updates weekly on wednesday at 10am UTC
-      interval: "weekly"
-      day: "wednesday"
+      # Check for updates on the first of each month at 10am UTC
+      interval: "monthly"
       time: "10:00"
     versioning-strategy: lockfile-only
 
@@ -44,8 +40,7 @@ updates:
   - package-ecosystem: "composer"
     directory: "/tests/smoke"
     schedule:
-      # Check for updates weekly on wednesday at 10am UTC
-      interval: "weekly"
-      day: "wednesday"
+      # Check for updates on the first of each month at 10am UTC
+      interval: "monthly"
       time: "10:00"
     versioning-strategy: lockfile-only


### PR DESCRIPTION
# Purpose

**_As a developer
I want to run Dependabot package update checks less frequently
So they are not so disruptive or costly_**

Fixes UML-1347

## Approach

Check for updates on the first of each month
Remove PR limits

## Learning

https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
