### PR TITLE
UML-1854 clear session values

### DIFF
--- a/service-front/app/src/Actor/src/Handler/RequestActivationKey/CheckDetailsAndConsentHandler.php
+++ b/service-front/app/src/Actor/src/Handler/RequestActivationKey/CheckDetailsAndConsentHandler.php
@@ -132,7 +132,6 @@ class CheckDetailsAndConsentHandler extends AbstractHandler implements UserAware
     {
         $this->form->setData($request->getParsedBody());
         if ($this->form->isValid()) {
-
             $this->data['first_names'] = $this->session->get('first_names');
             $this->data['last_name'] = $this->session->get('last_name');
             $this->data['dob'] = Carbon::create(

--- a/service-front/app/src/Actor/src/Handler/RequestActivationKey/CheckYourAnswersHandler.php
+++ b/service-front/app/src/Actor/src/Handler/RequestActivationKey/CheckYourAnswersHandler.php
@@ -23,6 +23,7 @@ use Common\Service\Features\FeatureEnabled;
 use Common\Service\Lpa\AddOlderLpa;
 use Common\Service\Lpa\LocalisedDate;
 use Common\Service\Lpa\OlderLpaApiResponse;
+use Common\Service\Session\RemoveAccessForAllSessionValues;
 use Laminas\Diactoros\Response\HtmlResponse;
 use Mezzio\Authentication\{AuthenticationInterface, UserInterface};
 use Mezzio\Helper\UrlHelper;
@@ -45,6 +46,7 @@ class CheckYourAnswersHandler extends AbstractHandler implements UserAware, Csrf
 
     private AddOlderLpa $addOlderLpa;
     private CheckYourAnswers $form;
+    private RemoveAccessForAllSessionValues $removeAccessForAllSessionValues;
     private ?SessionInterface $session;
     private ?UserInterface $user;
     private array $data;
@@ -65,7 +67,8 @@ class CheckYourAnswersHandler extends AbstractHandler implements UserAware, Csrf
         LoggerInterface $logger,
         EmailClient $emailClient,
         LocalisedDate $localisedDate,
-        FeatureEnabled $featureEnabled
+        FeatureEnabled $featureEnabled,
+        RemoveAccessForAllSessionValues $removeAccessForAllSessionValues
     ) {
         parent::__construct($renderer, $urlHelper, $logger);
 
@@ -74,6 +77,7 @@ class CheckYourAnswersHandler extends AbstractHandler implements UserAware, Csrf
         $this->emailClient = $emailClient;
         $this->localisedDate = $localisedDate;
         $this->featureEnabled = $featureEnabled;
+        $this->removeAccessForAllSessionValues = $removeAccessForAllSessionValues;
     }
 
     /**
@@ -132,13 +136,7 @@ class CheckYourAnswersHandler extends AbstractHandler implements UserAware, Csrf
 
     public function handlePost(ServerRequestInterface $request): ResponseInterface
     {
-        $this->session->unset('actor_id');
-        $this->session->unset('actor_role');
-        $this->session->unset('donor_first_names');
-        $this->session->unset('donor_last_name');
-        $this->session->unset('donor_dob');
-        $this->session->unset('telephone_option');
-        $this->session->unset('lpa_full_match_but_not_cleansed');
+        $this->removeAccessForAllSessionValues->removePostCheckAnswersSessionValues($this->session);
 
         $this->form->setData($request->getParsedBody());
         if ($this->form->isValid()) {

--- a/service-front/app/src/Actor/src/Handler/RequestActivationKey/CheckYourAnswersHandler.php
+++ b/service-front/app/src/Actor/src/Handler/RequestActivationKey/CheckYourAnswersHandler.php
@@ -136,7 +136,7 @@ class CheckYourAnswersHandler extends AbstractHandler implements UserAware, Csrf
 
     public function handlePost(ServerRequestInterface $request): ResponseInterface
     {
-        $this->removeAccessForAllSessionValues->removePostCheckAnswersSessionValues($this->session);
+        $this->removeAccessForAllSessionValues->removePostLPAMatchSessionValues($this->session);
 
         $this->form->setData($request->getParsedBody());
         if ($this->form->isValid()) {

--- a/service-front/app/src/Actor/src/Handler/RequestActivationKey/RequestActivationKeyInfoHandler.php
+++ b/service-front/app/src/Actor/src/Handler/RequestActivationKey/RequestActivationKeyInfoHandler.php
@@ -41,7 +41,6 @@ class RequestActivationKeyInfoHandler extends AbstractHandler implements UserAwa
 
         $this->setAuthenticator($authenticator);
         $this->featureEnabled = $featureEnabled;
-        $this->removeAccessForAllSessionValues = $removeAccessForAllSessionValues;
     }
 
     /**
@@ -51,7 +50,6 @@ class RequestActivationKeyInfoHandler extends AbstractHandler implements UserAwa
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $session = $this->getSession($request, 'session');
-        $this->removeAccessForAllSessionValues->cleanAccessForAllSessionValues($session);
         $user = $this->getUser($request);
         if (($this->featureEnabled)('allow_older_lpas')) {
             return new HtmlResponse($this->renderer->render('actor::before-requesting-activation-key-info', [

--- a/service-front/app/src/Actor/templates/actor/activation-key-request-received.html.twig
+++ b/service-front/app/src/Actor/templates/actor/activation-key-request-received.html.twig
@@ -34,7 +34,7 @@
                     <h2 class="govuk-heading-l">{% trans %}Have more than one LPA?{% endtrans %}</h2>
                     <p class="govuk-body">{% trans %}You'll need an activation key for each LPA that you'd like to add to your account.{% endtrans %}</p>
 
-                    <a href="{{ path('lpa.add-by-paper') }}" draggable="false" class="govuk-button">{% trans %}Request another activation key{% endtrans %}</a>
+                    <a href="{{ path('lpa.add-by-paper', {}, {'startAgain': 'true'})}}" draggable="false" class="govuk-button">{% trans %}Request another activation key{% endtrans %}</a>
                     <a class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1" href="{{ path('lpa.dashboard') }}">
                         {% trans %}Back to your LPAs{% endtrans %}
                     </a>

--- a/service-front/app/src/Actor/templates/actor/before-requesting-activation-key-info.html.twig
+++ b/service-front/app/src/Actor/templates/actor/before-requesting-activation-key-info.html.twig
@@ -60,7 +60,7 @@
                         </div>
                     </details>
 
-                    <a href="{{ path('lpa.add-by-paper') }}" class="govuk-button">{% trans %}Continue{% endtrans %}</a>
+                    <a href="{{ path('lpa.add-by-paper', {}, {'startAgain': 'true'}) }}" class="govuk-button">{% trans %}Continue{% endtrans %}</a>
                     <a href="{{ path('lpa.dashboard') }}" draggable="false" class="govuk-button govuk-button--secondary">{% trans %}Cancel{% endtrans %}</a>
 
                 </div>

--- a/service-front/app/src/Actor/templates/actor/cannot-find-lpa.html.twig
+++ b/service-front/app/src/Actor/templates/actor/cannot-find-lpa.html.twig
@@ -55,7 +55,7 @@
 
                     {% endif %}
 
-                    <a href="{{ path('lpa.add-by-paper',{}, {'startAgain': 'true'})}}" draggable="false" class="govuk-button">{% trans %}Try again{% endtrans %}</a>
+                    <a href="{{ path('lpa.add-by-paper', {}, {'startAgain': 'true'})}}" draggable="false" class="govuk-button">{% trans %}Try again{% endtrans %}</a>
                     <a class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1" href="{{ path('lpa.dashboard') }}">
                         {% trans %}Back to your LPAs{% endtrans %}
                     </a>

--- a/service-front/app/src/Actor/templates/actor/request-activation-key/info.html.twig
+++ b/service-front/app/src/Actor/templates/actor/request-activation-key/info.html.twig
@@ -64,7 +64,7 @@
                         <li>{% trans %}your date of birth is wrong on the LPA{% endtrans %}</li>
                     </ul>
 
-                    <a href="{{ path('lpa.add-by-paper') }}" class="govuk-button">{% trans %}Continue{% endtrans %}</a>
+                    <a href="{{ path('lpa.add-by-paper', {}, {'startAgain': 'true'}) }}" class="govuk-button">{% trans %}Continue{% endtrans %}</a>
 
                     <a href="{{ path('lpa.dashboard') }}" draggable="false" class="govuk-button govuk-button--secondary">{% trans %}Cancel{% endtrans %}</a>
 

--- a/service-front/app/src/Actor/templates/actor/send-activation-key-confirmation.html.twig
+++ b/service-front/app/src/Actor/templates/actor/send-activation-key-confirmation.html.twig
@@ -32,7 +32,7 @@
                     <h2 class="govuk-heading-m">{% trans %}Have more than one LPA?{% endtrans %}</h2>
                     <p class="govuk-body">{% trans %}You'll need an activation key for each LPA that you'd like to add to your account.{% endtrans %}</p>
 
-                    <a href="{{ path('lpa.add-by-paper') }}" draggable="false" class="govuk-button">{% trans %}Request another activation key{% endtrans %}</a>
+                    <a href="{{ path('lpa.add-by-paper', {}, {'startAgain': 'true'}) }}" draggable="false" class="govuk-button">{% trans %}Request another activation key{% endtrans %}</a>
                     <a class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1" href="{{ path('lpa.dashboard') }}">
                         {% trans %}Back to your LPAs{% endtrans %}
                     </a>

--- a/service-front/app/src/Common/src/Service/Session/RemoveAccessForAllSessionValues.php
+++ b/service-front/app/src/Common/src/Service/Session/RemoveAccessForAllSessionValues.php
@@ -13,10 +13,10 @@ class RemoveAccessForAllSessionValues
     public function cleanAccessForAllSessionValues(SessionInterface $session): void
     {
         $session->unset('opg_reference_number');
-        $this->removePostCheckAnswersSessionValues($session);
+        $this->removePostLPAMatchSessionValues($session);
     }
 
-    public function removePostCheckAnswersSessionValues(SessionInterface $session): void
+    public function removePostLPAMatchSessionValues(SessionInterface $session): void
     {
         $session->unset('actor_id');
         $session->unset('actor_role');

--- a/service-front/app/src/Common/src/Service/Session/RemoveAccessForAllSessionValues.php
+++ b/service-front/app/src/Common/src/Service/Session/RemoveAccessForAllSessionValues.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Common\Service\Session;
+
+use Mezzio\Session\SessionInterface;
+
+class RemoveAccessForAllSessionValues
+{
+    /**
+     * Cleans the session values removing any post check answers session values, also removes LPA reference number
+     * @param SessionInterface $session the users session
+     */
+    public function cleanAccessForAllSessionValues(SessionInterface $session): void
+    {
+        $session->unset('opg_reference_number');
+        $this->removePostCheckAnswersSessionValues($session);
+    }
+
+    public function removePostCheckAnswersSessionValues(SessionInterface $session): void
+    {
+        $session->unset('actor_id');
+        $session->unset('actor_role');
+        $session->unset('donor_first_names');
+        $session->unset('donor_last_name');
+        $session->unset('donor_dob');
+        $session->unset('telephone_option');
+        $session->unset('lpa_full_match_but_not_cleansed');
+    }
+}

--- a/service-front/app/test/CommonTest/Service/Session/RemoveAccessForAllSessionValuesTest.php
+++ b/service-front/app/test/CommonTest/Service/Session/RemoveAccessForAllSessionValuesTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace CommonTest\Service\Session;
+
+use Common\Service\Session\RemoveAccessForAllSessionValues;
+use Mezzio\Session\SessionInterface;
+use Monolog\Test\TestCase;
+
+class RemoveAccessForAllSessionValuesTest extends TestCase
+{
+    /** @test */
+    public function successfully_removes_post_lpa_match_session_values(): void
+    {
+        $removeSessionValues = new RemoveAccessForAllSessionValues();
+
+        $sessionProphecy = $this->prophesize(SessionInterface::class);
+
+        $postMatchSessionValues = [
+            'actor_id',
+            'actor_role',
+            'donor_first_names',
+            'donor_last_name',
+            'donor_dob',
+            'telephone_option',
+            'lpa_full_match_but_not_cleansed'
+        ];
+
+        foreach ($postMatchSessionValues as $sessionValue) {
+            $sessionProphecy->unset($sessionValue)->shouldBeCalled();
+        }
+
+        $removeSessionValues->removePostLPAMatchSessionValues($sessionProphecy->reveal());
+    }
+
+    /** @test */
+    public function successfully_cleans_all_access_for_all_session_values(): void
+    {
+        $removeSessionValues = new RemoveAccessForAllSessionValues();
+
+        $sessionProphecy = $this->prophesize(SessionInterface::class);
+
+        $toRemoveSessionValues = [
+            'opg_reference_number',
+            'actor_id',
+            'actor_role',
+            'donor_first_names',
+            'donor_last_name',
+            'donor_dob',
+            'telephone_option',
+            'lpa_full_match_but_not_cleansed'
+        ];
+
+        foreach ($toRemoveSessionValues as $sessionValue) {
+            $sessionProphecy->unset($sessionValue)->shouldBeCalled();
+        }
+
+        $removeSessionValues->cleanAccessForAllSessionValues($sessionProphecy->reveal());
+    }
+}
+

--- a/service-front/app/test/CommonTest/Service/Session/RemoveAccessForAllSessionValuesTest.php
+++ b/service-front/app/test/CommonTest/Service/Session/RemoveAccessForAllSessionValuesTest.php
@@ -57,4 +57,3 @@ class RemoveAccessForAllSessionValuesTest extends TestCase
         $removeSessionValues->cleanAccessForAllSessionValues($sessionProphecy->reveal());
     }
 }
-


### PR DESCRIPTION
# Purpose

Clear session values from access for all journey

Fixes UML-1854

## Approach

To many different places to clear at end of journey so instead we clear before the matching is done in check answers and at the beginning of the journey

## Checklist

* [x] I have performed a self-review of my own code
~~I have added relevant logging with appropriate levels to my code~~
~~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~~
* [x] I have added tests to prove my work
~~I have added welsh translation tags and updated translation files~~
~~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~~
* [x] The product team have tested these changes
