### PR TITLE
UML-1463 - Pin aws provider to 3.38.0 to avoid new linting error

### DIFF
--- a/terraform/environment/credentials.tf
+++ b/terraform/environment/credentials.tf
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "= 3.38.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
# Purpose

New aws provider version (3.40.0) introduces an error in validation of static response size limits.

Fixes UML-1463

## Approach

Pin AWS provider in environment to 3.38.0

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
