### PR TITLE
UML-1619 Add feature flag for the saving of older lpa requests. 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -199,6 +199,7 @@ services:
       # Feature flags
       ALLOW_OLDER_LPAS: "true"
       ALLOW_MERIS_LPAS: "false"
+      SAVE_OLDER_LPA_REQUESTS: "true"
 
       # Local only
       AWS_ACCESS_KEY_ID: "-"

--- a/service-api/app/config/autoload/features.global.php
+++ b/service-api/app/config/autoload/features.global.php
@@ -7,5 +7,6 @@ return [
         'use_legacy_codes_service' => getenv('USE_LEGACY_CODES_SERVICE') ?: 'false',
         'allow_older_lpas' => filter_var(getenv('ALLOW_OLDER_LPAS'), FILTER_VALIDATE_BOOLEAN) ?: false,
         'allow_meris_lpas' => filter_var(getenv('ALLOW_MERIS_LPAS'), FILTER_VALIDATE_BOOLEAN) ?: false,
+        'save_older_lpa_requests' => filter_var(getenv('SAVE_OLDER_LPA_REQUESTS'), FILTER_VALIDATE_BOOLEAN) ?: false,
     ]
 ];

--- a/terraform/environment/api_ecs.tf
+++ b/terraform/environment/api_ecs.tf
@@ -317,6 +317,10 @@ locals {
         {
           name  = "ALLOW_MERIS_LPAS",
           value = tostring(local.account.allow_meris_lpas)
+        },
+        {
+          name  = "SAVE_OLDER_LPA_REQUESTS",
+          value = tostring(local.account.save_older_lpa_requests)
         }
       ]
   })

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -64,6 +64,7 @@ variable "accounts" {
       delete_lpa_feature         = bool
       allow_older_lpas           = bool
       allow_meris_lpas           = bool
+      save_older_lpa_requests    = bool
     })
   )
 }

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -47,7 +47,8 @@
       "use_older_lpa_journey": true,
       "delete_lpa_feature": true,
       "allow_older_lpas": true,
-      "allow_meris_lpas": false
+      "allow_meris_lpas": false,
+      "save_older_lpa_requests": false
     },
     "preproduction": {
       "account_id": "888228022356",
@@ -91,7 +92,8 @@
       "use_older_lpa_journey": true,
       "delete_lpa_feature": true,
       "allow_older_lpas": false,
-      "allow_meris_lpas": false
+      "allow_meris_lpas": false,
+      "save_older_lpa_requests": false
     },
     "production": {
       "account_id": "690083044361",
@@ -135,7 +137,8 @@
       "use_older_lpa_journey": true,
       "delete_lpa_feature": false,
       "allow_older_lpas": false,
-      "allow_meris_lpas": false
+      "allow_meris_lpas": false,
+      "save_older_lpa_requests": false
     }
   }
 }


### PR DESCRIPTION
Disabled everywhere apart from local development. This is so this strand of work does not affect PRs for other codepaths

# Purpose

Add feature flag `save_older_lpa_requests` to the api app for development of that feature.

Fixes UML-1619

## Checklist

* [x] I have performed a self-review of my own code
* [ ] ~I have added relevant logging with appropriate levels to my code~
* [ ] ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* [ ] ~I have added tests to prove my work~
* [ ] ~I have added welsh translation tags and updated translation files~
* [ ] ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* [ ] ~The product team have tested these changes~
