### PR TITLE
UML-1783 UML-1785 UML-1786 UML-1787 - Cloudwatch Log Group Encryption

### DIFF
--- a/terraform/account/.envrc
+++ b/terraform/account/.envrc
@@ -1,4 +1,4 @@
-export TF_VAR_default_role=breakglass
+export TF_VAR_default_role=operator
 export TF_CLI_ARGS_init="-backend-config=role_arn=arn:aws:iam::311462405659:role/operator -upgrade=true -reconfigure"
 export TF_WORKSPACE=development
 export TF_VAR_pagerduty_token=$(aws-vault exec ual-dev -- aws secretsmanager get-secret-value --secret-id pagerduty_api_key | jq -r .'SecretString')

--- a/terraform/account/.envrc
+++ b/terraform/account/.envrc
@@ -1,4 +1,4 @@
-export TF_VAR_default_role=operator
+export TF_VAR_default_role=breakglass
 export TF_CLI_ARGS_init="-backend-config=role_arn=arn:aws:iam::311462405659:role/operator -upgrade=true -reconfigure"
 export TF_WORKSPACE=development
 export TF_VAR_pagerduty_token=$(aws-vault exec ual-dev -- aws secretsmanager get-secret-value --secret-id pagerduty_api_key | jq -r .'SecretString')

--- a/terraform/account/.terraform.lock.hcl
+++ b/terraform/account/.terraform.lock.hcl
@@ -2,21 +2,21 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.58.0"
+  version     = "3.61.0"
   constraints = "~> 3.0"
   hashes = [
-    "h1:kx8p0xV/mGa+7vnGOk02AenU/ZKxF08yT/0jynZgSQI=",
-    "zh:47118f7a69c8962d74ff67be3c13cac76ba99c900941eed4750c347252a0986d",
-    "zh:4f3322399bef25cdf43e62a00248d991c5e1ef9d744e9b7cd2f8c398bb60bef3",
-    "zh:55c2223b32f2f114ce5a0ccadbf1ffb8a892bb3862365a0dc4c8ea1248ff1814",
-    "zh:5a79cfdfde4c132544173fde8d8672659fd6e1bebdacdac856f103915238b1e4",
-    "zh:67fbddb0c184c25283fa66d4299b458079a3ed2d82189dc3338fda796b6be14c",
-    "zh:78ad660c2b965e5817c06aadf267d311e2320e7f6d3faad8061c1e29ef4b60ef",
-    "zh:a20eace4dbb0fb168f6152599b7ce75a9cf419c85f9ae26d8463baf14abe7ddc",
-    "zh:a31a99c9b924d98e9a5bf173ee8fe3aee73c9a92cd63b2b10c6f350d8b5c5e49",
-    "zh:a9210d9b0b65324bbf712318044e89f959a2f9aaff6f69c0a91bb294aff7101e",
-    "zh:aa885bc6647d218c8b73fcfe33cfee20c11d88078655aa1e194b013fde17a204",
-    "zh:c5a5122e5dcb1c9e9d8fde2c994bab7ba08d63904cabff61129e139cbf97332f",
+    "h1:fpZ14qQnn+uEOO2ZOlBFHgty48Ol8IOwd+ewxZ4z3zc=",
+    "zh:0483ca802ddb0ae4f73144b4357ba72242c6e2641aeb460b1aa9a6f6965464b0",
+    "zh:274712214ebeb0c1269cbc468e5705bb5741dc45b05c05e9793ca97f22a1baa1",
+    "zh:3c6bd97a2ca809469ae38f6893348386c476cb3065b120b785353c1507401adf",
+    "zh:53dd41a9aed9860adbbeeb71a23e4f8195c656fd15a02c90fa2d302a5f577d8c",
+    "zh:65c639c547b97bc880fd83e65511c0f4bbfc91b63cada3b8c0d5776444221700",
+    "zh:a2769e19137ff480c1dd3e4f248e832df90fb6930a22c66264d9793895161714",
+    "zh:a5897a99332cc0071e46a71359b86a8e53ab09c1453e94cd7cf45a0b577ff590",
+    "zh:bdc2353642d16d8e2437a9015cd4216a1772be9736645cc17d1a197480e2b5b7",
+    "zh:cbeace1deae938f6c0aca3734e6088f3633ca09611aff701c15cb6d42f2b918a",
+    "zh:d33ca19012aabd98cc03fdeccd0bd5ce56e28f61a1dfbb2eea88e89487de7fb3",
+    "zh:d548b29a864b0687e85e8a993f208e25e3ecc40fcc5b671e1985754b32fdd658",
   ]
 }
 

--- a/terraform/account/cloudwatch.tf
+++ b/terraform/account/cloudwatch.tf
@@ -1,6 +1,9 @@
+data "aws_caller_identity" "current" {}
+
 resource "aws_cloudwatch_log_group" "use-an-lpa" {
   name              = "use-an-lpa"
   retention_in_days = local.account.retention_in_days
+  kms_key_id        = aws_kms_key.cloudwatch.arn
 
   tags = merge(
     local.default_tags,
@@ -8,4 +11,81 @@ resource "aws_cloudwatch_log_group" "use-an-lpa" {
       "Name" = "use-an-lpa"
     },
   )
+}
+
+resource "aws_kms_key" "cloudwatch" {
+  description             = "Cloudwatch encryption ${local.environment}"
+  deletion_window_in_days = 10
+  policy                  = data.aws_iam_policy_document.cloudwatch_kms.json
+}
+
+resource "aws_kms_alias" "cloudwatch_alias" {
+  name          = "alias/cloudwatch_encryption"
+  target_key_id = aws_kms_key.cloudwatch.key_id
+}
+
+# See the following link for further information
+# https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html
+data "aws_iam_policy_document" "cloudwatch_kms" {
+  statement {
+    sid       = "Enable Root account permissions on Key"
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
+      ]
+    }
+  }
+
+  statement {
+    sid       = "Allow Key to be used for Encryption"
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "logs.${data.aws_region.current.name}.amazonaws.com",
+        "events.amazonaws.com"
+      ]
+    }
+  }
+
+  statement {
+    sid       = "Key Administrator"
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion"
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/breakglass"]
+    }
+  }
 }

