### PR TITLE
Uml 1697 filter not activated lpa from dashboard

### DIFF
--- a/service-api/app/features/context/Integration/LpaContext.php
+++ b/service-api/app/features/context/Integration/LpaContext.php
@@ -390,7 +390,7 @@ class LpaContext extends BaseIntegrationContext
             $this->lpa
         );
 
-        $lpa = $this->lpaService->getAllForUser($this->userId);
+        $lpa = $this->lpaService->getAllActivatedLpasForUser($this->userId);
 
         assertArrayHasKey($this->userLpaActorToken, $lpa);
         assertEquals($lpa[$this->userLpaActorToken]['user-lpa-actor-token'], $this->userLpaActorToken);
@@ -527,7 +527,7 @@ class LpaContext extends BaseIntegrationContext
             $this->lpa
         );
 
-        $lpa = $this->lpaService->getAllForUser($this->userId);
+        $lpa = $this->lpaService->getAllActivatedLpasForUser($this->userId);
 
         assertArrayHasKey($this->userLpaActorToken, $lpa);
         assertEquals($lpa[$this->userLpaActorToken]['user-lpa-actor-token'], $this->userLpaActorToken);
@@ -1598,7 +1598,7 @@ class LpaContext extends BaseIntegrationContext
      */
     public function theLPAHasNotBeenAdded()
     {
-        $lpas = $this->lpaService->getAllForUser($this->userId);
+        $lpas = $this->lpaService->getAllActivatedLpasForUser($this->userId);
 
         assertEmpty($lpas);
     }
@@ -1840,7 +1840,7 @@ class LpaContext extends BaseIntegrationContext
             $this->lpa
         );
 
-        $lpa = $this->lpaService->getAllForUser($this->userId);
+        $lpa = $this->lpaService->getAllActivatedLpasForUser($this->userId);
 
         assertEmpty($lpa);
     }

--- a/service-api/app/src/App/src/Handler/LpasCollectionHandler.php
+++ b/service-api/app/src/App/src/Handler/LpasCollectionHandler.php
@@ -35,7 +35,7 @@ class LpasCollectionHandler implements RequestHandlerInterface
     {
         $user = $request->getAttribute('actor-id');
 
-        $result = $this->lpaService->getAllForUser($user);
+        $result = $this->lpaService->getAllActivatedLpasForUser($user);
 
         return new JsonResponse($result);
     }

