### PR TITLE
UML-1595 - pin localstack version to 0.11.4

### DIFF
--- a/docker-compose.dependencies.yml
+++ b/docker-compose.dependencies.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
 
   localstack:
-    image: localstack/localstack
+    image: localstack/localstack:0.11.4
     ports:
       - 4569:4566
       - 8000:4566


### PR DESCRIPTION
# Purpose

Unable to connect to or seed locally running DynamoDB tables

Fixes UML-1595

## Approach

Pin localstack/localstack version to 0.11.4

## Learning

Related to https://github.com/localstack/localstack/issues/3069

## Checklist

* [x] I have performed a self-review of my own code
* [x] The product team have tested these changes
