### PR TITLE
Uml 1611 - TTL field existence

### DIFF
--- a/service-api/app/src/App/src/ConfigProvider.php
+++ b/service-api/app/src/App/src/ConfigProvider.php
@@ -76,7 +76,10 @@ class ConfigProvider
                 DataAccess\ApiGateway\RequestSigner::class => DataAccess\ApiGateway\RequestSignerFactory::class,
 
                 // Handlers
-                Handler\HealthcheckHandler::class => Handler\Factory\HealthcheckHandlerFactory::class
+                Handler\HealthcheckHandler::class => Handler\Factory\HealthcheckHandlerFactory::class,
+
+                Service\Features\FeatureEnabled::class => Service\Features\FeatureEnabledFactory::class
+
             ],
 
             'delegators' => [

--- a/service-api/app/src/App/src/Service/Features/FeatureEnabled.php
+++ b/service-api/app/src/App/src/Service/Features/FeatureEnabled.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Features;
+
+use RuntimeException;
+
+class FeatureEnabled
+{
+    /** @var array<string, mixed> */
+    private array $featureFlags;
+
+    /**
+     * FeatureEnabled constructor.
+     *
+     * @param array<string, mixed> $featureFlags An key value map of feature names to boolean values
+     *
+     * @codeCoverageIgnore
+     */
+    public function __construct(array $featureFlags)
+    {
+        $this->featureFlags = $featureFlags;
+    }
+
+    public function __invoke(string $featureName): bool
+    {
+        if (!array_key_exists($featureName, $this->featureFlags)) {
+            throw new RuntimeException('Feature flag "' . $featureName . '" is not currently configured');
+        }
+
+        if (!is_bool($this->featureFlags[$featureName])) {
+            throw new RuntimeException('Feature flag "' . $featureName . '" is not a boolean value');
+        }
+
+        return  $this->featureFlags[$featureName];
+    }
+}

--- a/service-api/app/src/App/src/Service/Features/FeatureEnabledFactory.php
+++ b/service-api/app/src/App/src/Service/Features/FeatureEnabledFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Features;
+
+use Psr\Container\ContainerInterface;
+use UnexpectedValueException;
+
+class FeatureEnabledFactory
+{
+    public function __invoke(ContainerInterface $container): FeatureEnabled
+    {
+        $config = $container->get('config');
+
+        if (!isset($config['feature_flags']) || !is_array($config['feature_flags'])) {
+            throw new UnexpectedValueException('Missing feature flags configuration');
+        }
+
+        return new FeatureEnabled(
+            $config['feature_flags']
+        );
+    }
+}

--- a/service-api/app/src/App/src/Service/Lpa/LpaAlreadyAdded.php
+++ b/service-api/app/src/App/src/Service/Lpa/LpaAlreadyAdded.php
@@ -4,25 +4,36 @@ declare(strict_types=1);
 
 namespace App\Service\Lpa;
 
+use App\DataAccess\Repository\UserLpaActorMapInterface;
+use App\Service\Features\FeatureEnabled;
 use Psr\Log\LoggerInterface;
 
 class LpaAlreadyAdded
 {
+    private FeatureEnabled $featureEnabled;
     private LpaService $lpaService;
-
     private LoggerInterface $logger;
+    private UserLpaActorMapInterface $userLpaActorMapRepository;
 
     /**
      * LpaAlreadyAdded constructor.
      *
+     * @codeCoverageIgnore
+     *
      * @param LpaService               $lpaService
+     * @param UserLpaActorMapInterface $userLpaActorMapRepository
+     * @param FeatureEnabled           $featureEnabled
      * @param LoggerInterface          $logger
      */
     public function __construct(
         LpaService $lpaService,
+        UserLpaActorMapInterface $userLpaActorMapRepository,
+        FeatureEnabled $featureEnabled,
         LoggerInterface $logger
     ) {
         $this->lpaService = $lpaService;
+        $this->userLpaActorMapRepository = $userLpaActorMapRepository;
+        $this->featureEnabled = $featureEnabled;
         $this->logger = $logger;
     }
 
@@ -33,6 +44,56 @@ class LpaAlreadyAdded
      * @return array|null
      */
     public function __invoke(string $userId, string $lpaUid): ?array
+    {
+        if (($this->featureEnabled)('save_older_lpa_requests')) {
+
+            $savedLpaRecords = $this->userLpaActorMapRepository->getUsersLpas($userId);
+
+            foreach($savedLpaRecords as $record) {
+                if ($record['SiriusUid'] === $lpaUid && !array_key_exists('ActivateBy', $record)) {
+                    $lpa = $this->lpaService->getByUserLpaActorToken($record['Id'], $userId);
+
+                    // a count of a null array will be 0
+                    if (count($lpa) === 0) {
+                        return null;
+                    }
+
+                    $this->logger->info(
+                        'Account with Id {id} has attempted to add LPA {uId} which already exists in their account',
+                        [
+                            'id' => $userId,
+                            'uId' => $lpaUid
+                        ]
+                    );
+
+                    return [
+                        'donor' => [
+                            'uId'         => $lpa['lpa']['donor']['uId'],
+                            'firstname'   => $lpa['lpa']['donor']['firstname'],
+                            'middlenames' => $lpa['lpa']['donor']['middlenames'],
+                            'surname'     => $lpa['lpa']['donor']['surname'],
+                        ],
+                        'caseSubtype'   => $lpa['lpa']['caseSubtype'],
+                        'lpaActorToken' => $record['Id']
+                    ];
+                }
+            }
+
+            return null;
+
+        } else {
+            return $this->preSaveOfRequestFeature($userId, $lpaUid);
+        }
+    }
+
+
+    /**
+     * @param string $userId
+     * @param string $lpaUid
+     *
+     * @return array|null
+     */
+    private function preSaveOfRequestFeature(string $userId, string $lpaUid): ?array
     {
         $lpasAdded = $this->lpaService->getAllForUser($userId);
 
@@ -57,6 +118,7 @@ class LpaAlreadyAdded
                 ];
             }
         }
