### PR TITLE
UML-1418 Show unknown for I&P for old donor signatures

### DIFF
--- a/service-front/app/src/Actor/templates/actor/view-lpa-summary.html.twig
+++ b/service-front/app/src/Actor/templates/actor/view-lpa-summary.html.twig
@@ -165,7 +165,9 @@
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">{% trans %}Preferences{% endtrans %}</dt>
                         <dd class="govuk-summary-list__value">
-                            {% if lpa.applicationHasGuidance %}
+                            {% if is_donor_signature_date_too_old(lpa) %}
+                                {% trans %}Unknown{% endtrans %}
+                            {% elseif lpa.applicationHasGuidance %}
                                 {% trans %}Yes, the donor made preferences on their <abbr title="lasting power of attorney">LPA</abbr>.<br>To view these, ask to see the paper <abbr title="lasting power of attorney">LPA</abbr>{% endtrans %}
                             {% else %}
                                 {% trans %}No{% endtrans %}
@@ -176,7 +178,9 @@
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">{% trans %}Instructions{% endtrans %}</dt>
                         <dd class="govuk-summary-list__value">
-                            {% if lpa.applicationHasRestrictions %}
+                            {% if is_donor_signature_date_too_old(lpa) %}
+                                {% trans %}Unknown{% endtrans %}
+                            {% elseif lpa.applicationHasRestrictions %}
                                 {% trans %}Yes, the donor set instructions on their <abbr title="lasting power of attorney">LPA</abbr>.<br>To view these, ask to see the paper <abbr title="lasting power of attorney">LPA</abbr>{% endtrans %}
                             {% else %}
                                 {% trans %}No{% endtrans %}

--- a/service-front/app/src/Common/src/View/Twig/LpaExtension.php
+++ b/service-front/app/src/Common/src/View/Twig/LpaExtension.php
@@ -36,7 +36,8 @@ class LpaExtension extends AbstractExtension
             new TwigFunction('check_if_code_is_cancelled', [$this, 'isCodeCancelled']),
             new TwigFunction('is_lpa_cancelled', [$this, 'isLpaCancelled']),
             new TwigFunction('donor_name_with_dob_removed', [$this, 'donorNameWithDobRemoved']),
-            ];
+            new TwigFunction('is_donor_signature_date_too_old', [$this, 'isDonorSignatureDateOld']),
+        ];
     }
 
     /**
@@ -199,7 +200,7 @@ class LpaExtension extends AbstractExtension
         $viewerCodeParts = str_split($viewerCode, 4);
         array_unshift($viewerCodeParts, 'V');
 
-        return implode(" - ", $viewerCodeParts);
+        return implode(' - ', $viewerCodeParts);
     }
 
     /**
@@ -210,6 +211,16 @@ class LpaExtension extends AbstractExtension
     {
         $status = $lpa->getStatus();
         return ($status === 'Cancelled') || ($status === 'Revoked');
+    }
+
+    /**
+     * @param Lpa $lpa
+     *
+     * @return bool
+     */
+    public function isDonorSignatureDateOld(Lpa $lpa): bool
+    {
+        return $lpa->getLpaDonorSignatureDate() < new DateTime('2016-01-01');
     }
 
     /**

--- a/service-front/app/src/Common/templates/partials/full-lpa-display.html.twig
+++ b/service-front/app/src/Common/templates/partials/full-lpa-display.html.twig
@@ -188,7 +188,9 @@
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">{% trans %}Preferences{% endtrans %}</dt>
                         <dd class="govuk-summary-list__value">
-                            {% if lpa.applicationHasGuidance %}
+                            {% if is_donor_signature_date_too_old(lpa) %}
+                                {% trans %}Unknown{% endtrans %}
+                            {% elseif lpa.applicationHasGuidance %}
                                 {% trans %}Yes, the donor made preferences on their LPA.<br>To view these, ask to see the paper LPA{% endtrans %}
                             {% else %}
                                 {% trans %}No{% endtrans %}
@@ -199,7 +201,9 @@
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">{% trans %}Instructions{% endtrans %}</dt>
                         <dd class="govuk-summary-list__value">
-                            {% if lpa.applicationHasRestrictions %}
+                            {% if is_donor_signature_date_too_old(lpa) %}
+                                {% trans %}Unknown{% endtrans %}
+                            {% elseif lpa.applicationHasRestrictions %}
                                 {% trans %}Yes, the donor set instructions on their LPA.<br>To view these, ask to see the paper LPA{% endtrans %}
                             {% else %}
                                 {% trans %}No{% endtrans %}

--- a/service-front/app/test/CommonTest/View/Twig/LpaExtensionTest.php
+++ b/service-front/app/test/CommonTest/View/Twig/LpaExtensionTest.php
@@ -24,16 +24,17 @@ class LpaExtensionTest extends TestCase
         $this->assertTrue(is_array($functions));
 
         $expectedFunctions = [
-            'actor_address'             => 'actorAddress',
-            'actor_name'                => 'actorName',
-            'lpa_date'                  => 'lpaDate',
-            'code_date'                 => 'formatDate',
-            'days_remaining_to_expiry'  => 'daysRemaining',
-            'check_if_code_has_expired' => 'hasCodeExpired',
-            'add_hyphen_to_viewer_code' => 'formatViewerCode',
-            'check_if_code_is_cancelled' => 'isCodeCancelled',
-            'is_lpa_cancelled'           => 'isLpaCancelled',
-            'donor_name_with_dob_removed' => 'donorNameWithDobRemoved'
+            'actor_address'                   => 'actorAddress',
+            'actor_name'                      => 'actorName',
+            'lpa_date'                        => 'lpaDate',
+            'code_date'                       => 'formatDate',
+            'days_remaining_to_expiry'        => 'daysRemaining',
+            'check_if_code_has_expired'       => 'hasCodeExpired',
+            'add_hyphen_to_viewer_code'       => 'formatViewerCode',
+            'check_if_code_is_cancelled'      => 'isCodeCancelled',
+            'is_lpa_cancelled'                => 'isLpaCancelled',
+            'donor_name_with_dob_removed'     => 'donorNameWithDobRemoved',
+            'is_donor_signature_date_too_old' => 'isDonorSignatureDateOld',
         ];
         $this->assertEquals(count($expectedFunctions), count($functions));
 
@@ -464,5 +465,22 @@ class LpaExtensionTest extends TestCase
         $donorName = $extension->donorNameWithDobRemoved($donorNameWithDob);
 
         $this->assertEquals('Harry Potter', $donorName);
+    }
+
+    /** @test */
+    public function it_checks_if_an_lpa_donor_signature_is_old_for_i_and_p(): void
+    {
+        $extension = new LpaExtension();
+        $lpa = new Lpa();
+
+        $lpa->setLpaDonorSignatureDate(new DateTime('2015-01-01'));
+        $status = $extension->isDonorSignatureDateOld($lpa);
+
+        $this->assertEquals(true, $status);
+
+        $lpa->setLpaDonorSignatureDate(new DateTime('2016-01-02'));
+        $status = $extension->isDonorSignatureDateOld($lpa);
+
+        $this->assertEquals(false, $status);
     }
 }


### PR DESCRIPTION
# Purpose

If the donor signed the LPA before 2016-01-01 then show "unknown" for Instructions and preferences even if the record contains the correct flags.

Fixes UML-1418

## Approach

Add Twig function and code to display record appropriately

## Checklist

* [x] I have performed a self-review of my own code
* [ ] ~I have added relevant logging with appropriate levels to my code~
* [ ] ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* [x] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* [ ] The product team have tested these changes
