### PR TITLE
UML-1366 Allows user to enter en dash and em dash for activation key field

### DIFF
--- a/service-front/app/features/actor-add-an-lpa.feature
+++ b/service-front/app/features/actor-add-an-lpa.feature
@@ -45,6 +45,11 @@ Feature: Add an LPA
       | c - xyup - hwqr - echv | XYUPHWQRECHV |
       | c-CYUP HWQR ECHV       | CYUPHWQRECHV |
       | C-xyup hwqr echv       | XYUPHWQRECHV |
+      | c–cyup–HWQR–echv       | CYUPHWQRECHV |
+      | c—cyup—HWQR—echv       | CYUPHWQRECHV |
+      | c-cyup–HWQR—echv       | CYUPHWQRECHV |
+      | cyup–HWQR–echv         | CYUPHWQRECHV |
+      | cyup—HWQR—echv         | CYUPHWQRECHV |
 
   @integration @ui
   Scenario: The user cannot add an LPA to their account as it does not exist

--- a/service-front/app/src/Common/src/Filter/ActorViewerCodeFilter.php
+++ b/service-front/app/src/Common/src/Filter/ActorViewerCodeFilter.php
@@ -15,7 +15,7 @@ class ActorViewerCodeFilter extends AbstractFilter
     public function filter($code): string
     {
         // Remove C- or V- from start of the code if present
-        $code = preg_replace('/^((v|c)(-| ))?/i', '', strtoupper($code));
+        $code = preg_replace('/^((v|c)(–|—|-| ))?/i', '', strtoupper($code));
 
         return (new StripSpacesAndHyphens())->filter($code);
     }

--- a/service-front/app/src/Common/src/Filter/StripSpacesAndHyphens.php
+++ b/service-front/app/src/Common/src/Filter/StripSpacesAndHyphens.php
@@ -16,6 +16,10 @@ class StripSpacesAndHyphens extends AbstractFilter
     {
         // strip out whitespace
         $value = str_replace(' ', '', $value);
+        // strip out en dash
+        $value = str_replace('–', '', $value);
+        // strip out em dash
+        $value = str_replace('—', '', $value);
         // strip out hyphens
         return str_replace('-', '', $value);
     }


### PR DESCRIPTION
# Purpose

https://opgtransform.atlassian.net/browse/UML-1366

Fixes UML-1366

## Approach

Allows user to enter en dash and em dash for activation key field, which then gets stripped.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
