### PR TITLE
UML-1778 UML-1779 - add description for security groups

### DIFF
--- a/terraform/account/elasticache.tf
+++ b/terraform/account/elasticache.tf
@@ -1,7 +1,8 @@
 resource "aws_security_group" "brute_force_cache_service" {
-  name   = "brute-force-cache-service"
-  vpc_id = aws_default_vpc.default.id
-  tags   = local.default_tags
+  name        = "brute-force-cache-service"
+  description = "brute force cache sg"
+  vpc_id      = aws_default_vpc.default.id
+  tags        = local.default_tags
 }
 
 resource "aws_elasticache_subnet_group" "private_subnets" {

--- a/terraform/account/vpc_endpoints.tf
+++ b/terraform/account/vpc_endpoints.tf
@@ -1,9 +1,10 @@
 data "aws_region" "current" {}
 
 resource "aws_security_group" "vpc_endpoints_private" {
-  name   = "vpc-endpoint-access-private-subnets-${data.aws_region.current.name}"
-  vpc_id = aws_default_vpc.default.id
-  tags   = { Name = "vpc-endpoint-access-private-subnets-${data.aws_region.current.name}" }
+  name        = "vpc-endpoint-access-private-subnets-${data.aws_region.current.name}"
+  description = "vpc endpoint private sg"
+  vpc_id      = aws_default_vpc.default.id
+  tags        = { Name = "vpc-endpoint-access-private-subnets-${data.aws_region.current.name}" }
 }
 
 resource "aws_security_group_rule" "vpc_endpoints_private_subnet_ingress" {


### PR DESCRIPTION
# Purpose

Descriptions provide context for the firewall rule reasons

Fixes UML-1778 UML-1779

## Approach

- Add descriptions for all security groups

## Learning

https://tfsec.dev/docs/aws/vpc/add-description-to-security-group#aws/vpc 
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule
https://www.cloudconformity.com/knowledge-base/aws/EC2/security-group-rules-description.html

## Checklist

* [x] I have performed a self-review of my own code