--- a/service-api/app/src/App/src/Service/Lpa/LpaAlreadyAdded.php
+++ b/service-api/app/src/App/src/Service/Lpa/LpaAlreadyAdded.php
@@ -47,25 +47,27 @@ class LpaAlreadyAdded
     {
         $lpasAdded = $this->lpaService->getAllActivatedLpasForUser($userId);
 
-        foreach ($lpasAdded as $userLpaActorToken => $lpaData) {
-            if ($lpaData['lpa']['uId'] === $lpaUid) {
-                $this->logger->info(
-                    'Account with Id {id} has attempted to add LPA {uId} which already exists in their account',
-                    [
-                        'id' => $userId,
-                        'uId' => $lpaUid
-                    ]
-                );
-                return [
-                    'donor' => [
-                        'uId' => $lpaData['lpa']['donor']['uId'],
-                        'firstname' => $lpaData['lpa']['donor']['firstname'],
-                        'middlenames' => $lpaData['lpa']['donor']['middlenames'],
-                        'surname' => $lpaData['lpa']['donor']['surname'],
-                    ],
-                    'caseSubtype' => $lpaData['lpa']['caseSubtype'],
-                    'lpaActorToken' => $userLpaActorToken
-                ];
+        if ($lpasAdded !== null) {
+            foreach ($lpasAdded as $userLpaActorToken => $lpaData) {
+                if ($lpaData['lpa']['uId'] === $lpaUid) {
+                    $this->logger->info(
+                        'Account with Id {id} has attempted to add LPA {uId} which already exists in their account',
+                        [
+                            'id' => $userId,
+                            'uId' => $lpaUid
+                        ]
+                    );
+                    return [
+                        'donor' => [
+                            'uId' => $lpaData['lpa']['donor']['uId'],
+                            'firstname' => $lpaData['lpa']['donor']['firstname'],
+                            'middlenames' => $lpaData['lpa']['donor']['middlenames'],
+                            'surname' => $lpaData['lpa']['donor']['surname'],
+                        ],
+                        'caseSubtype' => $lpaData['lpa']['caseSubtype'],
+                        'lpaActorToken' => $userLpaActorToken
+                    ];
+                }
             }
         }
         return null;

--- a/service-api/app/src/App/src/Service/Lpa/LpaService.php
+++ b/service-api/app/src/App/src/Service/Lpa/LpaService.php
@@ -131,7 +131,7 @@ class LpaService
      * @param string $userId User account ID to fetch LPAs for
      * @return array An array of LPA data structures containing processed LPA data and metadata
      */
-    public function getAllForUser(string $userId): array
+    public function getAllActivatedLpasForUser(string $userId): array
     {
         // Returns an array of all the LPAs Ids (plus other metadata) in the user's account.
         $lpaActorMaps = $this->userLpaActorMapRepository->getUsersLpas($userId);
@@ -148,7 +148,7 @@ class LpaService
 
         // Map the results...
         foreach ($lpaActorMaps as $item) {
-            if (array_key_exists('ActivateBy', $item)) {
+            if (array_key_exists('ActivateBy', $item) ) {
                 continue;
             }
 

--- a/service-api/app/src/App/src/Service/Lpa/LpaService.php
+++ b/service-api/app/src/App/src/Service/Lpa/LpaService.php
@@ -148,7 +148,7 @@ class LpaService
 
         // Map the results...
         foreach ($lpaActorMaps as $item) {
-            if (array_key_exists('ActivateBy', $item) ) {
+            if (array_key_exists('ActivateBy', $item)) {
                 continue;
             }
 

--- a/service-api/app/src/App/src/Service/Lpa/LpaService.php
+++ b/service-api/app/src/App/src/Service/Lpa/LpaService.php
@@ -148,6 +148,10 @@ class LpaService
 
         // Map the results...
         foreach ($lpaActorMaps as $item) {
+            if (array_key_exists('ActivateBy', $item)) {
+                continue;
+            }
+
             $lpa = $lpas[$item['SiriusUid']];
             $lpaData = $lpa->getData();
             $actor = ($this->resolveActor)($lpaData, $item['ActorId']);

--- a/service-api/app/test/AppTest/Service/Lpa/LpaAlreadyAddedTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/LpaAlreadyAddedTest.php
@@ -56,12 +56,9 @@ class LpaAlreadyAddedTest extends TestCase
     /**
      * @test
      * @covers ::__invoke
-     * @covers ::preSaveOfRequestFeature
      */
-    public function returns_null_if_lpa_not_already_added_pre_feature()
+    public function returns_null_if_lpa_not_already_added_with_other_lpas_in_account()
     {
-        $this->featureEnabledProphecy->__invoke('save_older_lpa_requests')->willReturn(false);
-
         $this->lpaServiceProphecy
             ->getAllActivatedLpasForUser('12345')
             ->willReturn(
@@ -85,10 +82,8 @@ class LpaAlreadyAddedTest extends TestCase
      */
     public function returns_null_if_lpa_not_already_added()
     {
-        $this->featureEnabledProphecy->__invoke('save_older_lpa_requests')->willReturn(true);
-
-        $this->userLpaActorMapProphecy
-            ->getUsersLpas($this->userId)
+        $this->lpaServiceProphecy
+            ->getAllActivatedLpasForUser($this->userId)
             ->willReturn([]);
 
         $lpaAddedData = ($this->getLpaAlreadyAddedService())($this->userId, '700000000321');
@@ -99,33 +94,8 @@ class LpaAlreadyAddedTest extends TestCase
      * @test
      * @covers ::__invoke
      */
-    public function returns_null_if_lpa_added_but_not_active()
-    {
-        $this->featureEnabledProphecy->__invoke('save_older_lpa_requests')->willReturn(true);
-
-        $this->userLpaActorMapProphecy
-            ->getUsersLpas($this->userId)
-            ->willReturn(
-                [
-                    [
-                        'SiriusUid' => $this->lpaUid,
-                        'ActivateBy' => (new \DateTimeImmutable('now'))->format('Y-m-d H:i:s'),
-                    ],
-                ]
-            );
-
-        $lpaAddedData = ($this->getLpaAlreadyAddedService())($this->userId, $this->lpaUid);
-        $this->assertNull($lpaAddedData);
-    }
-
-    /**
-     * @test
-     * @covers ::__invoke
-     */
     public function returns_null_if_lpa_added_but_not_usable_found_in_api()
     {
-        $this->featureEnabledProphecy->__invoke('save_older_lpa_requests')->willReturn(true);
-
         $this->userLpaActorMapProphecy
             ->getUsersLpas($this->userId)
             ->willReturn(
@@ -148,12 +118,9 @@ class LpaAlreadyAddedTest extends TestCase
     /**
      * @test
      * @covers ::__invoke
-     * @covers ::preSaveOfRequestFeature
      */
-    public function returns_lpa_data_if_lpa_is_already_added_pre_feature()
+    public function returns_lpa_data_if_lpa_is_already_added()
     {
-        $this->featureEnabledProphecy->__invoke('save_older_lpa_requests')->willReturn(false);
-
         $this->lpaServiceProphecy
             ->getAllActivatedLpasForUser($this->userId)
             ->willReturn(

--- a/service-api/app/test/AppTest/Service/Lpa/LpaAlreadyAddedTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/LpaAlreadyAddedTest.php
@@ -138,7 +138,7 @@ class LpaAlreadyAddedTest extends TestCase
             );
 
         $this->lpaServiceProphecy
-            ->getByUserLpaActorToken($this->userLpaActorToken, $this->userId)
+            ->getAllActivatedLpasForUser($this->userId)
             ->willReturn([]);
 
         $lpaAddedData = ($this->getLpaAlreadyAddedService())($this->userId, $this->lpaUid);
@@ -198,58 +198,5 @@ class LpaAlreadyAddedTest extends TestCase
             'caseSubtype' => 'hw',
             'lpaActorToken' => $this->userLpaActorToken
         ], $lpaAddedData);
-    }
-
-    /**
-     * @test
-     * @covers ::__invoke
-     */
-    public function returns_lpa_data_if_lpa_is_already_added()
-    {
-        $this->featureEnabledProphecy->__invoke('save_older_lpa_requests')->willReturn(true);
-
-        $this->userLpaActorMapProphecy
-            ->getUsersLpas($this->userId)
-            ->willReturn(
-                [
-                    [
-                        'Id' => $this->userLpaActorToken,
-                        'SiriusUid' => $this->lpaUid,
-                    ],
-                ]
-            );
-
-        $this->lpaServiceProphecy
-            ->getByUserLpaActorToken($this->userLpaActorToken, $this->userId)
-            ->willReturn(
-                [
-                    'user-lpa-actor-token' => $this->userLpaActorToken,
-                    'lpa' => [
-                        'uId' => $this->lpaUid,
-                        'caseSubtype' => 'hw',
-                        'donor' => [
-                            'uId' => '700000000444',
-                            'firstname'     => 'Another',
-                            'middlenames'   => '',
-                            'surname'       => 'Person',
-                        ],
-                    ],
-                ]
-            );
-
-        $lpaAddedData = ($this->getLpaAlreadyAddedService())($this->userId, $this->lpaUid);
-        $this->assertEquals(
-            [
-                'donor' => [
-                    'uId'         => '700000000444',
-                    'firstname'   => 'Another',
-                    'middlenames' => '',
-                    'surname'     => 'Person',
-                ],
-                'caseSubtype' => 'hw',
-                'lpaActorToken' => $this->userLpaActorToken
-            ],
-            $lpaAddedData
-        );
     }
 }

--- a/service-api/app/test/AppTest/Service/Lpa/LpaAlreadyAddedTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/LpaAlreadyAddedTest.php
@@ -63,7 +63,7 @@ class LpaAlreadyAddedTest extends TestCase
         $this->featureEnabledProphecy->__invoke('save_older_lpa_requests')->willReturn(false);
 
         $this->lpaServiceProphecy
-            ->getAllForUser('12345')
+            ->getAllActivatedLpasForUser('12345')
             ->willReturn(
                 [
                     $this->userLpaActorToken => [
@@ -155,7 +155,7 @@ class LpaAlreadyAddedTest extends TestCase
         $this->featureEnabledProphecy->__invoke('save_older_lpa_requests')->willReturn(false);
 
         $this->lpaServiceProphecy
-            ->getAllForUser($this->userId)
+            ->getAllActivatedLpasForUser($this->userId)
             ->willReturn(
                 [
                     'xyz321-987ltc' => [

--- a/service-api/app/test/AppTest/Service/Lpa/LpaServiceTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/LpaServiceTest.php
@@ -411,7 +411,7 @@ class LpaServiceTest extends TestCase
 
         $service = $this->getLpaService();
 
-        $result = $service->getAllForUser($t->UserId);
+        $result = $service->getAllActivatedLpasForUser($t->UserId);
 
         $this->assertIsArray($result);
         $this->assertCount(2, $result);
@@ -444,7 +444,7 @@ class LpaServiceTest extends TestCase
 
         $this->userLpaActorMapInterfaceProphecy->getUsersLpas($t->UserId)->willReturn([]);
 
-        $result = $service->getAllForUser($t->UserId);
+        $result = $service->getAllActivatedLpasForUser($t->UserId);
 
         $this->assertIsArray($result);
         $this->assertCount(0, $result);
@@ -541,7 +541,7 @@ class LpaServiceTest extends TestCase
 
         $service = $this->getLpaService();
 
-        $result = $service->getAllForUser($t->UserId);
+        $result = $service->getAllActivatedLpasForUser($t->UserId);
 
         $this->assertIsArray($result);
         $this->assertCount(2, $result);

--- a/service-api/app/test/AppTest/Service/Lpa/LpaServiceTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/LpaServiceTest.php
@@ -431,6 +431,8 @@ class LpaServiceTest extends TestCase
         $this->assertArrayHasKey('lpa', $result);
 
         $lpa = array_pop($t->lpaResults);
+
+        array_pop($t->mapResults); //this is the request and should not be returned by the result of getActivatedLpas
         $map = array_pop($t->mapResults);
 
         $this->assertEquals($map['Id'], $result['user-lpa-actor-token']);

--- a/service-api/app/test/AppTest/Service/Lpa/LpaServiceTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/LpaServiceTest.php
@@ -9,16 +9,13 @@ use App\DataAccess\{ApiGateway\ActorCodes,
     Repository\UserLpaActorMapInterface,
     Repository\ViewerCodesInterface};
 use App\DataAccess\Repository\Response\{ActorCode, Lpa};
-use App\Exception\ApiException;
-use App\Exception\BadRequestException;
-use App\Exception\NotFoundException;
 use App\Service\Lpa\GetAttorneyStatus;
 use App\Service\Lpa\IsValidLpa;
 use App\Service\Lpa\LpaService;
 use App\Service\Lpa\ResolveActor;
 use App\Service\ViewerCodes\ViewerCodeService;
 use DateTime;
-use Fig\Http\Message\StatusCodeInterface;
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
@@ -353,7 +350,7 @@ class LpaServiceTest extends TestCase
     }
 
     //-------------------------------------------------------------------------
-    // Test getAllForUser()
+    // Test getAllActivatedLpasForUser()
 
     private function init_valid_get_all_users()
     {
@@ -373,6 +370,13 @@ class LpaServiceTest extends TestCase
                 'SiriusUid' => 'uid-2',
                 'ActorId' => 2,
                 'Added'   => new DateTime('now')
+            ],
+            [
+                'Id' => 'token-3',
+                'SiriusUid' => 'uid-3',
+                'ActorId' => 3,
+                'Added' => new DateTimeImmutable('now'),
+                'ActivateBy' => (new DateTime('now'))->add(new \DateInterval('P1Y'))->getTimeStamp()
             ]
         ];
 


### PR DESCRIPTION
# Purpose

Change implementation of getUserLpas so only activated LPAs are recieved. This will then stop LPAs from being visible on the dashboard if they are not activated

Fixes UML-1697

## Approach

Changing this getUserLPAs method means that we are changing functionality as little as possible. Everywhere that gets LPAs are most likely using this method and will now mirror the existing functionality. 

In the future we should potentially add another method to get the non activated LPA requests to display on the dashboard. 

## Checklist

* [x] I have performed a self-review of my own code
* ~~[ ] I have added relevant logging with appropriate levels to my code~~
* ~~[ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~~
* [x] I have added tests to prove my work
* ~~[ ] I have added welsh translation tags and updated translation files~~
* ~~[ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found~~
* ~~[ ] The product team have tested these changes~~
