### PR TITLE
UML-1750 Check answers warning

### DIFF
--- a/service-front/app/features/actor-add-an-older-lpa.feature
+++ b/service-front/app/features/actor-add-an-older-lpa.feature
@@ -111,6 +111,18 @@ Feature: Add an older LPA
     Then I am taken back to the start of the "request an activation key" process
 
   @ui @ff:allow_older_lpas:true
+  Scenario: The user is not shown a warning on the check answers page if allow older lpas flag is on
+    Given I am on the add an older LPA page
+    When I provide the details from a valid paper document
+    Then I am not shown a warning that my details must match the information on record
+
+  @ui @ff:allow_older_lpas:false
+  Scenario: The user is shown warning on the check answers page if allow older lpas flag is on
+    Given I am on the add an older LPA page
+    When I provide the details from a valid paper document
+    Then I am shown a warning that my details must match the information on record
+
+  @ui @ff:allow_older_lpas:true
   Scenario: The user can add an older LPA to their account
     Given I am on the add an older LPA page
     When I provide the details from a valid paper document

--- a/service-front/app/features/actor-add-an-older-lpa.feature
+++ b/service-front/app/features/actor-add-an-older-lpa.feature
@@ -117,7 +117,7 @@ Feature: Add an older LPA
     Then I am not shown a warning that my details must match the information on record
 
   @ui @ff:allow_older_lpas:false
-  Scenario: The user is shown warning on the check answers page if allow older lpas flag is on
+  Scenario: The user is shown a warning on the check answers page if allow older lpas flag is on
     Given I am on the add an older LPA page
     When I provide the details from a valid paper document
     Then I am shown a warning that my details must match the information on record

--- a/service-front/app/features/context/UI/RequestActivationKeyContext.php
+++ b/service-front/app/features/context/UI/RequestActivationKeyContext.php
@@ -118,6 +118,16 @@ class RequestActivationKeyContext implements Context
     }
 
     /**
+     * @Then /^I am not shown a warning that my details must match the information on record$/
+     */
+    public function iAmNotShownAWarningThatMyDetailsMustMatchTheInformationOnRecord()
+    {
+        $this->ui->assertPageNotContainsText(
+            'These details must match the information we have about you on our records.'
+        );
+    }
+
+    /**
      * @Given /^I am on the ask for your date of birth page$/
      */
     public function iAmOnTheAskForYourDateOfBirth()
@@ -170,6 +180,16 @@ class RequestActivationKeyContext implements Context
     public function iAmRedirectedToTheActivationKeyPage()
     {
         $this->ui->assertPageAddress('lpa/request-code/lpa-reference-number');
+    }
+
+    /**
+     * @Then /^I am shown a warning that my details must match the information on record$/
+     */
+    public function iAmShownAWarningThatMyDetailsMustMatchTheInformationOnRecord()
+    {
+        $this->ui->assertPageContainsText(
+            'These details must match the information we have about you on our records.'
+        );
     }
 
     /**

--- a/service-front/app/src/Actor/templates/actor/check-your-answers.html.twig
+++ b/service-front/app/src/Actor/templates/actor/check-your-answers.html.twig
@@ -72,13 +72,15 @@
                         </div>
                     </dl>
 
-                    <div class="govuk-warning-text">
-                        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                        <strong class="govuk-warning-text__text">
-                            <span class="govuk-warning-text__assistive">{% trans %}Warning{% endtrans %}</span>
-                            {% trans %}These details must match the information we have about you on our records.{% endtrans %}
-                        </strong>
-                    </div>
+                    {% if not feature_enabled('allow_older_lpas') %}
+                        <div class="govuk-warning-text">
+                            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                            <strong class="govuk-warning-text__text">
+                                <span class="govuk-warning-text__assistive">{% trans %}Warning{% endtrans %}</span>
+                                {% trans %}These details must match the information we have about you on our records.{% endtrans %}
+                            </strong>
+                        </div>
+                    {% endif %}
 
                     {{ govuk_form_open(form) }}
 


### PR DESCRIPTION
# Purpose

Only displays warning when allow_older_lpa flag is OFF

Fixes UML-1750

## Approach

Wrapped content in twig file in an feature flag check and added 2 ui tests

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
