### PR TITLE
Uml 1643 update existing activation key (refactor pt1)

### DIFF
--- a/service-api/app/features/actor-add-an-older-lpa.feature
+++ b/service-api/app/features/actor-add-an-older-lpa.feature
@@ -8,7 +8,7 @@ Feature: Add an older LPA
     And I am a user of the lpa application
     And I am currently signed in
 
-  @integration @acceptance @ff:allow_older_lpas:false
+  @integration @acceptance @pact @ff:allow_older_lpas:false
   Scenario: The user cannot add an old LPA which does not have a registered status
     Given I am on the add an older LPA page
     When I provide details of an LPA that is not registered
@@ -80,7 +80,7 @@ Feature: Add an older LPA
     And A record of my activation key request is not saved
 
 
-  @acceptance @integration @ff:save_older_lpa_requests:false
+  @acceptance @integration @pact @ff:save_older_lpa_requests:false
   Scenario: The user is able to generate a new key even if an activation key already exists
     Given I am on the add an older LPA page
     And I lost the letter containing my activation key
@@ -95,7 +95,7 @@ Feature: Add an older LPA
     Then a letter is requested containing a one time use code
     And A record of my activation key request is saved
 
-  @acceptance @integration @ff:save_older_lpa_requests:false
+  @acceptance @integration @pact @ff:save_older_lpa_requests:false
   Scenario: The user is unable to request a key for an LPA that they have already added (save requests disabled)
     Given I am on the add an older LPA page
     And I have added an LPA to my account
@@ -103,7 +103,7 @@ Feature: Add an older LPA
     And I confirm the details I provided are correct
     Then I should be told that I have already added this LPA
 
-  @acceptance @integration @ff:save_older_lpa_requests:true
+  @acceptance @integration @pact @ff:save_older_lpa_requests:true
   Scenario: The user is unable to request a key for an LPA that they have already added (save requests enabled)
     Given I am on the add an older LPA page
     And I have added an LPA to my account

--- a/service-api/app/psalm.xml
+++ b/service-api/app/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="false"
+    errorLevel="4"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
@@ -12,44 +12,4 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
-
-    <issueHandlers>
-        <LessSpecificReturnType errorLevel="info" />
-
-        <!-- level 3 issues - slightly lazy code writing, but provably low false-negatives -->
-
-        <DeprecatedMethod errorLevel="info" />
-        <DeprecatedProperty errorLevel="info" />
-        <DeprecatedClass errorLevel="info" />
-        <DeprecatedConstant errorLevel="info" />
-        <DeprecatedFunction errorLevel="info" />
-        <DeprecatedInterface errorLevel="info" />
-        <DeprecatedTrait errorLevel="info" />
-
-        <InternalMethod errorLevel="info" />
-        <InternalProperty errorLevel="info" />
-        <InternalClass errorLevel="info" />
-
-        <MissingClosureReturnType errorLevel="info" />
-        <MissingReturnType errorLevel="info" />
-        <MissingPropertyType errorLevel="info" />
-        <InvalidDocblock errorLevel="info" />
-        <MisplacedRequiredParam errorLevel="info" />
-
-        <PropertyNotSetInConstructor errorLevel="info" />
-        <MissingConstructor errorLevel="info" />
-        <MissingClosureParamType errorLevel="info" />
-        <MissingParamType errorLevel="info" />
-
-        <RedundantCondition errorLevel="info" />
-
-        <DocblockTypeContradiction errorLevel="info" />
-        <RedundantConditionGivenDocblockType errorLevel="info" />
-
-        <UnresolvableInclude errorLevel="info" />
-
-        <RawObjectIteration errorLevel="info" />
-
-        <InvalidStringClass errorLevel="info" />
-    </issueHandlers>
 </psalm>

--- a/service-api/app/src/App/src/DataAccess/DynamoDb/UserLpaActorMap.php
+++ b/service-api/app/src/App/src/DataAccess/DynamoDb/UserLpaActorMap.php
@@ -133,7 +133,7 @@ class UserLpaActorMap implements UserLpaActorMapInterface
     /**
      * @inheritDoc
      */
