### PR TITLE
UML-1615-LPA-already-added-null-name-bug

### DIFF
--- a/service-front/app/src/Common/src/Service/Lpa/Response/Parse/ParseActivationKeyExistsResponse.php
+++ b/service-front/app/src/Common/src/Service/Lpa/Response/Parse/ParseActivationKeyExistsResponse.php
@@ -26,9 +26,9 @@ class ParseActivationKeyExistsResponse
     {
         if (
             !isset($data['donor']['uId']) ||
-            !isset($data['donor']['firstname']) ||
-            !isset($data['donor']['middlenames']) ||
-            !isset($data['donor']['surname']) ||
+            !array_key_exists('firstname', $data['donor']) ||
+            !array_key_exists('middlenames', $data['donor']) ||
+            !array_key_exists('surname', $data['donor']) ||
             !isset($data['caseSubtype'])
         ) {
             throw new InvalidArgumentException(

--- a/service-front/app/src/Common/src/Service/Lpa/Response/Parse/ParseLpaAlreadyAddedResponse.php
+++ b/service-front/app/src/Common/src/Service/Lpa/Response/Parse/ParseLpaAlreadyAddedResponse.php
@@ -26,9 +26,9 @@ class ParseLpaAlreadyAddedResponse
     {
         if (
             !isset($data['donor']['uId']) ||
-            !isset($data['donor']['firstname']) ||
-            !isset($data['donor']['middlenames']) ||
-            !isset($data['donor']['surname']) ||
+            !array_key_exists('firstname', $data['donor']) ||
+            !array_key_exists('middlenames', $data['donor']) ||
+            !array_key_exists('surname', $data['donor']) ||
             !isset($data['caseSubtype']) ||
             !isset($data['lpaActorToken'])
         ) {

--- a/service-front/app/test/CommonTest/Service/Lpa/Response/Parse/ParseActivationKeyExistsResponseTest.php
+++ b/service-front/app/test/CommonTest/Service/Lpa/Response/Parse/ParseActivationKeyExistsResponseTest.php
@@ -78,6 +78,72 @@ class ParseActivationKeyExistsResponseTest extends TestCase
     }
 
     /** @test */
+    public function it_will_fail_if_donor_firstname_array_key_doesnt_exist()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The data array passed to Common\Service\Lpa\Response\Parse\ParseActivationKeyExistsResponse::__invoke ' .
+            'does not contain the required fields'
+        );
+
+        $data = [
+            'donor'         => [
+                'uId'           => '12345',
+                'middlenames'   => 'Donor',
+                'surname'       => 'Person',
+            ],
+            'caseSubtype' => null
+        ];
+
+        $sut = new ParseActivationKeyExistsResponse($this->lpaFactory->reveal());
+        ($sut)($data);
+    }
+
+    /** @test */
+    public function it_will_fail_if_donor_middlenames_array_key_doesnt_exist()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The data array passed to Common\Service\Lpa\Response\Parse\ParseActivationKeyExistsResponse::__invoke ' .
+            'does not contain the required fields'
+        );
+
+        $data = [
+            'donor'         => [
+                'uId'           => '12345',
+                'firstname'     => 'Donor',
+                'surname'       => 'Person',
+            ],
+            'caseSubtype' => null
+        ];
+
+        $sut = new ParseActivationKeyExistsResponse($this->lpaFactory->reveal());
+        ($sut)($data);
+    }
+
+    /** @test */
+    public function it_will_fail_if_donor_surname_array_key_doesnt_exist()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The data array passed to Common\Service\Lpa\Response\Parse\ParseActivationKeyExistsResponse::__invoke ' .
+            'does not contain the required fields'
+        );
+
+        $data = [
+            'donor'         => [
+                'uId'           => '12345',
+                'firstname'     => 'Donor',
+                'middlenames'   => 'Person',
+            ],
+            'caseSubtype' => null
+        ];
+
+        $sut = new ParseActivationKeyExistsResponse($this->lpaFactory->reveal());
+        ($sut)($data);
+    }
+
+    /** @test */
     public function it_will_fail_if_lpa_type_is_not_set()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/service-front/app/test/CommonTest/Service/Lpa/Response/Parse/ParseLpaAlreadyAddedResponseTest.php
+++ b/service-front/app/test/CommonTest/Service/Lpa/Response/Parse/ParseLpaAlreadyAddedResponseTest.php
@@ -39,22 +39,121 @@ class ParseLpaAlreadyAddedResponseTest extends TestCase
         $this->lpaFactory = $this->prophesize(LpaFactory::class);
     }
 
