### PR TITLE
UML-1878 - Enable delete_lpa_feature flag on production

### DIFF
--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -185,7 +185,7 @@
       "sirius_account_id": "649098267436",
       "use_legacy_codes_service": false,
       "use_older_lpa_journey": true,
-      "delete_lpa_feature": false,
+      "delete_lpa_feature": true,
       "allow_older_lpas": false,
       "allow_meris_lpas": false,
       "save_older_lpa_requests": true,


### PR DESCRIPTION
# Purpose

Make the Delete LPA feature available for Use in production

Fixes UML-1878

## Approach

- Set delete_lpa_feature to `true` in tfvars production block

## Checklist

* [x] I have performed a self-review of my own code