### PR TITLE
UML-1870 - Get API key for shipping to opg-metrics

### DIFF
--- a/terraform/account/lambda_functions.tf
+++ b/terraform/account/lambda_functions.tf
@@ -86,7 +86,7 @@ data "aws_iam_policy_document" "ship_to_opg_metrics_lambda_function_policy" {
   statement {
     sid       = "AllowSecretsManagerAccess"
     effect    = "Allow"
-    resources = [aws_sqs_queue.ship_to_opg_metrics[0].arn]
+    resources = [data.aws_secretsmanager_secret_version.opg_metrics_api_key[0].arn]
     actions = [
       "secretsmanager:GetSecretValue",
     ]

--- a/terraform/account/lambda_functions.tf
+++ b/terraform/account/lambda_functions.tf
@@ -61,7 +61,7 @@ module "ship_to_opg_metrics" {
   working_directory = "/var/task"
   environment_variables = {
     "OPG_METRICS_URL" : local.account.opg_metrics.endpoint_url
-    "API_KEY" : data.aws_secretsmanager_secret_version.opg_metrics_api_key[0].secret_string
+    "SECRET_ID" : data.aws_secretsmanager_secret_version.opg_metrics_api_key[0].secret_id
   }
   image_uri                           = "${data.aws_ecr_repository.ship_to_opg_metrics.repository_url}:${var.lambda_container_version}"
   ecr_arn                             = data.aws_ecr_repository.ship_to_opg_metrics.arn

--- a/terraform/account/lambda_functions.tf
+++ b/terraform/account/lambda_functions.tf
@@ -93,7 +93,7 @@ data "aws_iam_policy_document" "ship_to_opg_metrics_lambda_function_policy" {
     effect = "Allow"
     # resources = [data.aws_secretsmanager_secret_version.opg_metrics_api_key[0].arn]
     resources = [
-      "arn:aws:secretsmanager:eu-west-1:679638075911:secret:opg-metrics-api-key/use-a-lasting-power-of-attorney-development-??????"
+      "arn:aws:secretsmanager:eu-west-1:679638075911:secret:opg-metrics-api-key/use-a-lasting-power-of-attorney-development-7wGnpC"
     ]
     actions = [
       "secretsmanager:GetSecretValue",
@@ -105,6 +105,7 @@ data "aws_iam_policy_document" "ship_to_opg_metrics_lambda_function_policy" {
     resources = [data.aws_kms_alias.opg_metrics_api_key_encryption.target_key_arn]
     actions = [
       "kms:Decrypt",
+      "kms:DescribeKey",
     ]
   }
 }

--- a/terraform/account/lambda_functions.tf
+++ b/terraform/account/lambda_functions.tf
@@ -88,7 +88,6 @@ data "aws_iam_policy_document" "ship_to_opg_metrics_lambda_function_policy" {
     effect    = "Allow"
     resources = [aws_sqs_queue.ship_to_opg_metrics[0].arn]
     actions = [
-      "secretsmanager:GetResourcePolicy",
       "secretsmanager:GetSecretValue",
     ]
   }

--- a/terraform/account/lambda_functions.tf
+++ b/terraform/account/lambda_functions.tf
@@ -42,9 +42,10 @@ data "aws_iam_policy_document" "clsf_to_sqs_lambda_function_policy" {
 }
 
 data "aws_secretsmanager_secret_version" "opg_metrics_api_key" {
-  count     = local.account.opg_metrics.enabled == true ? 1 : 0
-  secret_id = data.aws_secretsmanager_secret.opg_metrics_api_key[0].id
-  provider  = aws.shared
+  count         = local.account.opg_metrics.enabled == true ? 1 : 0
+  secret_id     = data.aws_secretsmanager_secret.opg_metrics_api_key[0].id
+  version_stage = "AWSCURRENT"
+  provider      = aws.shared
 }
 
 data "aws_secretsmanager_secret" "opg_metrics_api_key" {
@@ -88,9 +89,12 @@ data "aws_iam_policy_document" "ship_to_opg_metrics_lambda_function_policy" {
   }
 
   statement {
-    sid       = "AllowSecretsManagerAccess"
-    effect    = "Allow"
-    resources = [data.aws_secretsmanager_secret_version.opg_metrics_api_key[0].arn]
+    sid    = "AllowSecretsManagerAccess"
+    effect = "Allow"
+    # resources = [data.aws_secretsmanager_secret_version.opg_metrics_api_key[0].arn]
+    resources = [
+      "arn:aws:secretsmanager:eu-west-1:679638075911:secret:opg-metrics-api-key/use-a-lasting-power-of-attorney-development-??????"
+    ]
     actions = [
       "secretsmanager:GetSecretValue",
     ]
@@ -98,7 +102,7 @@ data "aws_iam_policy_document" "ship_to_opg_metrics_lambda_function_policy" {
   statement {
     sid       = "AllowKMSDecrypt"
     effect    = "Allow"
-    resources = [data.aws_kms_alias.opg_metrics_api_key_encryption.arn]
+    resources = [data.aws_kms_alias.opg_metrics_api_key_encryption.target_key_arn]
     actions = [
       "kms:Decrypt",
     ]

--- a/terraform/account/lambda_functions.tf
+++ b/terraform/account/lambda_functions.tf
@@ -61,7 +61,7 @@ module "ship_to_opg_metrics" {
   working_directory = "/var/task"
   environment_variables = {
     "OPG_METRICS_URL" : local.account.opg_metrics.endpoint_url
-    "SECRET_ID" : data.aws_secretsmanager_secret_version.opg_metrics_api_key[0].secret_id
+    "SECRET_ARN" : data.aws_secretsmanager_secret_version.opg_metrics_api_key[0].arn
   }
   image_uri                           = "${data.aws_ecr_repository.ship_to_opg_metrics.repository_url}:${var.lambda_container_version}"
   ecr_arn                             = data.aws_ecr_repository.ship_to_opg_metrics.arn

--- a/terraform/account/lambda_functions.tf
+++ b/terraform/account/lambda_functions.tf
@@ -54,7 +54,7 @@ data "aws_secretsmanager_secret" "opg_metrics_api_key" {
 }
 
 data "aws_kms_alias" "opg_metrics_api_key_encryption" {
-  name     = "alias/api_key_encryption"
+  name     = "alias/opg_metrics_api_key_encryption"
   provider = aws.shared
 }
 module "ship_to_opg_metrics" {

--- a/terraform/account/lambda_functions.tf
+++ b/terraform/account/lambda_functions.tf
@@ -58,6 +58,7 @@ data "aws_kms_alias" "opg_metrics_api_key_encryption" {
   name     = "alias/opg_metrics_api_key_encryption"
   provider = aws.shared
 }
+
 module "ship_to_opg_metrics" {
   source            = "./modules/lambda_function"
   count             = local.account.opg_metrics.enabled == true ? 1 : 0
@@ -91,9 +92,9 @@ data "aws_iam_policy_document" "ship_to_opg_metrics_lambda_function_policy" {
   statement {
     sid    = "AllowSecretsManagerAccess"
     effect = "Allow"
-    # resources = [data.aws_secretsmanager_secret_version.opg_metrics_api_key[0].arn]
     resources = [
-      "arn:aws:secretsmanager:eu-west-1:679638075911:secret:opg-metrics-api-key/use-a-lasting-power-of-attorney-development-7wGnpC"
+      data.aws_secretsmanager_secret.opg_metrics_api_key[0].arn,
+      "arn:aws:secretsmanager:eu-west-1:679638075911:secret:opg-metrics-api-key/use-a-lasting-power-of-attorney-development"
     ]
     actions = [
       "secretsmanager:GetSecretValue",
@@ -105,7 +106,6 @@ data "aws_iam_policy_document" "ship_to_opg_metrics_lambda_function_policy" {
     resources = [data.aws_kms_alias.opg_metrics_api_key_encryption.target_key_arn]
     actions = [
       "kms:Decrypt",
-      "kms:DescribeKey",
     ]
   }
 }

--- a/terraform/account/lambda_functions.tf
+++ b/terraform/account/lambda_functions.tf
@@ -82,4 +82,14 @@ data "aws_iam_policy_document" "ship_to_opg_metrics_lambda_function_policy" {
       "sqs:GetQueueAttributes",
     ]
   }
+
+  statement {
+    sid       = "AllowSecretsManagerAccess"
+    effect    = "Allow"
+    resources = [aws_sqs_queue.ship_to_opg_metrics[0].arn]
+    actions = [
+      "secretsmanager:GetResourcePolicy",
+      "secretsmanager:GetSecretValue",
+    ]
+  }
 }


### PR DESCRIPTION
# Purpose

Support rotating API keys by getting their value on execution rather than on deployment

Fixes UML-1870

## Approach

- Add function to get_secret_value from opg-metrics
- give lambda function permission to get secret value from opg metrics

## Learning

https://aws.amazon.com/premiumsupport/knowledge-center/secrets-manager-share-between-accounts/

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] The product team have tested these changes