-    public function getUsersLpas(string $userId): ?array
+    public function getByUserId(string $userId): ?array
     {
         $result = $this->client->query([
             'TableName' => $this->userLpaActorTable,

--- a/service-api/app/src/App/src/DataAccess/DynamoDb/UserLpaActorMap.php
+++ b/service-api/app/src/App/src/DataAccess/DynamoDb/UserLpaActorMap.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace App\DataAccess\DynamoDb;
 
 use App\DataAccess\Repository\UserLpaActorMapInterface;
-use App\DataAccess\Repository\KeyCollisionException;
 use Aws\DynamoDb\DynamoDbClient;
 use Aws\DynamoDb\Exception\DynamoDbException;
 use DateTimeImmutable;
 use Exception;
+use Ramsey\Uuid\Uuid;
 
 class UserLpaActorMap implements UserLpaActorMapInterface
 {
@@ -54,39 +54,44 @@ class UserLpaActorMap implements UserLpaActorMapInterface
      * @throws Exception
      */
     public function create(
-        string $lpaActorToken,
         string $userId,
         string $siriusUid,
         string $actorId,
         string $expiryInterval = null
-    ) {
+    ): string {
         $added = new DateTimeImmutable();
         $array = [
-            'Id'        => ['S' => $lpaActorToken],
             'UserId'    => ['S' => $userId],
             'SiriusUid' => ['S' => $siriusUid],
             'ActorId'   => ['N' => $actorId],
             'Added'     => ['S' => $added->format('Y-m-d\TH:i:s.u\Z') ]
         ];
 
-        //Add ActivateBy field to array if expiry interval is present
+        // Add ActivateBy field to array if expiry interval is present
         if ($expiryInterval !== null) {
             $expiry = $added->add(new \DateInterval($expiryInterval));
             $array['ActivateBy'] = ['N' => (string) $expiry->getTimestamp()];
         }
 
-        try {
-            $this->client->putItem([
-                'TableName' => $this->userLpaActorTable,
-                'Item' => $array,
-                'ConditionExpression' => 'attribute_not_exists(Id)'
-            ]);
-        } catch (DynamoDbException $e) {
-            if ($e->getAwsErrorCode() === 'ConditionalCheckFailedException') {
-                throw new KeyCollisionException();
+        do {
+            $id = Uuid::uuid4()->toString();
+            $array['Id'] = ['S' => $id];
+
+            try {
+                $this->client->putItem([
+                    'TableName' => $this->userLpaActorTable,
+                    'Item' => $array,
+                    'ConditionExpression' => 'attribute_not_exists(Id)'
+                ]);
+
+                return $id;
+            } catch (DynamoDbException $e) {
+                if ($e->getAwsErrorCode() === 'ConditionalCheckFailedException') {
+                    continue;
+                }
+                throw $e;
             }
-            throw $e;
-        }
+        } while (true);
     }
 
     /**

--- a/service-api/app/src/App/src/DataAccess/Repository/UserLpaActorMapInterface.php
+++ b/service-api/app/src/App/src/DataAccess/Repository/UserLpaActorMapInterface.php
@@ -15,22 +15,20 @@ interface UserLpaActorMapInterface
     /**
      * Creates a new mapping in the DB
      *
-     * @param string $lpaActorToken The UUID to represent this mapping in the database
-     * @param string $userId The UserID of the actors account
+     * @param string $userId    The UserID of the actors account
      * @param string $siriusUid The Sirius formatted UID that is associated with an LPA in the system
-     * @param string $actorId The Sirius formatted UID that is associated with an actor in the system
+     * @param string $actorId   The Sirius formatted UID that is associated with an actor in the system
      * @param string|null $expiryInterval The interval of when this record should expire.
      *                                    If null the record will not expire
      *
-     * @throws KeyCollisionException Thrown if the lpaActorToken is not unique
+     * @return string The lpaActorToken of the newly created mapping
      */
     public function create(
-        string $lpaActorToken,
         string $userId,
         string $siriusUid,
         string $actorId,
         string $expiryInterval = null
-    );
+    ): string;
 
     /**
      * Returns the IDs for the LPA and associated Actor for the given token.

--- a/service-api/app/src/App/src/DataAccess/Repository/UserLpaActorMapInterface.php
+++ b/service-api/app/src/App/src/DataAccess/Repository/UserLpaActorMapInterface.php
@@ -46,7 +46,7 @@ interface UserLpaActorMapInterface
      * @param $userId
      * @return mixed
      */
-    public function getUsersLpas(string $userId): ?array;
+    public function getByUserId(string $userId): ?array;
 
     /**
      * Deletes an relation. Should only be called if a rollback is needed.

--- a/service-api/app/src/App/src/Service/ActorCodes/ActorCodeService.php
+++ b/service-api/app/src/App/src/Service/ActorCodes/ActorCodeService.php
@@ -109,7 +109,7 @@ class ActorCodeService
         //---
         $lpaId = $details['lpa']['uId'];
 
-        $lpas = $this->userLpaActorMapRepository->getUsersLpas($userId);
+        $lpas = $this->userLpaActorMapRepository->getByUserId($userId);
         $idToLpaMap = array_column($lpas, 'Id', 'SiriusUid');
 
         if (array_key_exists($lpaId, $idToLpaMap)) {

--- a/service-api/app/src/App/src/Service/ActorCodes/ActorCodeService.php
+++ b/service-api/app/src/App/src/Service/ActorCodes/ActorCodeService.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace App\Service\ActorCodes;
 
-use App\DataAccess\{Repository\KeyCollisionException, Repository\UserLpaActorMapInterface};
+use App\DataAccess\Repository\UserLpaActorMapInterface;
 use App\Exception\{ActorCodeMarkAsUsedException, ActorCodeValidationException};
 use App\Service\Lpa\LpaService;
 use App\Service\Lpa\ResolveActor;
-use Ramsey\Uuid\Uuid;
 
 class ActorCodeService
 {
@@ -38,36 +37,6 @@ class ActorCodeService
         $this->lpaService = $lpaService;
         $this->userLpaActorMapRepository = $userLpaActorMapRepository;
         $this->resolveActor = $resolveActor;
-    }
-
-    /**
-     * @param string $userId
-     * @param array  $details
-     *
-     * @return string
-     * @throws \Exception
-     */
-    public function addLpaRecord(string $userId, array $details): string
-    {
-        do {
-            $added = false;
-
-            $id = Uuid::uuid4()->toString();
-
-            try {
-                $this->userLpaActorMapRepository->create(
-                    $id,
-                    $userId,
-                    $details['lpa']['uId'],
-                    (string)$details['actor']['details']['id']
-                );
-
-                $added = true;
-            } catch (KeyCollisionException $e) {
-                // Allows the loop to repeat with a new ID.
-            }
-        } while (!$added);
-        return $id;
     }
 
     /**

--- a/service-api/app/src/App/src/Service/ActorCodes/ActorCodeService.php
+++ b/service-api/app/src/App/src/Service/ActorCodes/ActorCodeService.php
@@ -115,7 +115,11 @@ class ActorCodeService
         if (array_key_exists($lpaId, $idToLpaMap)) {
             $id = $this->removeTTLFromRequest($idToLpaMap[$lpaId]);
         } else {
-            $id = $this->addLpaRecord($userId, $details);
+            $id = $this->userLpaActorMapRepository->create(
+                $userId,
+                $lpaId,
+                (string)$details['actor']['details']['id']
+            );
         }
 
         try {

--- a/service-api/app/src/App/src/Service/Lpa/LpaAlreadyAdded.php
+++ b/service-api/app/src/App/src/Service/Lpa/LpaAlreadyAdded.php
@@ -48,7 +48,7 @@ class LpaAlreadyAdded
         if (($this->featureEnabled)('save_older_lpa_requests')) {
             $savedLpaRecords = $this->userLpaActorMapRepository->getByUserId($userId);
 
-            foreach($savedLpaRecords as $record) {
+            foreach ($savedLpaRecords as $record) {
                 if ($record['SiriusUid'] === $lpaUid) {
                     $lpa = $this->lpaService->getByUserLpaActorToken($record['Id'], $userId);
 

--- a/service-api/app/src/App/src/Service/Lpa/LpaAlreadyAdded.php
+++ b/service-api/app/src/App/src/Service/Lpa/LpaAlreadyAdded.php
@@ -46,7 +46,7 @@ class LpaAlreadyAdded
     public function __invoke(string $userId, string $lpaUid): ?array
     {
         if (($this->featureEnabled)('save_older_lpa_requests')) {
-            $savedLpaRecords = $this->userLpaActorMapRepository->getUsersLpas($userId);
+            $savedLpaRecords = $this->userLpaActorMapRepository->getByUserId($userId);
 
             foreach($savedLpaRecords as $record) {
                 if ($record['SiriusUid'] === $lpaUid) {

--- a/service-api/app/src/App/src/Service/Lpa/LpaService.php
+++ b/service-api/app/src/App/src/Service/Lpa/LpaService.php
@@ -8,8 +8,7 @@ use App\DataAccess\Repository\{LpasInterface,
     Response\LpaInterface,
     UserLpaActorMapInterface,
     ViewerCodeActivityInterface,
-    ViewerCodesInterface
-};
+    ViewerCodesInterface};
 use App\Exception\GoneException;
 use DateTime;
 use Psr\Log\LoggerInterface;
@@ -140,7 +139,7 @@ class LpaService
     public function getAllForUser(string $userId): array
     {
         // Returns an array of all the LPAs Ids (plus other metadata) in the user's account.
-        $lpaActorMaps = $this->userLpaActorMapRepository->getUsersLpas($userId);
+        $lpaActorMaps = $this->userLpaActorMapRepository->getByUserId($userId);
 
         $lpaActorMaps = array_filter($lpaActorMaps, function ($item) {
             return !array_key_exists('ActivateBy', $item);
@@ -159,7 +158,7 @@ class LpaService
     public function getAllLpasAndRequestsForUser(string $userId): array
     {
         // Returns an array of all the LPAs Ids (plus other metadata) in the user's account.
-        $lpaActorMaps = $this->userLpaActorMapRepository->getUsersLpas($userId);
+        $lpaActorMaps = $this->userLpaActorMapRepository->getByUserId($userId);
 
         return $this->lookupAndFormatLpas($lpaActorMaps);
     }

--- a/service-api/app/src/App/src/Service/Lpa/OlderLpaService.php
+++ b/service-api/app/src/App/src/Service/Lpa/OlderLpaService.php
@@ -5,15 +5,12 @@ declare(strict_types=1);
 namespace App\Service\Lpa;
 
 use App\DataAccess\ApiGateway\ActorCodes;
-use App\DataAccess\Repository\KeyCollisionException;
 use App\DataAccess\Repository\LpasInterface;
 use App\DataAccess\Repository\UserLpaActorMapInterface;
 use App\Exception\ApiException;
 use App\Service\Features\FeatureEnabled;
 use DateTime;
-use Exception;
 use Psr\Log\LoggerInterface;
-use Ramsey\Uuid\Uuid;
 
 class OlderLpaService
 {
@@ -90,11 +87,7 @@ class OlderLpaService
     {
         $requestId = null;
         if (($this->featureEnabled)('save_older_lpa_requests')) {
-            $requestId = $this->storeLPARequest(
-                $uid,
-                $userId,
-                $actorUid
-            );
+            $this->userLpaActorMap->create($userId, $uid, $actorUid, 'P1Y');
         }
 
         $uidInt = (int)$uid;
@@ -123,27 +116,5 @@ class OlderLpaService
             }
             throw $apiException;
         }
-    }
-
-    /**
-     * Stores an Entry in UserLPAActorMap for the request of an older lpa
-     * @param string $lpaId
-     * @param string $userId
-     * @param string $actorId
-     *
-     * @return string       The lpaActorToken
-     * @throws Exception    throws an ApiException
-     */
-    public function storeLPARequest(string $lpaId, string $userId, string $actorId): string
-    {
-        do {
-            $id = Uuid::uuid4()->toString();
-            try {
-                $this->userLpaActorMap->create($id, $userId, $lpaId, $actorId, 'P1Y');
-                return $id;
-            } catch (KeyCollisionException $e) {
-                // Allows the loop to repeat with a new ID.
-            }
-        } while (true);
     }
 }

--- a/service-api/app/src/App/src/Service/Lpa/OlderLpaService.php
+++ b/service-api/app/src/App/src/Service/Lpa/OlderLpaService.php
@@ -85,9 +85,9 @@ class OlderLpaService
      */
     public function requestAccessByLetter(string $uid, string $actorUid, string $userId): void
     {
-        $requestId = null;
+        $recordId = null;
         if (($this->featureEnabled)('save_older_lpa_requests')) {
-            $this->userLpaActorMap->create($userId, $uid, $actorUid, 'P1Y');
+            $recordId = $this->userLpaActorMap->create($userId, $uid, $actorUid, 'P1Y');
         }
 
         $uidInt = (int)$uid;
@@ -111,8 +111,8 @@ class OlderLpaService
                     'lpa' => $uidInt,
                 ]
             );
-            if ($requestId !== null) {
-                $this->removeLpa($requestId);
+            if ($recordId !== null) {
+                $this->removeLpa($recordId);
             }
             throw $apiException;
         }

--- a/service-api/app/test/AppTest/DataAccess/DynamoDb/UserLpaActorMapTest.php
+++ b/service-api/app/test/AppTest/DataAccess/DynamoDb/UserLpaActorMapTest.php
@@ -384,7 +384,7 @@ class UserLpaActorMapTest extends TestCase
 
         $repo = new UserLpaActorMap($this->dynamoDbClientProphecy->reveal(), self::TABLE_NAME);
 
-        $result = $repo->getUsersLpas($testUserId);
+        $result = $repo->getByUserId($testUserId);
 
         $this->assertIsArray($result);
         $this->assertCount(1, $result);

--- a/service-api/app/test/AppTest/Service/ActorCodes/ActorCodeServiceTest.php
+++ b/service-api/app/test/AppTest/Service/ActorCodes/ActorCodeServiceTest.php
@@ -167,44 +167,7 @@ class ActorCodeServiceTest extends TestCase
 
         $service = $this->getActorCodeService();
 
-        $this->userLpaActorMapInterfaceProphecy->getUsersLpas('test-user')->willReturn([])->shouldBeCalled();
-
-        $result = $service->confirmDetails('test-code', 'test-uid', 'test-dob', 'test-user');
-    }
-
-    /** @test */
-    public function confirmation_with_vaild_details_has_key_collision(): void
-    {
-        $this->initValidParameterSet();
-
-        $this->codeValidatorProphecy->flagCodeAsUsed('test-code')
-            ->willReturn('id-of-db-row')
-            ->shouldBeCalled();
-
-        // We call the create function multiple times till it works.
-        $createCalls = 0;
-        $this->userLpaActorMapInterfaceProphecy->create(
-            Argument::that(
-                function (string $id) {
-                    $this->assertRegExp('|^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$|', $id);
-                    return true;
-                }
-            ),
-            'test-user',
-            'test-uid',
-            '1'
-        )->will(function () use (&$createCalls) {
-            if ($createCalls > 0) {
-                return;
-            }
-
-            $createCalls++;
-            throw new KeyCollisionException();
-        });
-
-        $service = $this->getActorCodeService();
-
-        $this->userLpaActorMapInterfaceProphecy->getUsersLpas('test-user')->willReturn([])->shouldBeCalled();
+        $this->userLpaActorMapInterfaceProphecy->getByUserId('test-user')->willReturn([])->shouldBeCalled();
 
         $result = $service->confirmDetails('test-code', 'test-uid', 'test-dob', 'test-user');
 

--- a/service-api/app/test/AppTest/Service/ActorCodes/ActorCodeServiceTest.php
+++ b/service-api/app/test/AppTest/Service/ActorCodes/ActorCodeServiceTest.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace AppTest\Service\Lpa;
 
-use App\DataAccess\ApiGateway\ActorCodes;
 use App\DataAccess\Repository;
-use App\DataAccess\Repository\ActorCodesInterface;
-use App\DataAccess\Repository\KeyCollisionException;
 use App\DataAccess\Repository\UserLpaActorMapInterface;
 use App\Exception\ActorCodeMarkAsUsedException;
 use App\Exception\ActorCodeValidationException;
@@ -23,29 +20,19 @@ use Psr\Log\LoggerInterface;
 
 class ActorCodeServiceTest extends TestCase
 {
-    /**
-     * @var CodeValidationStrategyInterface|ObjectProphecy
-     */
+    /** @var CodeValidationStrategyInterface|ObjectProphecy */
     private $codeValidatorProphecy;
 
-    /**
-     * @var LpaService|ObjectProphecy
-     */
+    /** @var LpaService|ObjectProphecy */
     private $lpaServiceProphecy;
 
-    /**
-     * @var UserLpaActorMapInterface|ObjectProphecy
-     */
+    /** @var UserLpaActorMapInterface|ObjectProphecy */
     private $userLpaActorMapInterfaceProphecy;
 
-    /**
-     * @var LoggerInterface|ObjectProphecy
-     */
+    /** @var LoggerInterface|ObjectProphecy */
     private $loggerProphecy;
 
-    /**
-     * @var ResolveActor|ObjectProphecy
-     */
+    /** @var ResolveActor|ObjectProphecy */
     private $resolveActorProphecy;
 
     public function setUp(): void
@@ -81,26 +68,20 @@ class ActorCodeServiceTest extends TestCase
             ->shouldBeCalled();
 
         $this->userLpaActorMapInterfaceProphecy->create(
-            Argument::that(
-                function (string $id) {
-                    $this->assertRegExp('|^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$|', $id);
-                    return true;
-                }
-            ),
             'test-user',
             'test-uid',
             '1'
-        )->shouldBeCalled();
+        )
+            ->willReturn('00000000-0000-4000-A000-000000000000')
+            ->shouldBeCalled();
 
-
-        $this->userLpaActorMapInterfaceProphecy->getUsersLpas('test-user')->willReturn([])->shouldBeCalled();
+        $this->userLpaActorMapInterfaceProphecy->getByUserId('test-user')->willReturn([])->shouldBeCalled();
 
         $service = $this->getActorCodeService();
 
         $result = $service->confirmDetails('test-code', 'test-uid', 'test-dob', 'test-user');
 
-        // We expect a uuid4 back.
-        $this->assertRegExp('|^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$|', $result);
+        $this->assertEquals('00000000-0000-4000-A000-000000000000', $result);
     }
 
     /** @test */
@@ -124,7 +105,7 @@ class ActorCodeServiceTest extends TestCase
             ]
         ];
 