--- a/terraform/account/lambda_functions.tf
+++ b/terraform/account/lambda_functions.tf
@@ -19,10 +19,11 @@ module "clsf_to_sqs" {
     "METRIC_SUBCATEGORY" : "service",
     "METRIC_ENVIRONMENT" : local.environment
   }
-  image_uri                   = "${data.aws_ecr_repository.clsf_to_sqs.repository_url}:${var.lambda_container_version}"
-  ecr_arn                     = data.aws_ecr_repository.clsf_to_sqs.arn
-  lambda_role_policy_document = data.aws_iam_policy_document.clsf_to_sqs_lambda_function_policy[0].json
-  tags                        = local.default_tags
+  image_uri                           = "${data.aws_ecr_repository.clsf_to_sqs.repository_url}:${var.lambda_container_version}"
+  ecr_arn                             = data.aws_ecr_repository.clsf_to_sqs.arn
+  lambda_role_policy_document         = data.aws_iam_policy_document.clsf_to_sqs_lambda_function_policy[0].json
+  aws_cloudwatch_log_group_kms_key_id = aws_kms_key.cloudwatch.arn
+  tags                                = local.default_tags
 }
 
 data "aws_secretsmanager_secret_version" "opg_metrics_api_key" {
@@ -61,10 +62,11 @@ module "ship_to_opg_metrics" {
     "OPG_METRICS_URL" : local.account.opg_metrics.endpoint_url
     "API_KEY" : data.aws_secretsmanager_secret_version.opg_metrics_api_key[0].secret_string
   }
-  image_uri                   = "${data.aws_ecr_repository.ship_to_opg_metrics.repository_url}:${var.lambda_container_version}"
-  ecr_arn                     = data.aws_ecr_repository.ship_to_opg_metrics.arn
-  lambda_role_policy_document = data.aws_iam_policy_document.ship_to_opg_metrics_lambda_function_policy[0].json
-  tags                        = local.default_tags
+  image_uri                           = "${data.aws_ecr_repository.ship_to_opg_metrics.repository_url}:${var.lambda_container_version}"
+  ecr_arn                             = data.aws_ecr_repository.ship_to_opg_metrics.arn
+  lambda_role_policy_document         = data.aws_iam_policy_document.ship_to_opg_metrics_lambda_function_policy[0].json
+  aws_cloudwatch_log_group_kms_key_id = aws_kms_key.cloudwatch.arn
+  tags                                = local.default_tags
 }
 
 data "aws_iam_policy_document" "ship_to_opg_metrics_lambda_function_policy" {

--- a/terraform/account/modules/lambda_function/main.tf
+++ b/terraform/account/modules/lambda_function/main.tf
@@ -21,6 +21,7 @@ resource "aws_lambda_function" "lambda_function" {
 }
 
 resource "aws_cloudwatch_log_group" "lambda_function" {
-  name = "/aws/lambda/${var.lambda_name}"
-  tags = var.tags
+  name       = "/aws/lambda/${var.lambda_name}"
+  kms_key_id = var.aws_cloudwatch_log_group_kms_key_id
+  tags       = var.tags
 }

--- a/terraform/account/modules/lambda_function/variables.tf
+++ b/terraform/account/modules/lambda_function/variables.tf
@@ -67,3 +67,8 @@ variable "working_directory" {
   type        = string
   default     = null
 }
+
+variable "aws_cloudwatch_log_group_kms_key_id" {
+  type        = string
+  description = "The ARN of the KMS Key to use when encrypting log data."
+}

--- a/terraform/account/vpc_flowlogs.tf
+++ b/terraform/account/vpc_flowlogs.tf
@@ -6,8 +6,9 @@ resource "aws_flow_log" "vpc_flow_logs" {
 }
 
 resource "aws_cloudwatch_log_group" "vpc_flow_logs" {
-  name = "vpc_flow_logs"
-  tags = local.default_tags
+  name       = "vpc_flow_logs"
+  kms_key_id = aws_kms_key.cloudwatch.arn
+  tags       = local.default_tags
 }
 
 resource "aws_iam_role" "vpc_flow_logs" {


### PR DESCRIPTION
# Purpose

Log data may be leaked if the logs are compromised. No auditing of who have viewed the logs.

Fixes UML-1783 UML-1785 UML-1786 UML-1787

## Approach

- create kms key with permissions for cloudwatch log group encryption
- user kms key for log groups
- pass kms key for log group encryption into lambda function module

## Learning

  - https://tfsec.dev/docs/aws/cloudwatch/log-group-customer-key#aws/cloudwatch 
  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#kms_key_id 
  - https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html 

## Checklist

* [ ] I have performed a self-review of my own code