### PR TITLE
Enable all event codes to send to opg-metrics

### DIFF
--- a/terraform/environment/ship_to_metrics.tf
+++ b/terraform/environment/ship_to_metrics.tf
@@ -1,11 +1,3 @@
-locals {
-  clsf_event_codes = [
-    "DOWNLOAD_SUMMARY",
-    # "ACCOUNT_CREATED",
-    # "ACCOUNT_DELETED",
-  ]
-}
-
 data "aws_sqs_queue" "ship_to_opg_metrics" {
   count = local.account.ship_metrics_queue_enabled == true ? 1 : 0
   name  = "${local.account_name}-ship-to-opg-metrics"
@@ -21,20 +13,19 @@ data "aws_lambda_function" "ship_to_opg_metrics" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "events" {
-  for_each        = local.account.ship_metrics_queue_enabled == true ? toset(local.clsf_event_codes) : []
+  count           = local.account.ship_metrics_queue_enabled == true ? 1 : 0
   name            = "${local.environment}-clsf-to-sqs-${lower(each.value)}"
   log_group_name  = aws_cloudwatch_log_group.application_logs.name
-  filter_pattern  = "{$.context.event_code = ${each.value}}"
+  filter_pattern  = "{$.context.event_code EXISTS}"
   destination_arn = data.aws_lambda_function.clsf_to_sqs[0].arn
-  #destination_arn = module.clsf_to_sqs[0].lambda_function.arn
-  depends_on = [aws_lambda_permission.allow_cloudwatch]
+  depends_on      = [aws_lambda_permission.allow_cloudwatch]
 }
+
 resource "aws_lambda_permission" "allow_cloudwatch" {
   count         = local.account.ship_metrics_queue_enabled == true ? 1 : 0
   statement_id  = "${local.environment}-AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
   function_name = data.aws_lambda_function.clsf_to_sqs[0].function_name
-  #function_name = module.clsf_to_sqs[0].lambda_function.function_name
-  principal  = "logs.eu-west-1.amazonaws.com"
-  source_arn = "${aws_cloudwatch_log_group.application_logs.arn}:*"
+  principal     = "logs.eu-west-1.amazonaws.com"
+  source_arn    = "${aws_cloudwatch_log_group.application_logs.arn}:*"
 }


### PR DESCRIPTION
# Purpose

Enable all event codes to send to opg-metrics

Fixes UML-1581

## Approach

If a event_code is present within a log message it will ship it to opg-metrics service


## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
