### PR TITLE
UML-1401 - Validate Codecov before using it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1006,6 +1006,9 @@ orbs:
           - attach_workspace:
               at: build
           - run:
+              name: Validate Codecov
+              command: bash ~/project/scripts/pipeline/codecov_uploader/validate_codecov_uploader.sh
+          - run:
               name: Upload to Codecov
               command: bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN || echo 'Codecov upload failed'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1010,7 +1010,7 @@ orbs:
               command: bash ~/project/scripts/pipeline/codecov_uploader/validate_codecov_uploader.sh
           - run:
               name: Upload to Codecov
-              command: bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN || echo 'Codecov upload failed'
+              command: bash ~/project/codecov -t $CODECOV_TOKEN || echo 'Codecov upload failed'
 
       #----------------------------------------------------
       # Terraform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1006,7 +1006,7 @@ orbs:
           - attach_workspace:
               at: build
           - run:
-              name: Validate Codecov
+              name: Get and Validate Codecov App
               command: bash ~/project/scripts/pipeline/codecov_uploader/validate_codecov_uploader.sh
           - run:
               name: Upload to Codecov

--- a/scripts/pipeline/codecov_uploader/validate_codecov_uploader.sh
+++ b/scripts/pipeline/codecov_uploader/validate_codecov_uploader.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+curl -s https://codecov.io/bash > codecov;
+VERSION=$(grep 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
+echo $VERSION
+
+for i in 1 256 512
+do
+  shasum -a $i -c <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") ||
+  shasum -a $i -c <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM")
+done

--- a/scripts/pipeline/codecov_uploader/validate_codecov_uploader.sh
+++ b/scripts/pipeline/codecov_uploader/validate_codecov_uploader.sh
@@ -6,6 +6,6 @@ echo $VERSION
 
 for i in 1 256 512
 do
-  shasum -a $i -c <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") ||
+  shasum -a $i -c --ignore-missing <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") ||
   shasum -a $i -c <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM")
 done

--- a/scripts/pipeline/codecov_uploader/validate_codecov_uploader.sh
+++ b/scripts/pipeline/codecov_uploader/validate_codecov_uploader.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 
-curl -s https://codecov.io/env > env;
+# curl -s https://codecov.io/env > env;
 curl -s https://codecov.io/bash > codecov;
 VERSION=$(grep 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
 echo $VERSION

--- a/scripts/pipeline/codecov_uploader/validate_codecov_uploader.sh
+++ b/scripts/pipeline/codecov_uploader/validate_codecov_uploader.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 
+
+curl -s https://codecov.io/env > env;
 curl -s https://codecov.io/bash > codecov;
 VERSION=$(grep 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
 echo $VERSION
 
 for i in 1 256 512
 do
-  shasum -a $i -c --ignore-missing <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") ||
-  shasum -a $i -c <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM")
+  curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM" > codecov-hashes
+  shasum -a $i -c --ignore-missing codecov-hashes ||
+  shasum -a $i -c codecov-hashes
 done

--- a/scripts/pipeline/codecov_uploader/validate_codecov_uploader.sh
+++ b/scripts/pipeline/codecov_uploader/validate_codecov_uploader.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 
-# curl -s https://codecov.io/env > env;
 curl -s https://codecov.io/bash > codecov;
 VERSION=$(grep 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
 echo $VERSION


### PR DESCRIPTION
# Purpose

Reduce the chance of a compromised Codecov script being run, check the scripts SHA checksum against the github release SHA

Fixes UML-1401

## Approach

- Create a bash script that can be run before the codecov upload
- Fail upload job before executing the script if validation fails

## Learning

https://docs.codecov.io/docs/about-the-codecov-bash-uploader#validating-the-bash-script

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
