### PR TITLE
UML-1620 - Bug - Duplicate loadbalancer security group error

### DIFF
--- a/terraform/environment/.envrc
+++ b/terraform/environment/.envrc
@@ -1,5 +1,5 @@
-export TF_VAR_default_role=operator
-export TF_VAR_management_role=operator
+export TF_VAR_default_role=breakglass
+export TF_VAR_management_role=breakglass
 export TF_CLI_ARGS_init="-backend-config=role_arn=arn:aws:iam::311462405659:role/operator -upgrade=true -reconfigure"
 # export TF_WORKSPACE=
 export TF_VAR_pagerduty_token=$(aws-vault exec ual-dev -- aws secretsmanager get-secret-value --secret-id pagerduty_api_key | jq -r .'SecretString')

--- a/terraform/environment/.envrc
+++ b/terraform/environment/.envrc
@@ -1,5 +1,5 @@
-export TF_VAR_default_role=breakglass
-export TF_VAR_management_role=breakglass
+export TF_VAR_default_role=operator
+export TF_VAR_management_role=operator
 export TF_CLI_ARGS_init="-backend-config=role_arn=arn:aws:iam::311462405659:role/operator -upgrade=true -reconfigure"
 # export TF_WORKSPACE=
 export TF_VAR_pagerduty_token=$(aws-vault exec ual-dev -- aws secretsmanager get-secret-value --secret-id pagerduty_api_key | jq -r .'SecretString')

--- a/terraform/environment/actor_load_balancer.tf
+++ b/terraform/environment/actor_load_balancer.tf
@@ -196,9 +196,6 @@ resource "aws_security_group_rule" "actor_loadbalancer_ingress_http" {
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:AWS006 - open ingress for load balancers
   security_group_id = aws_security_group.actor_loadbalancer.id
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 resource "aws_security_group_rule" "actor_loadbalancer_ingress" {
@@ -220,9 +217,6 @@ resource "aws_security_group_rule" "actor_loadbalancer_ingress_production" {
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:AWS006 - open ingress for load balancers
   security_group_id = aws_security_group.actor_loadbalancer.id
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 resource "aws_security_group_rule" "actor_loadbalancer_egress" {
@@ -233,9 +227,6 @@ resource "aws_security_group_rule" "actor_loadbalancer_egress" {
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:AWS007 - open egress for load balancers
   security_group_id = aws_security_group.actor_loadbalancer.id
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 resource "aws_security_group" "actor_loadbalancer_route53" {
@@ -253,7 +244,4 @@ resource "aws_security_group_rule" "actor_loadbalancer_ingress_route53_healthche
   to_port           = "443"
   cidr_blocks       = data.aws_ip_ranges.route53_healthchecks.cidr_blocks
   security_group_id = aws_security_group.actor_loadbalancer_route53.id
-  lifecycle {
-    create_before_destroy = true
-  }
 }

--- a/terraform/environment/actor_load_balancer.tf
+++ b/terraform/environment/actor_load_balancer.tf
@@ -209,9 +209,6 @@ resource "aws_security_group_rule" "actor_loadbalancer_ingress" {
   protocol          = "tcp"
   cidr_blocks       = module.whitelist.moj_sites
   security_group_id = aws_security_group.actor_loadbalancer.id
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 resource "aws_security_group_rule" "actor_loadbalancer_ingress_production" {

--- a/terraform/environment/shared_data_sources.tf
+++ b/terraform/environment/shared_data_sources.tf
@@ -88,7 +88,7 @@ data "aws_ecr_repository" "use_an_lpa_admin_app" {
 }
 
 module "whitelist" {
-  source = "git@github.com:ministryofjustice/terraform-aws-moj-ip-whitelist.git"
+  source = "git@github.com:ministryofjustice/terraform-aws-moj-ip-whitelist.git?ref=v1.4.0"
 }
 
 data "aws_secretsmanager_secret" "notify_api_key" {

--- a/terraform/environment/viewer_load_balancer.tf
+++ b/terraform/environment/viewer_load_balancer.tf
@@ -213,9 +213,6 @@ resource "aws_security_group_rule" "viewer_loadbalancer_ingress" {
   protocol          = "tcp"
   cidr_blocks       = module.whitelist.moj_sites
   security_group_id = aws_security_group.viewer_loadbalancer.id
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 resource "aws_security_group_rule" "viewer_loadbalancer_ingress_production" {

--- a/terraform/environment/viewer_load_balancer.tf
+++ b/terraform/environment/viewer_load_balancer.tf
@@ -199,10 +199,6 @@ resource "aws_security_group_rule" "viewer_loadbalancer_ingress_http" {
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:AWS006 - open ingress for load balancers
   security_group_id = aws_security_group.viewer_loadbalancer.id
-  lifecycle {
-    create_before_destroy = true
-  }
-
 }
 
 resource "aws_security_group_rule" "viewer_loadbalancer_ingress" {
@@ -224,10 +220,6 @@ resource "aws_security_group_rule" "viewer_loadbalancer_ingress_production" {
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:AWS006 - open ingress for load balancers
   security_group_id = aws_security_group.viewer_loadbalancer.id
-  lifecycle {
-    create_before_destroy = true
-  }
-
 }
 
 resource "aws_security_group_rule" "viewer_loadbalancer_egress" {
@@ -259,8 +251,4 @@ resource "aws_security_group_rule" "viewer_loadbalancer_ingress_route53_healthch
   to_port           = "443"
   cidr_blocks       = data.aws_ip_ranges.route53_healthchecks.cidr_blocks
   security_group_id = aws_security_group.viewer_loadbalancer_route53.id
-  lifecycle {
-    create_before_destroy = true
-  }
-
 }


### PR DESCRIPTION
# Purpose

Remove lifecycles on loadbalancer security group rules to prevent duplicate rule errors on apply.

Fixes UML-1620

## Approach

remove 
```hcl
lifecycle {
  create_before_destroy = true
}
```

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] The product team have tested these changes
