### PR TITLE
Fix forms without labels and accessibility issues

### DIFF
--- a/service-front/app/src/Actor/templates/actor/request-activation-key/date-of-birth.html.twig
+++ b/service-front/app/src/Actor/templates/actor/request-activation-key/date-of-birth.html.twig
@@ -33,8 +33,7 @@
                             'label_class': 'govuk-!-font-weight-bold'
                         },
                         'aria_labelledby': 'dob_heading'
-                    })
-                    }}
+                    }) }}
 
                     <button data-prevent-double-click="true" type="submit" class="govuk-button govuk-!-margin-right-1">{% trans %}Continue{% endtrans %}</button>
 

--- a/service-front/app/src/Actor/templates/actor/request-activation-key/date-of-birth.html.twig
+++ b/service-front/app/src/Actor/templates/actor/request-activation-key/date-of-birth.html.twig
@@ -18,7 +18,7 @@
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
 
-                    <h1 class="govuk-heading-xl">{% trans %}What is your date of birth?{% endtrans %}</h1>
+                    <h1 class="govuk-heading-xl" id="dob_heading">{% trans %}What is your date of birth?{% endtrans %}</h1>
 
                     {{ govuk_error_summary(form) }}
 
@@ -28,7 +28,13 @@
 
                     {{ govuk_form_fieldset(form.get('dob'), {
                         'hint': 'For example, 31 03 1980'| trans,
-                        'attr': {'class': 'xyz', 'label_class': 'govuk-!-font-weight-bold'} }) }}
+                        'attr': {
+                            'class': 'xyz',
+                            'label_class': 'govuk-!-font-weight-bold'
+                        },
+                        'aria_labelledby': 'dob_heading'
+                    })
+                    }}
 
                     <button data-prevent-double-click="true" type="submit" class="govuk-button govuk-!-margin-right-1">{% trans %}Continue{% endtrans %}</button>
 

--- a/service-front/app/src/Actor/templates/actor/request-activation-key/postcode.html.twig
+++ b/service-front/app/src/Actor/templates/actor/request-activation-key/postcode.html.twig
@@ -18,7 +18,7 @@
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
 
-                    <h1 class="govuk-heading-xl">{% trans %}Postcode{% endtrans %}</h1>
+                    <h1 class="govuk-heading-xl" id="postcode_heading">{% trans %}Postcode{% endtrans %}</h1>
 
                     {{ govuk_error_summary(form) }}
 
@@ -29,6 +29,7 @@
                         {{ govuk_form_element(form.get('postcode'), {
                             'hint': 'This must be your current postcode and match the one we have on our records. The activation key will be posted to this address. <a href="%link%" class="govuk-link">Let us know if you have moved.</a>'| trans({'%link%': path('lpa.change-details')}),
                             'label_attr': {'class': 'govuk-!-font-weight-bold'},
+                            'aria_labelledby': 'postcode_heading',
                             'attr' : {'class': 'govuk-input--width-10', 'label_class': 'govuk-!-font-weight-bold'}
                         }) }}
 

--- a/service-front/app/src/Actor/templates/actor/request-activation-key/reference-number.html.twig
+++ b/service-front/app/src/Actor/templates/actor/request-activation-key/reference-number.html.twig
@@ -18,7 +18,7 @@
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
 
-                    <h1 class="govuk-heading-xl">{% trans %}LPA reference number{% endtrans %}</h1>
+                    <h1 class="govuk-heading-xl" id="ref_number_heading">{% trans %}LPA reference number{% endtrans %}</h1>
 
                     {{ govuk_error_summary(form) }}
 
