### PR TITLE
UML-1603 - ResourceConflictException for aws_lambda_permission

### DIFF
--- a/terraform/environment/ship_to_metrics.tf
+++ b/terraform/environment/ship_to_metrics.tf
@@ -31,7 +31,7 @@ resource "aws_cloudwatch_log_subscription_filter" "events" {
 }
 resource "aws_lambda_permission" "allow_cloudwatch" {
   count         = local.account.ship_metrics_queue_enabled == true ? 1 : 0
-  statement_id  = "AllowExecutionFromCloudWatch"
+  statement_id  = "${local.environment}-AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
   function_name = data.aws_lambda_function.clsf_to_sqs[0].function_name
   #function_name = module.clsf_to_sqs[0].lambda_function.function_name


### PR DESCRIPTION
# Purpose

Dev environment builds failed due to resource conflict exception

Fixes UML-1603

## Approach

make aws_lambda_permission statement_ids unique by including the environment name

## Checklist

* [x] I have performed a self-review of my own code
