### PR TITLE
UML-1659 - Do not map public IP on launch - Subnets

### DIFF
--- a/terraform/account/network.tf
+++ b/terraform/account/network.tf
@@ -11,8 +11,9 @@ data "aws_availability_zones" "default" {
 }
 
 resource "aws_default_subnet" "public" {
-  count             = 3
-  availability_zone = element(data.aws_availability_zones.default.names, count.index)
+  count                   = 3
+  availability_zone       = element(data.aws_availability_zones.default.names, count.index)
+  map_public_ip_on_launch = false
 
   tags = merge(
     local.default_tags,
@@ -23,11 +24,11 @@ resource "aws_default_subnet" "public" {
 }
 
 resource "aws_subnet" "private" {
-  count      = 3
-  cidr_block = cidrsubnet(aws_default_vpc.default.cidr_block, 4, count.index + 3)
-  vpc_id     = aws_default_vpc.default.id
-
-  availability_zone = element(data.aws_availability_zones.default.names, count.index)
+  count                   = 3
+  cidr_block              = cidrsubnet(aws_default_vpc.default.cidr_block, 4, count.index + 3)
+  vpc_id                  = aws_default_vpc.default.id
+  availability_zone       = element(data.aws_availability_zones.default.names, count.index)
+  map_public_ip_on_launch = false
 
   tags = merge(
     local.default_tags,


### PR DESCRIPTION
# Purpose

Address SecurityHub findings

Fixes UML-1659

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#ec2-15-remediation
## Checklist

* [ ] I have performed a self-review of my own code
* [ ] The product team have tested these changes