@@ -28,9 +28,13 @@
 
                         {{ govuk_form_element(form.get('opg_reference_number'), {
                             'hint': 'LPA reference numbers are 12 numbers long<br/>For example, 7000-0000-0000'| trans,
-                            'attr' : {'class': 'govuk-input--width-20', 'label_class': 'govuk-!-font-weight-bold govuk-!-margin-bottom-4'},
+                            'attr' : {
+                                'class': 'govuk-input--width-20',
+                                'label_class': 'govuk-!-font-weight-bold govuk-!-margin-bottom-4',
+                            },
                             'inputmode': 'numeric',
-                            'pattern': '[0-9 -]*'
+                            'pattern': '[0-9 -]*',
+                            'aria_labelledby': 'ref_number_heading'
                         }) }}
 
                         <button data-prevent-double-click="true" type="submit" class="govuk-button govuk-!-margin-right-1">{% trans %}Continue{% endtrans %}</button>

--- a/service-front/app/src/Common/templates/partials/govuk_form.html.twig
+++ b/service-front/app/src/Common/templates/partials/govuk_form.html.twig
@@ -11,9 +11,11 @@
 {%- block form_element_simple -%}
     <div class="govuk-form-group {{- block('form_group_error_class') -}}">
 
-        <label class="govuk-label {{- block('input_extra_label_class') -}} " for="{{ element.getName() }}">
-            {{ label | raw }}
-        </label>
+        {% if label is defined %}
+            <label class="govuk-label {{- block('input_extra_label_class') -}} " for="{{ element.getName() }}">
+                {{ label | raw }}
+            </label>
+        {% endif %}
 
         {% if element.getName() == 'opg_reference_number' %}
             <p class="govuk-body">{% trans %}The LPA reference number (also called OPG reference number) is on the first page of the paper LPA and printed on any letter you get from the Office of the Public Guardian.{% endtrans %}</p>
@@ -125,12 +127,19 @@
 {%- block form_fieldset_date -%}
     <div class="govuk-form-group {% if fieldset.getMessages() is not empty %}govuk-form-group--error{% endif %}">
 
-        <fieldset name="{{ fieldset.getName() }}" class="govuk-fieldset" aria-describedby="{{ fieldset.getName() }}-hint" role="group">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-                <label class="govuk-label {{- block('input_extra_label_class') -}}" for="{{ fieldset.getName() }}">
-                    {{ label | raw }}
-                </label>
-            </legend>
+        <fieldset
+                name="{{ fieldset.getName() }}"
+                class="govuk-fieldset"
+                aria-describedby="{{ fieldset.getName() }}-hint"
+                {%- if aria_labelledby is defined -%}aria-labelledby="{{ aria_labelledby }}"{% endif %}
+                role="group">
+            {% if label is defined %}
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                    <label class="govuk-label {{- block('input_extra_label_class') -}}" for="{{ fieldset.getName() }}">
+                        {{ label | raw }}
+                    </label>
+                </legend>
+            {% endif %}
 
             {% with { element: fieldset } %}
                 {{- block('input_hint') -}}
@@ -238,5 +247,6 @@
             {% if inputmode is defined and inputmode is not empty %}inputmode="{{ inputmode }}"{% endif %}
             {% if pattern is defined and pattern is not empty %}pattern="{{ pattern }}"{% endif %}
             {% if spellcheck is defined and spellcheck is not empty %}spellcheck="{{ spellcheck }}"{% endif %}
-            {% if autocomplete is defined and autocomplete is not empty %}autocomplete="{{ autocomplete }}"{% endif %}/>
+            {% if autocomplete is defined and autocomplete is not empty %}autocomplete="{{ autocomplete }}"{% endif %}
+            {% if aria_labelledby is defined and aria_labelledby is not empty %}aria-labelledby="{{ aria_labelledby }}"{% endif %}/>
 {%- endblock form_input -%}


### PR DESCRIPTION
# Purpose

500 errors were appearing on the older lpa form pages as they did not contain labels. The issue only appeared on my machine as it is maybe running in a super strict mode?

## Approach

Set an aria_labelledby tag on the form fields which is set to the page heading id. This fixes the accessibility issues on the forms. Also made labels optional by wrapping them in an if block and checking if they are defined. 

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
