### PR TITLE
UML-1788-Clear session values in check answers handler

### DIFF
--- a/service-front/app/src/Actor/src/Handler/RequestActivationKey/CheckYourAnswersHandler.php
+++ b/service-front/app/src/Actor/src/Handler/RequestActivationKey/CheckYourAnswersHandler.php
@@ -131,6 +131,13 @@ class CheckYourAnswersHandler extends AbstractHandler implements UserAware, Csrf
 
     public function handlePost(ServerRequestInterface $request): ResponseInterface
     {
+        $this->session->unset('actor_role');
+        $this->session->unset('donor_first_names');
+        $this->session->unset('donor_last_name');
+        $this->session->unset('donor_dob');
+        $this->session->unset('telephone_option');
+        $this->session->unset('lpa_full_match_but_not_cleansed');
+
         $this->form->setData($request->getParsedBody());
         if ($this->form->isValid()) {
             $result = $this->addOlderLpa->validate(


### PR DESCRIPTION
# Purpose

We need to unset any session values that are set in the "full match" or "partial match" part of the the journey. These values are used in logic statements to map which journey the user has come from or decide whether the LPA should be send to be cleansed. If these values are not cleared from the session on each request, incorrect behaviour will occur as session values will still be present from the previous request.

Fixes UML-1788

## Approach

Hard-coded the session value to unset the check answers handler

## Checklist

* [x] I have performed a self-review of my own code
* [ ] The product team have tested these changes
