### PR TITLE
UML-1859 - Create a notify key secret for the demo environment

### DIFF
--- a/terraform/account/secretsmanager.tf
+++ b/terraform/account/secretsmanager.tf
@@ -3,6 +3,12 @@ resource "aws_secretsmanager_secret" "notify_api_key" {
   kms_key_id = aws_kms_key.secrets_manager.key_id
 }
 
+resource "aws_secretsmanager_secret" "notify_api_key_demo" {
+  count      = local.account_name == "development" ? 1 : 0
+  name       = "notify-api-key-demo"
+  kms_key_id = aws_kms_key.secrets_manager.key_id
+}
+
 resource "aws_kms_key" "secrets_manager" {
   description             = "Secrets Manager encryption ${local.environment}"
   deletion_window_in_days = 10


### PR DESCRIPTION
# Purpose

Demo environment will need to be able to send notifcations for any user, not just team members

Fixes UML-1859

## Approach

- Create an account level Secrets Manager secret for a notify key in development

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret

## Checklist

* [x] I have performed a self-review of my own code