### PR TITLE
UML-1858 UML-1735 - CMK for SNS Encryption

### DIFF
--- a/terraform/account/pagerduty.tf
+++ b/terraform/account/pagerduty.tf
@@ -1,3 +1,67 @@
+resource "aws_kms_key" "pagerduty_sns" {
+  description             = "KMS Key for encryption of AWS Config SNS Messages"
+  deletion_window_in_days = 10
+  policy                  = data.aws_iam_policy_document.pagerduty_sns_kms.json
+  enable_key_rotation     = true
+}
+
+data "aws_iam_policy_document" "pagerduty_sns_kms" {
+  statement {
+    sid       = "Allow Key to be used for Encryption by AWS Cloudwatch"
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*",
+    ]
+    principals {
+      identifiers = ["cloudwatch.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+  statement {
+    sid       = "Enable Root account permissions on Key"
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
+      ]
+    }
+  }
+  statement {
+    sid       = "Key Administrator"
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion"
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/breakglass"]
+    }
+  }
+}
+
+
+
 data "pagerduty_service" "pagerduty" {
   name = local.account.pagerduty_service_name
 }

--- a/terraform/account/pagerduty.tf
+++ b/terraform/account/pagerduty.tf
@@ -5,6 +5,12 @@ resource "aws_kms_key" "pagerduty_sns" {
   enable_key_rotation     = true
 }
 
+resource "aws_kms_alias" "pagerduty_sns" {
+  name          = "alias/pagerduty-sns"
+  target_key_id = aws_kms_key.pagerduty_sns.key_id
+}
+
+
 data "aws_iam_policy_document" "pagerduty_sns_kms" {
   statement {
     sid       = "Allow Key to be used for Encryption by AWS Cloudwatch"

--- a/terraform/account/pagerduty.tf
+++ b/terraform/account/pagerduty.tf
@@ -78,7 +78,7 @@ resource "pagerduty_service_integration" "cloudwatch_integration" {
 
 resource "aws_sns_topic" "cloudwatch_to_pagerduty" {
   name              = "CloudWatch-to-PagerDuty-${local.environment}-Account"
-  kms_master_key_id = "alias/aws/sns"
+  kms_master_key_id = aws_kms_key.pagerduty_sns.key_id
 }
 
 resource "aws_sns_topic_subscription" "cloudwatch_sns_subscription" {

--- a/terraform/environment/pagerduty.tf
+++ b/terraform/environment/pagerduty.tf
@@ -14,7 +14,8 @@ resource "pagerduty_service_integration" "cloudwatch_integration" {
 
 resource "aws_sns_topic" "cloudwatch_to_pagerduty" {
   name              = "CloudWatch-to-PagerDuty-${local.environment}"
-  kms_master_key_id = "alias/aws/sns"
+  kms_master_key_id = data.aws_kms_alias.secrets_manager.target_key_arn
+
 }
 
 resource "aws_sns_topic_subscription" "cloudwatch_sns_subscription" {

--- a/terraform/environment/pagerduty.tf
+++ b/terraform/environment/pagerduty.tf
@@ -14,8 +14,7 @@ resource "pagerduty_service_integration" "cloudwatch_integration" {
 
 resource "aws_sns_topic" "cloudwatch_to_pagerduty" {
   name              = "CloudWatch-to-PagerDuty-${local.environment}"
-  kms_master_key_id = data.aws_kms_alias.secrets_manager.target_key_arn
-
+  kms_master_key_id = data.aws_kms_alias.pagerduty_sns.target_key_arn
 }
 
 resource "aws_sns_topic_subscription" "cloudwatch_sns_subscription" {

--- a/terraform/environment/shared_data_sources.tf
+++ b/terraform/environment/shared_data_sources.tf
@@ -58,6 +58,10 @@ data "aws_kms_alias" "secrets_manager" {
   name = "alias/secrets_manager_encryption"
 }
 
+data "aws_kms_alias" "pagerduty_sns" {
+  name = "alias/pagerduty-sns"
+}
+
 //--------------------
 // ECR Repos
 


### PR DESCRIPTION
# Purpose

Pagerduty alarms would not trigger due to permissions errors

Fixes UML-1858 UML-1735

## Approach

- create a Customer Managed Key for pagerduty SNS

## Learning

https://aws.amazon.com/premiumsupport/knowledge-center/cloudwatch-receive-sns-for-alarm-trigger/

## Checklist

* [x] I have performed a self-review of my own code