### PR TITLE
UML-1777 - allow execution_role to decrypt secrets manager secrets

### DIFF
--- a/terraform/environment/ecs_cluster.tf
+++ b/terraform/environment/ecs_cluster.tf
@@ -73,7 +73,10 @@ data "aws_iam_policy_document" "execution_role" {
 
     actions = [
       "kms:Decrypt",
-      "kms:GenerateDataKey*",
+      "kms:GenerateDataKey",
+      "kms:GenerateDataKeyPair",
+      "kms:GenerateDataKeyPairWithoutPlaintext",
+      "kms:GenerateDataKeyWithoutPlaintext",
       "kms:DescribeKey",
     ]
   }

--- a/terraform/environment/ecs_cluster.tf
+++ b/terraform/environment/ecs_cluster.tf
@@ -66,4 +66,15 @@ data "aws_iam_policy_document" "execution_role" {
       "secretsmanager:GetSecretValue",
     ]
   }
+  statement {
+    effect = "Allow"
+
+    resources = [data.aws_kms_alias.secrets_manager.target_key_arn]
+
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+    ]
+  }
 }

--- a/terraform/environment/shared_data_sources.tf
+++ b/terraform/environment/shared_data_sources.tf
@@ -54,6 +54,10 @@ data "aws_kms_alias" "sessions_actor" {
   name = "alias/sessions-actor"
 }
 
+data "aws_kms_alias" "secrets_manager" {
+  name = "alias/secrets_manager_encryption"
+}
+
 //--------------------
 // ECR Repos
 


### PR DESCRIPTION
# Purpose

Deployment triggered access denied alerts

Fixes UML-1777

## Approach

Add decrypt permission for execution role

## Checklist

* [x] I have performed a self-review of my own code