### PR TITLE
UML-1728 - Upgrade CircleCI executor images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -496,7 +496,7 @@ orbs:
         steps:
           - run:
               name: Install AWS CLI
-              command: sudo pip3 install awscli --upgrade
+              command: sudo pip install awscli --upgrade
       install_python:
         steps:
           - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -560,14 +560,14 @@ orbs:
         resource_class: small
       php:
         docker:
-          - image: circleci/php:7-cli
+          - image: cimg/php:7.4
             auth:
               username: $DOCKER_USER
               password: $DOCKER_ACCESS_TOKEN
         resource_class: small
       php-browsers:
         docker:
-          - image: circleci/php:7-cli-browsers
+          - image: cimg/php:7.4-browsers
             auth:
               username: $DOCKER_USER
               password: $DOCKER_ACCESS_TOKEN
@@ -581,7 +581,7 @@ orbs:
         resource_class: small
       python:
         docker:
-          - image: circleci/python
+          - image: cimg/python:3.7
             auth:
               username: $DOCKER_USER
               password: $DOCKER_ACCESS_TOKEN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1277,7 +1277,7 @@ orbs:
           - run:
               name: Seed DynamoDB
               command: |
-                sudo pip3 install -r service-api/seeding/requirements.txt
+                pip install -r service-api/seeding/requirements.txt
                 export AWS_ACCOUNT_ID=$(cat /tmp/cluster_config.json | jq .account_id | xargs)
                 export DYNAMODB_TABLE_ACTOR_CODES=$(cat /tmp/cluster_config.json | jq .actor_lpa_codes_table | xargs)
                 export DYNAMODB_TABLE_VIEWER_CODES=$(cat /tmp/cluster_config.json | jq .viewer_codes_table | xargs)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -491,6 +491,7 @@ orbs:
   use-my-lpa:
     orbs:
       docker: circleci/docker@1.4.0
+      browser-tools: circleci/browser-tools@1.2.2
     commands:
       install_aws_cli:
         steps:
@@ -1298,6 +1299,12 @@ orbs:
         steps:
           - checkout
           - install_python
+          - browser-tools/install-chrome
+          - browser-tools/install-chromedriver
+          - run:
+              command: |
+                google-chrome --version
+                chromedriver --version
           - attach_workspace:
               at: /tmp
           - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -496,7 +496,7 @@ orbs:
         steps:
           - run:
               name: Install AWS CLI
-              command: sudo pip install awscli --upgrade
+              command: pip install awscli --upgrade
       install_python:
         steps:
           - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -546,7 +546,7 @@ orbs:
     executors:
       golang:
         docker:
-          - image: circleci/golang:1.16
+          - image: cimg/go:1.16
             auth:
               username: $DOCKER_USER
               password: $DOCKER_ACCESS_TOKEN
@@ -574,7 +574,7 @@ orbs:
         resource_class: small
       node-browsers:
         docker:
-          - image: circleci/node:14.15.5-browsers
+          - image: cimg/node:14.18-browsers
             auth:
               username: $DOCKER_USER
               password: $DOCKER_ACCESS_TOKEN


### PR DESCRIPTION
# Purpose

fromCircleCI
```
Our new convenience images were built from the ground up with CI, efficiency, and determinism in mind. Here are some of the highlights:

    Faster spin-up time - In Docker terminology, these next-gen images will generally have fewer and smaller layers. Using these new images will lead to faster image downloads when a build starts, and a higher likelihood that the image is already cached on the host.

    Improved reliability & stability - The current images are rebuilt practically every day with potential changes from upstream that we can’t always test fast enough. This leads to frequent breaking changes, which is not the best environment for stable, deterministic builds. Next-gen images will only be rebuilt for security and critical-bugs, leading to more stable and deterministic images.
```

Fixes UML-1728

## Approach

- use cimg/go:1.16
- use cimg/node:14.18-browsers
- use cimg/php:7.4-browsers
- use cimg/php:7.4
- use cimg/python:3.7
- use circleci/browser-tools@1.2.2  to install chrome and chrome driver to behat testing

## Learning

https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/
https://circleci.com/developer/images/image/cimg/python
https://circleci.com/developer/orbs/orb/circleci/browser-tools


## Checklist

* [x] I have performed a self-review of my own code