### PR TITLE
UML-1666 - S3 block all public and cross account access at account level

### DIFF
--- a/terraform/account/s3.tf
+++ b/terraform/account/s3.tf
@@ -2,6 +2,14 @@ data "aws_elb_service_account" "main" {
   region = "eu-west-1"
 }
 
+resource "aws_s3_account_public_access_block" "block_all" {
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+
 data "aws_iam_policy_document" "viewer_loadbalancer" {
   statement {
     sid = "accessLogBucketAccess"

--- a/terraform/account/s3.tf
+++ b/terraform/account/s3.tf
@@ -9,7 +9,6 @@ resource "aws_s3_account_public_access_block" "block_all" {
   restrict_public_buckets = true
 }
 
-
 data "aws_iam_policy_document" "viewer_loadbalancer" {
   statement {
     sid = "accessLogBucketAccess"


### PR DESCRIPTION
# Purpose

Ensure that public access cannot be added to S3 by mistake

Fixes UML-1666

## Learning

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_account_public_access_block

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] The product team have tested these changes