-        $this->userLpaActorMapInterfaceProphecy->getUsersLpas('test-user')->willReturn($mapResults)->shouldBeCalled();
+        $this->userLpaActorMapInterfaceProphecy->getByUserId('test-user')->willReturn($mapResults)->shouldBeCalled();
 
         $service = $this->getActorCodeService();
 
@@ -143,25 +124,13 @@ class ActorCodeServiceTest extends TestCase
             ->willThrow(new ActorCodeMarkAsUsedException());
 
         $this->userLpaActorMapInterfaceProphecy->create(
-            Argument::that(
-                function (string $id) {
-                    $this->assertRegExp('|^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$|', $id);
-                    return true;
-                }
-            ),
             'test-user',
             'test-uid',
             '1'
-        )->shouldBeCalled();
+        )->willReturn('00000000-0000-4000-A000-000000000000');
 
-        $this->userLpaActorMapInterfaceProphecy->delete(
-            Argument::that(
-                function (string $id) {
-                    $this->assertRegExp('|^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$|', $id);
-                    return true;
-                }
-            )
-        )->shouldBeCalled();
+        $this->userLpaActorMapInterfaceProphecy->delete('00000000-0000-4000-A000-000000000000')
+            ->shouldBeCalled();
 
         //---
 
@@ -170,9 +139,6 @@ class ActorCodeServiceTest extends TestCase
         $this->userLpaActorMapInterfaceProphecy->getByUserId('test-user')->willReturn([])->shouldBeCalled();
 
         $result = $service->confirmDetails('test-code', 'test-uid', 'test-dob', 'test-user');