-    public function it_creates_a_already_added_dto_from_array_data()
+    /** @test */
+    public function it_creates_an_already_added_dto_from_array_data()
     {
+        $this->lpaFactory
+            ->createCaseActorFromData($this->response['donor'])
+            ->willReturn($this->donor);
+
         $sut = new ParseLpaAlreadyAddedResponse($this->lpaFactory->reveal());
         $result = ($sut)($this->response);
 
         $this->assertInstanceOf(LpaAlreadyAddedResponse::class, $result);
         $this->assertEquals($this->donor, $result->getDonor());
-        $this->assertEquals('pfa', $result->getCaseSubtype());
+        $this->assertEquals('hw', $result->getCaseSubtype());
         $this->assertEquals('abc-321', $result->getLpaActorToken());
+    }
+
+    /** @test */
+    public function it_creates_an_already_added_dto_from_array_data_with_null_name_fields()
+    {
+        $this->response['donor']['firstname'] = null;
+        $this->response['donor']['middlenames'] = null;
+        $this->response['donor']['surname'] = null;
+
+        $donor = new CaseActor();
+        $donor->setUId('12345');
+
+        $this->lpaFactory
+            ->createCaseActorFromData($this->response['donor'])
+            ->willReturn($donor);
+
+        $sut = new ParseLpaAlreadyAddedResponse($this->lpaFactory->reveal());
+        $result = ($sut)($this->response);
+
+        $this->assertInstanceOf(LpaAlreadyAddedResponse::class, $result);
+        $this->assertNull($result->getDonor()->getFirstname());
+        $this->assertNull($result->getDonor()->getMiddlenames());
+        $this->assertNull($result->getDonor()->getSurname());
+        $this->assertEquals('hw', $result->getCaseSubtype());
+        $this->assertEquals('abc-321', $result->getLpaActorToken());
+    }
+
+    /** @test */
+    public function it_will_fail_if_donor_firstname_array_key_doesnt_exist()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The data array passed to Common\Service\Lpa\Response\Parse\ParseLpaAlreadyAddedResponse::__invoke ' .
+            'does not contain the required fields'
+        );
+
+        $data = [
+            'donor'         => [
+                'uId'           => '12345',
+                'middlenames'   => 'Donor',
+                'surname'       => 'Person',
+            ],
+            'caseSubtype' => 'hw',
+            'lpaActorToken' => 'abc-321'
+        ];
+
+        $sut = new ParseLpaAlreadyAddedResponse($this->lpaFactory->reveal());
+        ($sut)($data);
+    }
+
+    /** @test */
+    public function it_will_fail_if_donor_middlenames_array_key_doesnt_exist()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The data array passed to Common\Service\Lpa\Response\Parse\ParseLpaAlreadyAddedResponse::__invoke ' .
+            'does not contain the required fields'
+        );
+
+        $data = [
+            'donor'         => [
+                'uId'           => '12345',
+                'firstname'     => 'Donor',
+                'surname'       => 'Person',
+            ],
+            'caseSubtype' => 'hw',
+            'lpaActorToken' => 'abc-321'
+        ];
+
+        $sut = new ParseLpaAlreadyAddedResponse($this->lpaFactory->reveal());
+        ($sut)($data);
+    }
+
+    /** @test */
+    public function it_will_fail_if_donor_surname_array_key_doesnt_exist()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The data array passed to Common\Service\Lpa\Response\Parse\ParseLpaAlreadyAddedResponse::__invoke ' .
+            'does not contain the required fields'
+        );
+
+        $data = [
+            'donor'         => [
+                'uId'           => '12345',
+                'firstname'     => 'Donor',
+                'middlenames'   => 'Person',
+            ],
+            'caseSubtype' => 'hw',
+            'lpaActorToken' => 'abc-321'
+        ];
+
+        $sut = new ParseLpaAlreadyAddedResponse($this->lpaFactory->reveal());
+        ($sut)($data);
     }
 
     /**
      * @dataProvider alreadyAddedDataProvider
      * @test
      */
-    public function it_will_fail_if_data_attributes_are_not_set(array $data)
+    public function it_will_fail_if_donor_uId_or_lpa_type_or_token_is_not_set(array $data)
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
@@ -81,18 +180,6 @@ class ParseLpaAlreadyAddedResponseTest extends TestCase
                     'donor'         => [
                         'uId'           => null,
                         'firstname'     => 'Example',
-                        'middlenames'   => 'Donor',
-                        'surname'       => 'Person',
-                    ],
-                    'caseSubtype' => 'hw',
-                    'lpaActorToken' => 'abc-321'
-                ]
-            ],
-            [
-                [
-                    'donor'         => [
-                        'uId'           => '12345',
-                        'firstname'     => null,
                         'middlenames'   => 'Donor',
                         'surname'       => 'Person',
                     ],


### PR DESCRIPTION
# Purpose

Fixes a bug for the LPA already added feature and when a user is requesting an activation key when they already have one, whereby if any of the donor's name fields are null, breaks the workflow

Fixes UML-1615

## Approach

Updated the ParseLpaAlreadyAddedResponse.php and ParseActivationKeyExistsResponse.php files to remove the php function`isset` check on the donor name fields and replaces them with an `array_key_exists` check instead to ignore the value of the field

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes
