### PR TITLE
UML-1770 - workspace cleanup table management

### DIFF
--- a/terraform/account/workspace_cleanup.tf
+++ b/terraform/account/workspace_cleanup.tf
@@ -8,6 +8,10 @@ resource "aws_dynamodb_table" "workspace_cleanup_table" {
     name = "WorkspaceName"
     type = "S"
   }
+  ttl {
+    attribute_name = "ExpiresTTL"
+    enabled        = true
+  }
 
   tags = local.default_tags
 

--- a/terraform/account/workspace_cleanup.tf
+++ b/terraform/account/workspace_cleanup.tf
@@ -1,17 +1,17 @@
-# resource "aws_dynamodb_table" "workspace_cleanup_table" {
-#   count        = local.account_name == "development" ? 1 : 0
-#   name         = "WorkspaceCleanup"
-#   billing_mode = "PAY_PER_REQUEST"
-#   hash_key     = "WorkspaceName"
+resource "aws_dynamodb_table" "workspace_cleanup_table" {
+  count        = local.account_name == "development" ? 1 : 0
+  name         = "WorkspaceCleanup"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "WorkspaceName"
 
-#   attribute {
-#     name = "WorkspaceName"
-#     type = "S"
-#   }
+  attribute {
+    name = "WorkspaceName"
+    type = "S"
+  }
 
-#   tags = local.default_tags
+  tags = local.default_tags
 
-#   lifecycle {
-#     prevent_destroy = false
-#   }
-# }
+  lifecycle {
+    prevent_destroy = true
+  }
+}


### PR DESCRIPTION
# Purpose

Take control of workspace cleanup table and address securityhub findings

Fixes UML-1770

## Approach

- Manage workspace cleanup table with terraform
- prevent destroy on table
- set billing mode to pay per request
- suppress Security Hub check for point in time restore (not required for this table)

This change requires a terraform import before merging

```
tf import aws_dynamodb_table.workspace_cleanup_table WorkspaceCleanup
```
## Checklist

* [x] I have performed a self-review of my own code