### PR TITLE
UML-1604: Add missing requirements.txt for lambda function

### DIFF
--- a/terraform/account/lambda/docker-compose-ship-to-opg-metrics.yml
+++ b/terraform/account/lambda/docker-compose-ship-to-opg-metrics.yml
@@ -5,7 +5,7 @@ services:
     image: ship-to-opg-metrics
     build:
       context: ./ship-to-opg-metrics
-      dockerfile: Test.Dockerfile
+      dockerfile: test.Dockerfile
     ports:
       - 9000:8080
     volumes:

--- a/terraform/account/lambda/ship-to-opg-metrics/Dockerfile
+++ b/terraform/account/lambda/ship-to-opg-metrics/Dockerfile
@@ -1,5 +1,9 @@
 FROM public.ecr.aws/lambda/python:3.8
 
 WORKDIR /var/task
+
+COPY terraform/account/lambda/ship-to-opg-metrics/src/requirements.txt ./
 COPY terraform/account/lambda/ship-to-opg-metrics/src/main.py ./
+RUN pip install -r ./requirements.txt
+
 CMD ["main.handler"]

--- a/terraform/account/lambda/ship-to-opg-metrics/src/requirements.txt
+++ b/terraform/account/lambda/ship-to-opg-metrics/src/requirements.txt
@@ -1,0 +1,2 @@
+requests
+boto3


### PR DESCRIPTION
# Purpose

Adds missing requirements.txt for lambda function which causes request to error as it is no longer available as default in AWS Lambda images

Fixes UML-1604

## Approach

Add a requirements.txt file with the dependency

## Learning

Use requirements

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have added tests to prove my work
