### PR TITLE
Add feature flags and enable in local/PR environments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,8 +118,11 @@ services:
       GOOGLE_ANALYTICS_ID: "UA-170469426-1"
       KMS_SESSION_CMK_ALIAS: "alias/viewer-sessions-cmk-alias"
 
+      # Feature flags
       USE_OLDER_LPA_JOURNEY: "true"
       DELETE_LPA_FEATURE: "true"
+      ALLOW_OLDER_LPAS: "true"
+      ALLOW_MERRIS_LPAS: "false"
 
       # Local only
       API_SERVICE_URL: http://api-web
@@ -190,6 +193,10 @@ services:
 
       SIRIUS_API_ENDPOINT: "http://api_gateway:4343"
       LPA_CODES_API_ENDPOINT: "http://codes-gateway:4343"
+
+      # Feature flags
+      ALLOW_OLDER_LPAS: "true"
+      ALLOW_MERRIS_LPAS: "false"
 
       # Local only
       AWS_ACCESS_KEY_ID: "-"

--- a/service-api/app/config/autoload/features.global.php
+++ b/service-api/app/config/autoload/features.global.php
@@ -5,5 +5,7 @@ declare(strict_types=1);
 return [
     'feature_flags' => [
         'use_legacy_codes_service' => getenv('USE_LEGACY_CODES_SERVICE') ?: 'false',
+        'allow_older_lpas' => filter_var(getenv('ALLOW_OLDER_LPAS'), FILTER_VALIDATE_BOOLEAN) ?: false,
+        'allow_merris_lpas' => filter_var(getenv('ALLOW_MERRIS_LPAS'), FILTER_VALIDATE_BOOLEAN) ?: false,
     ]
 ];

--- a/service-front/app/config/autoload/features.global.php
+++ b/service-front/app/config/autoload/features.global.php
@@ -6,5 +6,7 @@ return [
     'feature_flags' => [
         'use_older_lpa_journey' => filter_var(getenv('USE_OLDER_LPA_JOURNEY'), FILTER_VALIDATE_BOOLEAN) ?: false,
         'delete_lpa_feature' => filter_var(getenv('DELETE_LPA_FEATURE'), FILTER_VALIDATE_BOOLEAN) ?: false,
+        'allow_older_lpas' => filter_var(getenv('ALLOW_OLDER_LPAS'), FILTER_VALIDATE_BOOLEAN) ?: false,
+        'allow_merris_lpas' => filter_var(getenv('ALLOW_MERRIS_LPAS'), FILTER_VALIDATE_BOOLEAN) ?: false,
     ]
 ];

--- a/terraform/environment/actor_ecs.tf
+++ b/terraform/environment/actor_ecs.tf
@@ -241,6 +241,14 @@ locals {
         {
           name  = "DELETE_LPA_FEATURE",
           value = tostring(local.account.delete_lpa_feature)
+        },
+        {
+          name  = "ALLOW_OLDER_LPAS",
+          value = tostring(local.account.allow_older_lpas)
+        },
+        {
+          name  = "ALLOW_MERRIS_LPAS",
+          value = tostring(local.account.allow_merris_lpas)
         }
       ]
   })

--- a/terraform/environment/api_ecs.tf
+++ b/terraform/environment/api_ecs.tf
@@ -292,7 +292,16 @@ locals {
         {
           name  = "LOGGING_LEVEL",
           value = tostring(local.account.logging_level)
-      }]
+        },
+        {
+          name  = "ALLOW_OLDER_LPAS",
+          value = tostring(local.account.allow_older_lpas)
+        },
+        {
+          name  = "ALLOW_MERRIS_LPAS",
+          value = tostring(local.account.allow_merris_lpas)
+        }
+      ]
   })
 }
 

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -44,7 +44,9 @@
       "sirius_account_id": "288342028542",
       "use_legacy_codes_service": false,
       "use_older_lpa_journey": true,
-      "delete_lpa_feature": true
+      "delete_lpa_feature": true,
+      "allow_older_lpas": true,
+      "allow_merris_lpas": false
     },
     "preproduction": {
       "account_id": "888228022356",
@@ -85,7 +87,9 @@
       "sirius_account_id": "288342028542",
       "use_legacy_codes_service": false,
       "use_older_lpa_journey": true,
-      "delete_lpa_feature": true
+      "delete_lpa_feature": true,
+      "allow_older_lpas": false,
+      "allow_merris_lpas": false
     },
     "production": {
       "account_id": "690083044361",
@@ -126,7 +130,9 @@
       "sirius_account_id": "649098267436",
       "use_legacy_codes_service": false,
       "use_older_lpa_journey": true,
-      "delete_lpa_feature": false
+      "delete_lpa_feature": false,
+      "allow_older_lpas": false,
+      "allow_merris_lpas": false
     }
   }
 }


### PR DESCRIPTION
# Purpose

Implements feature flag configuration values in the Actor and API services.

Fixes UML-1567 UML-1572

## Approach

Addition of environment variables in the deployed environment (terraform) and local docker-compose environment. These are pulled through and made available as configuration in the app containers. To be used as we currently use feature flags.

Two flags;
 * ALLOW_OLDER_LPAS - will let us implement the older older lpa flow.
 * ALLOW_MERRIS_LPAS - when we get to it we can start work on the bottom track using this.

Older lpas is *only* enabled on the local and PR envrionments. Merris is not enabled *anywhere*

## Checklist

* [x] I have performed a self-review of my own code
* [ ] ~I have added relevant logging with appropriate levels to my code~
* [ ] ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* [ ] ~I have added tests to prove my work~
* [ ] ~I have added welsh translation tags and updated translation files~
* [ ] ~ have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* [ ] ~The product team have tested these changes~
