### PR TITLE
Update node versions for M1 compatibility

### DIFF
--- a/service-front/web/Dockerfile
+++ b/service-front/web/Dockerfile
@@ -1,7 +1,9 @@
-FROM node:14-alpine
+FROM node:15-alpine
 
 RUN apk add --no-cache \
       chromium \
+      python \
+      make g++ \
       nss \
       freetype \
       freetype-dev \

--- a/service-front/web/package.json
+++ b/service-front/web/package.json
@@ -37,7 +37,7 @@
     "jest": "^26.6.3",
     "jest-junit": "^12.0.0",
     "mini-css-extract-plugin": "^1.6.0",
-    "node-sass": "^5.0.0",
+    "node-sass": "^6.0.0",
     "optimize-css-assets-webpack-plugin": "^5.0.6",
     "prettier": "^2.3.0",
     "sass": "^1.33.0",


### PR DESCRIPTION
building binaries do not work with sass 5.0 so updated to 6.0.

node 14 updated to 15

python, make and g++ all needed to be installed to make the sass binary

# Purpose

Currently there are no node-sass binaries for arm macs. To get around this docker will build the binaries itself but the tools used to build the binaries need to be added to the container.


## Checklist

* [ x] I have performed a self-review of my own code
