### PR TITLE
UML-1701 Remove pattern and inputmode types

### DIFF
--- a/service-front/app/src/Actor/templates/actor/lpa-add.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-add.html.twig
@@ -57,8 +57,6 @@
                         'label': 'LPA reference number'| trans,
                         'hint': 'LPA reference numbers are 12 numbers long<br/>For example, 7000-0000-0000'| trans,
                         'attr' : {'class': 'govuk-input--width-20', 'label_class': 'govuk-label--m'},
-                        'inputmode': 'numeric',
-                        'pattern': '[0-9 -]*'
                     }) }}
 
                     <details class="govuk-details" data-module="govuk-details">

--- a/service-front/app/src/Actor/templates/actor/lpa-add.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-add.html.twig
@@ -53,7 +53,7 @@
                         'hint': 'For example, 31 03 1980'| trans,
                         'attr': {'class': 'xyz', 'label_class': 'govuk-label--m'} }) }}
 
-                {{ govuk_form_element(form.get('reference_number'), {
+                    {{ govuk_form_element(form.get('reference_number'), {
                         'label': 'LPA reference number'| trans,
                         'hint': 'LPA reference numbers are 12 numbers long<br/>For example, 7000-0000-0000'| trans,
                         'attr' : {'class': 'govuk-input--width-20', 'label_class': 'govuk-label--m'},

--- a/service-front/app/src/Actor/templates/actor/request-activation-key/reference-number.html.twig
+++ b/service-front/app/src/Actor/templates/actor/request-activation-key/reference-number.html.twig
@@ -56,8 +56,6 @@
                                 'class': 'govuk-input--width-20',
                                 'label_class': 'govuk-label--s'
                             },
-                            'inputmode': 'numeric',
-                            'pattern': '[0-9 -]*',
                             'aria_labelledby': 'ref_number_heading'
                         }) }}
 


### PR DESCRIPTION
# Purpose

Removing the inputmode and patterns will stop iOS devices from showing the wrong type of keyboard for this kind of field. It used to be accurate when we only accepted numbers but now we also accept hypens and such which can cause user confusion.

Fixes UML-1701

## Approach

Couldn't just remove the pattern as the inputmode is also incorrect as per HTML specs

## Learning

https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* The product team have tested these changes