-
-        // We expect a uuid4 back.
-        $this->assertRegExp('|^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$|', $result);
     }
 
     /** @test */

--- a/service-api/app/test/AppTest/Service/Lpa/LpaAlreadyAddedTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/LpaAlreadyAddedTest.php
@@ -88,7 +88,7 @@ class LpaAlreadyAddedTest extends TestCase
         $this->featureEnabledProphecy->__invoke('save_older_lpa_requests')->willReturn(true);
 
         $this->userLpaActorMapProphecy
-            ->getUsersLpas($this->userId)
+            ->getByUserId($this->userId)
             ->willReturn([]);
 
         $lpaAddedData = ($this->getLpaAlreadyAddedService())($this->userId, '700000000321');
@@ -104,7 +104,7 @@ class LpaAlreadyAddedTest extends TestCase
         $this->featureEnabledProphecy->__invoke('save_older_lpa_requests')->willReturn(true);
 
         $this->userLpaActorMapProphecy
-            ->getUsersLpas($this->userId)
+            ->getByUserId($this->userId)
             ->willReturn(
                 [
                     [
@@ -157,7 +157,7 @@ class LpaAlreadyAddedTest extends TestCase
         $this->featureEnabledProphecy->__invoke('save_older_lpa_requests')->willReturn(true);
 
         $this->userLpaActorMapProphecy
-            ->getUsersLpas($this->userId)
+            ->getByUserId($this->userId)
             ->willReturn(
                 [
                     [
@@ -239,7 +239,7 @@ class LpaAlreadyAddedTest extends TestCase
         $this->featureEnabledProphecy->__invoke('save_older_lpa_requests')->willReturn(true);
 
         $this->userLpaActorMapProphecy
-            ->getUsersLpas($this->userId)
+            ->getByUserId($this->userId)
             ->willReturn(
                 [
                     [

--- a/service-api/app/test/AppTest/Service/Lpa/LpaServiceTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/LpaServiceTest.php
@@ -8,17 +8,13 @@ use App\DataAccess\{ApiGateway\ActorCodes,
     Repository,
     Repository\UserLpaActorMapInterface,
     Repository\ViewerCodesInterface};
-use App\DataAccess\Repository\Response\{ActorCode, Lpa};
-use App\Exception\ApiException;
-use App\Exception\BadRequestException;
-use App\Exception\NotFoundException;
+use App\DataAccess\Repository\Response\{Lpa};
 use App\Service\Lpa\GetAttorneyStatus;
 use App\Service\Lpa\IsValidLpa;
 use App\Service\Lpa\LpaService;
 use App\Service\Lpa\ResolveActor;
 use App\Service\ViewerCodes\ViewerCodeService;
 use DateTime;
-use Fig\Http\Message\StatusCodeInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
@@ -394,7 +390,7 @@ class LpaServiceTest extends TestCase
             ], new DateTime())
         ];
 
-        $this->userLpaActorMapInterfaceProphecy->getUsersLpas($t->UserId)->willReturn($t->mapResults);
+        $this->userLpaActorMapInterfaceProphecy->getByUserId($t->UserId)->willReturn($t->mapResults);
 
         $this->lpasInterfaceProphecy->lookup(['uid-1', 'uid-2'])->willReturn($t->lpaResults);
 
@@ -494,7 +490,7 @@ class LpaServiceTest extends TestCase
 
         $service = $this->getLpaService();
 
-        $this->userLpaActorMapInterfaceProphecy->getUsersLpas($t->UserId)->willReturn([]);
+        $this->userLpaActorMapInterfaceProphecy->getByUserId($t->UserId)->willReturn([]);
 
         $result = $service->getAllForUser($t->UserId);
 
@@ -544,7 +540,7 @@ class LpaServiceTest extends TestCase
             'uid-2' => $lpa2
         ];
 
-        $this->userLpaActorMapInterfaceProphecy->getUsersLpas($t->UserId)->willReturn($t->mapResults);
+        $this->userLpaActorMapInterfaceProphecy->getByUserId($t->UserId)->willReturn($t->mapResults);
 
         $this->lpasInterfaceProphecy->lookup(array_column($t->mapResults, 'SiriusUid'))->willReturn($t->lpaResults);
 
@@ -587,7 +583,7 @@ class LpaServiceTest extends TestCase
     {
         $t = $this->init_valid_get_all_users_with_linked();
 
-        $this->userLpaActorMapInterfaceProphecy->getUsersLpas($t->UserId)->willReturn($t->mapResults);
+        $this->userLpaActorMapInterfaceProphecy->getByUserId($t->UserId)->willReturn($t->mapResults);
 
         $this->lpasInterfaceProphecy->lookup(array_column($t->mapResults, 'SiriusUid'))->willReturn($t->lpaResults);
 

--- a/service-api/app/test/AppTest/Service/Lpa/OlderLpaServiceTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/OlderLpaServiceTest.php
@@ -129,6 +129,7 @@ class OlderLpaServiceTest extends TestCase
 
         $this->userLpaActorMapProphecy
             ->delete('00000000-0000-4000-A000-000000000000')
+            ->shouldBeCalled()
             ->willReturn([]);
 
         $service = $this->getOlderLpaService();

--- a/service-api/app/test/AppTest/Service/Lpa/OlderLpaServiceTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/OlderLpaServiceTest.php
@@ -4,17 +4,13 @@ namespace AppTest\Service\Lpa;
 
 use App\DataAccess\ApiGateway\ActorCodes;
 use App\DataAccess\DynamoDb\UserLpaActorMap;
-use App\DataAccess\Repository\KeyCollisionException;
 use App\DataAccess\Repository\LpasInterface;
 use App\DataAccess\Repository\Response\ActorCode;
 use App\DataAccess\Repository\UserLpaActorMapInterface;
 use App\Exception\ApiException;
-use App\Exception\BadRequestException;
 use App\Service\Features\FeatureEnabled;
-use App\Service\Lpa\AddOlderLpa;
 use App\Service\Lpa\OlderLpaService;
 use DateTime;
-use Fig\Http\Message\StatusCodeInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -85,12 +81,11 @@ class OlderLpaServiceTest extends TestCase
         $this->featureEnabledProphecy->__invoke('save_older_lpa_requests')->willReturn(true);
 
         $this->userLpaActorMapProphecy->create(
-            Argument::type('string'),
             $this->userId,
             $this->lpaUid,
             $this->actorUid,
             'P1Y'
-        )->shouldBeCalled();
+        )->willReturn('00000000-0000-4000-A000-000000000000');
 
         $service = $this->getOlderLpaService();
         $service->requestAccessByLetter($this->lpaUid, $this->actorUid, $this->userId);
@@ -106,7 +101,6 @@ class OlderLpaServiceTest extends TestCase
         $this->featureEnabledProphecy->__invoke('save_older_lpa_requests')->willReturn(false);
 
         $this->userLpaActorMapProphecy->create(
-            Argument::type('string'),
             $this->userId,
             $this->lpaUid,
             $this->actorUid,
@@ -124,21 +118,22 @@ class OlderLpaServiceTest extends TestCase
             ->requestLetter((int) $this->lpaUid, (int) $this->actorUid)
             ->willThrow(ApiException::create('bad api call'));
 
-        $service = $this->getOlderLpaService();
-
-        $this->expectException(ApiException::class);
+        $this->featureEnabledProphecy->__invoke('save_older_lpa_requests')->willReturn(true);
 
         $this->userLpaActorMapProphecy->create(
-            Argument::type('string'),
             $this->userId,
             $this->lpaUid,
             $this->actorUid,
             'P1Y'
-        )->shouldBeCalled();
+        )->willReturn('00000000-0000-4000-A000-000000000000');
 
-        $this->userLpaActorMapProphecy->delete(Argument::type('string'))->willReturn([])->shouldBeCalled();
+        $this->userLpaActorMapProphecy
+            ->delete('00000000-0000-4000-A000-000000000000')
+            ->willReturn([]);
 
-        $this->featureEnabledProphecy->__invoke('save_older_lpa_requests')->willReturn(true);
+        $service = $this->getOlderLpaService();
+
+        $this->expectException(ApiException::class);
 
         $service->requestAccessByLetter($this->lpaUid, $this->actorUid, $this->userId);
     }
@@ -209,61 +204,5 @@ class OlderLpaServiceTest extends TestCase
 
         $codeExists = $service->hasActivationCode($this->lpaUid, $this->actorUid);
         $this->assertNull($codeExists);
-    }
-
-    /**
-     * @test
-     */
-    public function older_lpa_request_is_saved_with_a_TTL()
-    {
-        $this->userLpaActorMapProphecy->create(
-            Argument::that(
-                function (string $id) {
-                    $this->assertRegExp('|^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$|', $id);
-                    return true;
-                }
-            ),
-            $this->userId,
-            $this->lpaUid,
-            $this->actorUid,
-            'P1Y'
-        )->shouldBeCalled();
-
-        $service = $this->getOlderLpaService();
-
-        $service->storeLPARequest($this->lpaUid, $this->userId, $this->actorUid);
-    }
-
-    /**
-     * @test
-     */
-    public function older_lpa_request_is_looped_until_no_id_collision()
-    {
-        $createCalls = 0;
-        $this->userLpaActorMapProphecy->create(
-            Argument::that(
-                function (string $id) {
-                    $this->assertRegExp('|^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$|', $id);
-                    return true;
-                }
-            ),
-            $this->userId,
-            $this->lpaUid,
-            $this->actorUid,
-            'P1Y'
-        )->will(
-            function () use (&$createCalls) {
-                if ($createCalls > 0) {
-                    return;
-                }
-
-                $createCalls++;
-                throw new KeyCollisionException();
-            }
-        );
-
-        $service = $this->getOlderLpaService();
-
-        $service->storeLPARequest($this->lpaUid, $this->userId, $this->actorUid);
     }
 }

--- a/service-front/app/features/bootstrap/behat.config.php
+++ b/service-front/app/features/bootstrap/behat.config.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 return [
     Laminas\ConfigAggregator\ConfigAggregator::ENABLE_CACHE => false,
+    'debug' => false,
 
     'dependencies' => [
         'factories' => [
             \Http\Adapter\Guzzle6\Client::class => \BehatTest\Http\Adapter\Guzzle6\TestClientFactory::class,
 
             \Aws\Sdk::class => \BehatTest\Common\Service\Aws\SdkFactory::class,
+
+            \Mezzio\Middleware\ErrorResponseGenerator::class => \Mezzio\Container\ErrorResponseGeneratorFactory::class,
         ],
     ],
 
@@ -123,5 +126,7 @@ return [
                 'requests_per_interval' => 4
             ]
         ]
-    ]
+    ],
+
+    'whoops' => new \Laminas\Stdlib\ArrayUtils\MergeRemoveKey()
 ];


### PR DESCRIPTION
# Purpose

As a part of the work on UML-1643 it's been necessary to refactor some of the logic around saving records into the UserActorLpaMap table. This simplifies the code that then needs to change records in this table.

Additionally some fixes have gone in to ensure that development mode files do not affect behat test runs.

## Approach

Move the loop of code  that retried UUID's down into the datamapper layer and remove that from the 2 calling services.

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* [x] I have added tests to prove my work
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~The product team have tested these changes~
