### PR TITLE
Back-button-translation-switch-css-fix

### DIFF
--- a/service-front/web/src/scss/_translation-switch.scss
+++ b/service-front/web/src/scss/_translation-switch.scss
@@ -1,5 +1,6 @@
 .trans-switch {
   overflow: auto;
+  display: inline;
   &__list {
     display: inline;
   }


### PR DESCRIPTION
# Purpose

The recently fixed flash message styling PR has unintentionally changed how the back button and welsh switch are styled together. The back button is now being displayed on the level below the welsh switch, this PR fixes that so that they are inline again

## Approach

Added display: inline to the welsh switch css element

## Checklist

* [x] I have performed a self-review of my own code