+
         return null;
     }
 }

--- a/service-api/app/test/AppTest/Service/Features/FeatureEnabledFactoryTest.php
+++ b/service-api/app/test/AppTest/Service/Features/FeatureEnabledFactoryTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppTest\Service\Features;
+
+use App\Service\Features\FeatureEnabled;
+use App\Service\Features\FeatureEnabledFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use UnexpectedValueException;
+
+/**
+ * Class FeatureEnabledFactoryTest
+ *
+ * @package AppTest\Service\Features
+ *
+ * @coversDefaultClass \App\Service\Features\FeatureEnabledFactory
+ */
+class FeatureEnabledFactoryTest extends TestCase
+{
+    /**
+     * @test
+     * @covers ::__invoke
+     */
+    public function it_creates_a_featureenabled_service_instance(): void
+    {
+        $containerProphecy = $this->prophesize(ContainerInterface::class);
+        $containerProphecy
+            ->get('config')
+            ->willReturn(
+                [
+                    'feature_flags' => [],
+                ]
+            );
+
+        $factory = new FeatureEnabledFactory();
+
+        $instance = $factory($containerProphecy->reveal());
+
+        $this->assertInstanceOf(FeatureEnabled::class, $instance);
+    }
+
+    /**
+     * @test
+     * @covers ::__invoke
+     */
+    public function it_will_throw_an_exception_if_not_configured(): void
+    {
+        $containerProphecy = $this->prophesize(ContainerInterface::class);
+        $containerProphecy
+            ->get('config')
+            ->willReturn([]);
+
+        $factory = new FeatureEnabledFactory();
+
+        $this->expectException(UnexpectedValueException::class);
+        $instance = $factory($containerProphecy->reveal());
+    }
+
+    /**
+     * @test
+     * @covers ::__invoke
+     */
+    public function it_will_throw_an_exception_if_badly_configured(): void
+    {
+        $containerProphecy = $this->prophesize(ContainerInterface::class);
+        $containerProphecy
+            ->get('config')
+            ->willReturn(
+                [
+                    'feature_flags' => 'not an array',
+                ]
+            );
+
+        $factory = new FeatureEnabledFactory();
+
+        $this->expectException(UnexpectedValueException::class);
+        $instance = $factory($containerProphecy->reveal());
+    }
+}

--- a/service-api/app/test/AppTest/Service/Features/FeatureEnabledTest.php
+++ b/service-api/app/test/AppTest/Service/Features/FeatureEnabledTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppTest\Service\Features;
+
+use App\Service\Features\FeatureEnabled;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Class FeatureEnabledTest
+ *
+ * @package AppTest\Service\Features
+ * @coversDefaultClass \App\Service\Features\FeatureEnabled
+ */
+class FeatureEnabledTest extends TestCase
+{
+    /**
+     * @test
+     * @covers ::__invoke
+     */
+    public function it_correctly_returns_feature_value_from_configuration(): void
+    {
+        $flags = [
+            'feature_name' => true
+        ];
+
+        $sut = new FeatureEnabled($flags);
+
+        $enabled = $sut('feature_name');
+
+        $this->assertTrue($enabled);
+    }
+
+    /**
+     * @test
+     * @covers ::__invoke
+     */
+    public function it_throws_an_exception_when_not_finding_a_feature_value(): void
+    {
+        $flags = [
+            'feature_name' => true
+        ];
+
+        $sut = new FeatureEnabled($flags);
+
+        $this->expectException(RuntimeException::class);
+        $enabled = $sut('other_feature_name');
+    }
+
+    /**
+     * @test
+     * @covers ::__invoke
+     */
+    public function it_throws_an_exception_when_not_finding_badly_configured_feature_value(): void
+    {
+        $flags = [
+            'feature_name' => 'Yes'
+        ];
+
+        $sut = new FeatureEnabled($flags);
+
+        $this->expectException(RuntimeException::class);
+        $enabled = $sut('feature_name');
+    }
+}


### PR DESCRIPTION
# Purpose

We need to change our check for the existence of the Lpa within a users account so that if the _ActivateBy_ column exists then the check passes (as if the user does not have the Lpa in their account.

Fixes UML-1611

## Approach

Add feature flag usage and refactor code to check the db *without* pulling every LPA the user has from Sirius

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [ ] ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* [x] I have added tests to prove my work
* [ ] ~I have added welsh translation tags and updated translation files~
* [ ] ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* [ ] ~The product team have tested these changes~
