### PR TITLE
UML-1499 - pin composer layers to 2.0.14

### DIFF
--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -1,10 +1,10 @@
-FROM composer AS composer
+FROM composer:2.0.14 AS composer
 
 COPY service-front/app/composer.json service-front/app/composer.lock /app/
 
 RUN composer install --prefer-dist --no-dev --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs
 
-FROM composer AS composer-dev
+FROM composer:2.0.14 AS composer-dev
 
 COPY service-front/app/composer.json service-front/app/composer.lock /app/
 


### PR DESCRIPTION
# Purpose

Pipielines fail to run unit tests for service-front app image

```
Fatal error: Uncaught Error: Class 'PHPUnit\TextUI\Command' not found in /app/vendor/phpunit/phpunit/phpunit:61
Stack trace:
#0 {main}
  thrown in /app/vendor/phpunit/phpunit/phpunit on line 61
PHP Fatal error:  Uncaught Error: Class 'PHPUnit\TextUI\Command' not found in /app/vendor/phpunit/phpunit/phpunit:61
Stack trace:
#0 {main}
  thrown in /app/vendor/phpunit/phpunit/phpunit on line 61

Exited with code exit status 255
```

Fixes UML-1499

## Approach

Pin composer layers to a previous working tag

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
