### PR TITLE
UML-1662 - Deletion protection for load balancers

### DIFF
--- a/terraform/environment/actor_load_balancer.tf
+++ b/terraform/environment/actor_load_balancer.tf
@@ -17,6 +17,8 @@ resource "aws_lb" "actor" {
   subnets                    = data.aws_subnet_ids.public.ids
   tags                       = local.default_tags
 
+  enable_deletion_protection = local.account.load_balancer_deletion_protection_enabled
+
   security_groups = [
     aws_security_group.actor_loadbalancer.id,
     aws_security_group.actor_loadbalancer_route53.id,

--- a/terraform/environment/admin_load_balancer.tf
+++ b/terraform/environment/admin_load_balancer.tf
@@ -19,6 +19,8 @@ resource "aws_lb" "admin" {
   subnets                    = data.aws_subnet_ids.public.ids
   tags                       = local.default_tags
 
+  enable_deletion_protection = local.account.load_balancer_deletion_protection_enabled
+
   security_groups = [
     aws_security_group.admin_loadbalancer[0].id,
   ]

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -41,30 +41,31 @@ variable "accounts" {
           maximum = number
         })
       })
-      build_admin                = bool
-      cookie_expires_use         = number
-      cookie_expires_view        = number
-      google_analytics_id_use    = string
-      google_analytics_id_view   = string
-      have_a_backup_plan         = bool
-      is_production              = bool
-      log_retention_in_days      = number
-      logging_level              = number
-      lpa_codes_endpoint         = string
-      lpas_collection_endpoint   = string
-      pagerduty_service_name     = string
-      session_expires_use        = number
-      session_expires_view       = number
-      session_expires_admin      = number
-      session_expiry_warning     = number
-      ship_metrics_queue_enabled = bool
-      sirius_account_id          = string
-      use_legacy_codes_service   = bool
-      use_older_lpa_journey      = bool
-      delete_lpa_feature         = bool
-      allow_older_lpas           = bool
-      allow_meris_lpas           = bool
-      save_older_lpa_requests    = bool
+      build_admin                               = bool
+      cookie_expires_use                        = number
+      cookie_expires_view                       = number
+      google_analytics_id_use                   = string
+      google_analytics_id_view                  = string
+      have_a_backup_plan                        = bool
+      is_production                             = bool
+      log_retention_in_days                     = number
+      logging_level                             = number
+      lpa_codes_endpoint                        = string
+      lpas_collection_endpoint                  = string
+      pagerduty_service_name                    = string
+      session_expires_use                       = number
+      session_expires_view                      = number
+      session_expires_admin                     = number
+      session_expiry_warning                    = number
+      ship_metrics_queue_enabled                = bool
+      sirius_account_id                         = string
+      use_legacy_codes_service                  = bool
+      use_older_lpa_journey                     = bool
+      delete_lpa_feature                        = bool
+      allow_older_lpas                          = bool
+      allow_meris_lpas                          = bool
+      save_older_lpa_requests                   = bool
+      load_balancer_deletion_protection_enabled = bool
     })
   )
 }

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -95,7 +95,7 @@
       "allow_older_lpas": false,
       "allow_meris_lpas": false,
       "save_older_lpa_requests": false,
-      "load_balancer_deletion_protection_enabled": false
+      "load_balancer_deletion_protection_enabled": true
     },
     "production": {
       "account_id": "690083044361",

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -48,7 +48,8 @@
       "delete_lpa_feature": true,
       "allow_older_lpas": true,
       "allow_meris_lpas": false,
-      "save_older_lpa_requests": true
+      "save_older_lpa_requests": true,
+      "load_balancer_deletion_protection_enabled": false
     },
     "preproduction": {
       "account_id": "888228022356",
@@ -93,7 +94,8 @@
       "delete_lpa_feature": true,
       "allow_older_lpas": false,
       "allow_meris_lpas": false,
-      "save_older_lpa_requests": false
+      "save_older_lpa_requests": false,
+      "load_balancer_deletion_protection_enabled": false
     },
     "production": {
       "account_id": "690083044361",
@@ -138,7 +140,8 @@
       "delete_lpa_feature": false,
       "allow_older_lpas": false,
       "allow_meris_lpas": false,
-      "save_older_lpa_requests": false
+      "save_older_lpa_requests": false,
+      "load_balancer_deletion_protection_enabled": true
     }
   }
 }

--- a/terraform/environment/viewer_load_balancer.tf
+++ b/terraform/environment/viewer_load_balancer.tf
@@ -17,6 +17,8 @@ resource "aws_lb" "viewer" {
   subnets                    = data.aws_subnet_ids.public.ids
   tags                       = local.default_tags
 
+  enable_deletion_protection = local.account.load_balancer_deletion_protection_enabled
+
   security_groups = [
     aws_security_group.viewer_loadbalancer.id,
     aws_security_group.viewer_loadbalancer_route53.id,


### PR DESCRIPTION
# Purpose

[ELB.6] Application Load Balancer deletion protection should be enabled

Fixes UML-1662

## Approach
- enable protection on production
- disable protection on development and preproduction environments

For testing, AWS Security Hub checks for deletion protection in preproduction and production

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added tests to prove my work
* [x] The product team have tested these changes
