### PR TITLE
UML-1780 UML-1781 - Set tracing config to Active

### DIFF
--- a/terraform/account/modules/lambda_function/iam.tf
+++ b/terraform/account/modules/lambda_function/iam.tf
@@ -66,3 +66,8 @@ resource "aws_iam_role_policy_attachment" "vpc_access_execution_role" {
   role       = aws_iam_role.lambda_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
+
+resource "aws_iam_role_policy_attachment" "xray_write_execution_role" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+}

--- a/terraform/account/modules/lambda_function/main.tf
+++ b/terraform/account/modules/lambda_function/main.tf
@@ -11,6 +11,10 @@ resource "aws_lambda_function" "lambda_function" {
     working_directory = var.working_directory
   }
 
+  tracing_config {
+    mode = "Active"
+  }
+
   dynamic "environment" {
     for_each = length(keys(var.environment_variables)) == 0 ? [] : [true]
     content {


### PR DESCRIPTION
# Purpose

Without full tracing enabled, it is difficult to trace the flow of logs

Fixes UML-1780 UML-1781

## Approach

- Set tracing config to Active in lambda function tf module
- add xray write policy to lambda execution role

## Learning

  - https://tfsec.dev/docs/aws/lambda/enable-tracing#aws/lambda 
  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#mode 

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] The product team have tested these changes
