### PR TITLE
Switch save requests flag on and fix ActivateBy TTL put item error

### DIFF
--- a/service-api/app/src/App/src/DataAccess/DynamoDb/UserLpaActorMap.php
+++ b/service-api/app/src/App/src/DataAccess/DynamoDb/UserLpaActorMap.php
@@ -72,7 +72,7 @@ class UserLpaActorMap implements UserLpaActorMapInterface
         //Add ActivateBy field to array if expiry interval is present
         if ($expiryInterval !== null) {
             $expiry = $added->add(new \DateInterval($expiryInterval));
-            $array['ActivateBy'] = ['N' => $expiry->getTimestamp()];
+            $array['ActivateBy'] = ['N' => (string) $expiry->getTimestamp()];
         }
 
         try {

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -48,7 +48,7 @@
       "delete_lpa_feature": true,
       "allow_older_lpas": true,
       "allow_meris_lpas": false,
-      "save_older_lpa_requests": false
+      "save_older_lpa_requests": true
     },
     "preproduction": {
       "account_id": "888228022356",


### PR DESCRIPTION
# Purpose

The `save_older_lpa_requests` flag has always been turned off in dev mode, meaning any tickets relying on that feature were never UAT'd properly. Since switching it on I have come across this error when requesting an activation key:
`"NUMBER_VALUE cannot be converted to String"` . I believe this is due to the fact that dynamoDB expects number values to be represented as strings (see doc for details https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_AttributeValue.html). 

Therefore this line was causing the issue:
`$array['ActivateBy'] = ['N' => $expiry->getTimestamp()];`
and has been fixed by converting the timestamp to a string

## Checklist

* [x] I have performed a self-review of my own code
* [ ] The product team have tested these changes
