### PR TITLE
UML-1778 - Fix - Create security groups before destroying them

### DIFF
--- a/terraform/account/elasticache.tf
+++ b/terraform/account/elasticache.tf
@@ -1,8 +1,11 @@
 resource "aws_security_group" "brute_force_cache_service" {
-  name        = "brute-force-cache-service"
+  name_prefix = "brute-force-cache-service"
   description = "brute force cache sg"
   vpc_id      = aws_default_vpc.default.id
   tags        = local.default_tags
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_elasticache_subnet_group" "private_subnets" {

--- a/terraform/account/vpc_endpoints.tf
+++ b/terraform/account/vpc_endpoints.tf
@@ -1,10 +1,13 @@
 data "aws_region" "current" {}
 
 resource "aws_security_group" "vpc_endpoints_private" {
-  name        = "vpc-endpoint-access-private-subnets-${data.aws_region.current.name}"
+  name_prefix = "vpc-endpoint-access-private-subnets-${data.aws_region.current.name}"
   description = "vpc endpoint private sg"
   vpc_id      = aws_default_vpc.default.id
   tags        = { Name = "vpc-endpoint-access-private-subnets-${data.aws_region.current.name}" }
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "vpc_endpoints_private_subnet_ingress" {

--- a/terraform/environment/shared_data_sources.tf
+++ b/terraform/environment/shared_data_sources.tf
@@ -101,7 +101,10 @@ data "aws_ip_ranges" "route53_healthchecks" {
 }
 
 data "aws_security_group" "brute_force_cache_service" {
-  name = "brute-force-cache-service"
+  filter {
+    name   = "group-name"
+    values = ["brute-force-cache-service*"]
+  }
 }
 
 data "aws_elasticache_replication_group" "brute_force_cache_replication_group" {


### PR DESCRIPTION
# Purpose

Path to live cannot complete because it cannot destroy security groups in use

Fixes UML-1778

## Approach

- use create_before_destroy lifecycle on security groups

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] The product team have tested these changes
