### PR TITLE
UML-1900 - Create a CircleCI workflow for Terraform only changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,6 +273,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
+              /terraform\/.*/
               ] } }
 
         - use-my-lpa/lint_terraform:
@@ -280,6 +281,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
+              /terraform\/.*/
               ] } }
 
         - use-my-lpa/node_test_web:
@@ -287,6 +289,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
+              /terraform\/.*/
               ] } }
 
         - use-my-lpa/node_build_web:
@@ -294,6 +297,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
+              /terraform\/.*/
               ] } }
             requires: [test_web]
 
@@ -302,6 +306,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
+              /terraform\/.*/
               ] } }
 
         - use-my-lpa/docker_build_front_app:
@@ -332,6 +337,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
+              /terraform\/.*/
               ] } }
 
         - use-my-lpa/docker_test_admin:
@@ -346,6 +352,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
+              /terraform\/.*/
               ] } }
 
         - use-my-lpa/docker_build_pdf:
@@ -353,6 +360,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
+              /terraform\/.*/
               ] } }
             requires: [test_pdf]
 
@@ -361,6 +369,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
+              /terraform\/.*/
               ] } }
             requires:
               [
@@ -377,6 +386,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
+              /terraform\/.*/
               ] } }
             requires: [cancel_previous_jobs,lint_terraform]
 
@@ -385,6 +395,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
+              /terraform\/.*/
               ] } }
             requires:
               [
@@ -403,6 +414,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
+              /terraform\/.*/
               ] } }
             requires:
               [
@@ -420,6 +432,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
+              /terraform\/.*/
               ] } }
             requires: [dev_apply_environment_terraform]
 
@@ -428,6 +441,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
+              /terraform\/.*/
               ] } }
             requires: [dev_seed_database]
 
@@ -438,12 +452,18 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
+              /terraform\/.*/
               ] } }
             requires: [dev_run_behat_tests]
 
         # Required end of workflow job
         - use-my-lpa/end_of_workflow:
             name: end_of_workflow
+            filters: { branches: { ignore: [
+              main,
+              /dependabot\/.*/,
+              /terraform\/.*/
+              ] } }
             requires: [post_environment_domains]
 
   path_to_live:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ workflows:
       - slack_notify_stats:
           name: slack_notify_stats
 
-  dependabot_build:
+  package_update_pr:
       jobs:
         - cancel_redundant_builds:
             name: cancel_previous_jobs
@@ -189,7 +189,7 @@ workflows:
                   ]
             requires: [codecov_upload]
 
-  terraform_only_build:
+  terraform_only_pr:
       jobs:
         - cancel_redundant_builds:
             name: cancel_previous_jobs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,26 +161,35 @@ workflows:
                 ignore: [/dependabot\/terraform\/.*/]
             requires: [codecov_upload]
 
-  dependabot_terraform_build:
+  terraform_only_build:
       jobs:
         - cancel_redundant_builds:
             name: cancel_previous_jobs
             filters:
               branches:
-                only: [/dependabot\/terraform\/.*/]
+                only: [
+                  /dependabot\/terraform\/.*/,
+                  /terraform\/.*/
+                  ]
 
         - use-my-lpa/lint_terraform:
             name: lint_terraform
             filters:
               branches:
-                only: [/dependabot\/terraform\/.*/]
+                only: [
+                  /dependabot\/terraform\/.*/,
+                  /terraform\/.*/
+                  ]
 
             # Provision and test development
         - use-my-lpa/plan_shared_terraform:
             name: dev_plan_shared_terraform
             filters:
               branches:
-                only: [/dependabot\/terraform\/.*/]
+                only: [
+                  /dependabot\/terraform\/.*/,
+                  /terraform\/.*/
+                  ]
             requires: [cancel_previous_jobs,lint_terraform]
 
         - use-my-lpa/apply_environment_terraform:
@@ -188,7 +197,10 @@ workflows:
             image_tag_input: latest
             filters:
               branches:
-                only: [/dependabot\/terraform\/.*/]
+                only: [
+                  /dependabot\/terraform\/.*/,
+                  /terraform\/.*/
+                  ]
             requires:
               [
                 cancel_previous_jobs,
@@ -199,14 +211,20 @@ workflows:
             name: dev_seed_database
             filters:
               branches:
-                only: [/dependabot\/terraform\/.*/]
+                only: [
+                  /dependabot\/terraform\/.*/,
+                  /terraform\/.*/
+                  ]
             requires: [dev_apply_environment_terraform]
 
         - use-my-lpa/run_behat_suite:
             name: dev_run_behat_tests
             filters:
               branches:
-                only: [/dependabot\/terraform\/.*/]
+                only: [
+                  /dependabot\/terraform\/.*/,
+                  /terraform\/.*/
+                  ]
             requires: [dev_seed_database]
 
         # Required end of workflow job
@@ -214,7 +232,10 @@ workflows:
             name: end_of_workflow
             filters:
               branches:
-                only: [/dependabot\/terraform\/.*/]
+                only: [
+                  /dependabot\/terraform\/.*/,
+                  /terraform\/.*/
+                  ]
             requires: [dev_run_behat_tests]
 
   pr_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,59 +51,98 @@ workflows:
       jobs:
         - cancel_redundant_builds:
             name: cancel_previous_jobs
-            filters: { branches: { only: [/dependabot\/.*/] } }
+            filters:
+              branches:
+                ignore: [/dependabot\/terraform\/.*/]
+                only: [/dependabot\/.*/]
 
         - use-my-lpa/lint_terraform:
             name: lint_terraform
-            filters: { branches: { only: [/dependabot\/.*/] } }
+            filters:
+              branches:
+                ignore: [/dependabot\/terraform\/.*/]
+                only: [/dependabot\/.*/]
 
         - use-my-lpa/node_test_web:
             name: test_web
-            filters: { branches: { only: [/dependabot\/.*/] } }
+            filters:
+              branches:
+                ignore: [/dependabot\/terraform\/.*/]
+                only: [/dependabot\/.*/]
 
         - use-my-lpa/node_build_web:
             name: build_web
-            filters: { branches: { only: [/dependabot\/.*/] } }
+            filters:
+              branches:
+                ignore: [/dependabot\/terraform\/.*/]
+                only: [/dependabot\/.*/]
             requires: [test_web]
 
         - use-my-lpa/node_test_service_pdf:
             name: test_pdf
-            filters: { branches: { only: [/dependabot\/.*/] } }
+            filters:
+              branches:
+                ignore: [/dependabot\/terraform\/.*/]
+                only: [/dependabot\/.*/]
 
         - use-my-lpa/docker_build_front_app:
             name: app_front_build
-            filters: { branches: { only: [/dependabot\/.*/] } }
+            filters:
+              branches:
+                ignore: [/dependabot\/terraform\/.*/]
+                only: [/dependabot\/.*/]
             requires: [build_web]
 
         - use-my-lpa/docker_build_front_web:
             name: web_front_build
-            filters: { branches: { only: [/dependabot\/.*/] } }
+            filters:
+              branches:
+                ignore: [/dependabot\/terraform\/.*/]
+                only: [/dependabot\/.*/]
             requires: [build_web]
 
         - use-my-lpa/docker_build_api_app:
             name: app_api_build
-            filters: { branches: { only: [/dependabot\/.*/] } }
+            filters:
+              branches:
+                ignore: [/dependabot\/terraform\/.*/]
+                only: [/dependabot\/.*/]
 
         - use-my-lpa/docker_build_api_web:
             name: web_api_build
-            filters: { branches: { only: [/dependabot\/.*/] } }
+            filters:
+              branches:
+                ignore: [/dependabot\/terraform\/.*/]
+                only: [/dependabot\/.*/]
 
         - use-my-lpa/docker_build_pdf:
             name: pdf_build
-            filters: { branches: { only: [/dependabot\/.*/] } }
+            filters:
+              branches:
+                ignore: [/dependabot\/terraform\/.*/]
+                only: [/dependabot\/.*/]
             requires: [test_pdf]
 
         - use-my-lpa/docker_test_admin:
             name: admin_app_test
-            filters: { branches: { only: [/dependabot\/.*/] } }
+            filters:
+              branches:
+                ignore: [/dependabot\/terraform\/.*/]
+                only: [/dependabot\/.*/]
 
         - use-my-lpa/docker_build_admin:
             name: admin_app_build
-            filters: { branches: { only: [/dependabot\/.*/] } }
+            filters:
+              branches:
+                ignore: [/dependabot\/terraform\/.*/]
+                only: [/dependabot\/.*/]
 
         - use-my-lpa/codecov_upload:
             name: codecov_upload
-            filters: { branches: { only: [/dependabot\/.*/] } }
+            filters:
+              branches:
+                ignore: [/dependabot\/terraform\/.*/]
+                only: [/dependabot\/.*/]
             requires:
               [
                 app_front_build,
@@ -116,7 +155,81 @@ workflows:
         # Required end of workflow job
         - use-my-lpa/end_of_workflow:
             name: end_of_workflow
+            filters:
+              branches:
+                ignore: [/dependabot\/terraform\/.*/]
+                only: [/dependabot\/.*/]
             requires: [codecov_upload]
+
+  dependabot_terraform_build:
+      jobs:
+        - cancel_redundant_builds:
+            name: cancel_previous_jobs
+            filters:
+              tags:
+                only: [terraform]
+              branches:
+                only: [/dependabot\/terraform\/.*/]
+
+        - use-my-lpa/lint_terraform:
+            name: lint_terraform
+            filters:
+              tags:
+                only: [terraform]
+              branches:
+                only: [/dependabot\/terraform\/.*/]
+
+            # Provision and test development
+        - use-my-lpa/plan_shared_terraform:
+            name: dev_plan_shared_terraform
+            filters:
+              tags:
+                only: [terraform]
+              branches:
+                only: [/dependabot\/terraform\/.*/]
+            requires: [cancel_previous_jobs,lint_terraform]
+
+        - use-my-lpa/apply_environment_terraform:
+            name: dev_apply_environment_terraform
+            image_tag_input: latest
+            filters:
+              tags:
+                only: [terraform]
+              branches:
+                only: [/dependabot\/terraform\/.*/]
+            requires:
+              [
+                cancel_previous_jobs,
+                dev_plan_shared_terraform,
+              ]
+
+        - use-my-lpa/seed_database:
+            name: dev_seed_database
+            filters:
+              tags:
+                only: [terraform]
+              branches:
+                only: [/dependabot\/terraform\/.*/]
+            requires: [dev_apply_environment_terraform]
+
+        - use-my-lpa/run_behat_suite:
+            name: dev_run_behat_tests
+            filters:
+              tags:
+                only: [terraform]
+              branches:
+                only: [/dependabot\/terraform\/.*/]
+            requires: [dev_seed_database]
+
+        # Required end of workflow job
+        - use-my-lpa/end_of_workflow:
+            name: end_of_workflow
+            filters:
+              tags:
+                only: [terraform]
+              branches:
+                only: [/dependabot\/terraform\/.*/]
+            requires: [post_environment_domains]
 
   pr_build:
       jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,6 +314,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
+              /terraform\/.*/
               ] } }
             requires: [build_web]
 
@@ -322,6 +323,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
+              /terraform\/.*/
               ] } }
             requires: [build_web]
 
@@ -330,6 +332,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
+              /terraform\/.*/
               ] } }
 
         - use-my-lpa/docker_build_api_web:
@@ -345,6 +348,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
+              /terraform\/.*/
               ] } }
 
         - use-my-lpa/docker_build_admin:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,96 +53,122 @@ workflows:
             name: cancel_previous_jobs
             filters:
               branches:
-                only: [/dependabot\/.*/]
-                ignore: [/dependabot\/terraform\/.*/]
+                only: [
+                  /dependabot\/npm_and_yarn\/.*/,
+                  /dependabot\/composer\/.*/,
+                  ]
 
         - use-my-lpa/lint_terraform:
             name: lint_terraform
             filters:
               branches:
-                only: [/dependabot\/.*/]
-                ignore: [/dependabot\/terraform\/.*/]
+                only: [
+                  /dependabot\/npm_and_yarn\/.*/,
+                  /dependabot\/composer\/.*/,
+                  ]
 
         - use-my-lpa/node_test_web:
             name: test_web
             filters:
               branches:
-                only: [/dependabot\/.*/]
-                ignore: [/dependabot\/terraform\/.*/]
+                only: [
+                  /dependabot\/npm_and_yarn\/.*/,
+                  /dependabot\/composer\/.*/,
+                  ]
 
         - use-my-lpa/node_build_web:
             name: build_web
             filters:
               branches:
-                only: [/dependabot\/.*/]
-                ignore: [/dependabot\/terraform\/.*/]
+                only: [
+                  /dependabot\/npm_and_yarn\/.*/,
+                  /dependabot\/composer\/.*/,
+                  ]
             requires: [test_web]
 
         - use-my-lpa/node_test_service_pdf:
             name: test_pdf
             filters:
               branches:
-                only: [/dependabot\/.*/]
-                ignore: [/dependabot\/terraform\/.*/]
+                only: [
+                  /dependabot\/npm_and_yarn\/.*/,
+                  /dependabot\/composer\/.*/,
+                  ]
 
         - use-my-lpa/docker_build_front_app:
             name: app_front_build
             filters:
               branches:
-                only: [/dependabot\/.*/]
-                ignore: [/dependabot\/terraform\/.*/]
+                only: [
+                  /dependabot\/npm_and_yarn\/.*/,
+                  /dependabot\/composer\/.*/,
+                  ]
             requires: [build_web]
 
         - use-my-lpa/docker_build_front_web:
             name: web_front_build
             filters:
               branches:
-                only: [/dependabot\/.*/]
-                ignore: [/dependabot\/terraform\/.*/]
+                only: [
+                  /dependabot\/npm_and_yarn\/.*/,
+                  /dependabot\/composer\/.*/,
+                  ]
             requires: [build_web]
 
         - use-my-lpa/docker_build_api_app:
             name: app_api_build
             filters:
               branches:
-                only: [/dependabot\/.*/]
-                ignore: [/dependabot\/terraform\/.*/]
+                only: [
+                  /dependabot\/npm_and_yarn\/.*/,
+                  /dependabot\/composer\/.*/,
+                  ]
 
         - use-my-lpa/docker_build_api_web:
             name: web_api_build
             filters:
               branches:
-                only: [/dependabot\/.*/]
-                ignore: [/dependabot\/terraform\/.*/]
+                only: [
+                  /dependabot\/npm_and_yarn\/.*/,
+                  /dependabot\/composer\/.*/,
+                  ]
 
         - use-my-lpa/docker_build_pdf:
             name: pdf_build
             filters:
               branches:
-                only: [/dependabot\/.*/]
-                ignore: [/dependabot\/terraform\/.*/]
+                only: [
+                  /dependabot\/npm_and_yarn\/.*/,
+                  /dependabot\/composer\/.*/,
+                  ]
             requires: [test_pdf]
 
         - use-my-lpa/docker_test_admin:
             name: admin_app_test
             filters:
               branches:
-                only: [/dependabot\/.*/]
-                ignore: [/dependabot\/terraform\/.*/]
+                only: [
+                  /dependabot\/npm_and_yarn\/.*/,
+                  /dependabot\/composer\/.*/,
+                  ]
 
         - use-my-lpa/docker_build_admin:
             name: admin_app_build
             filters:
               branches:
-                only: [/dependabot\/.*/]
-                ignore: [/dependabot\/terraform\/.*/]
+                only: [
+                  /dependabot\/npm_and_yarn\/.*/,
+                  /dependabot\/composer\/.*/,
+                  ]
 
         - use-my-lpa/codecov_upload:
             name: codecov_upload
             filters:
               branches:
-                only: [/dependabot\/.*/]
-                ignore: [/dependabot\/terraform\/.*/]
+                only: [
+                  /dependabot\/npm_and_yarn\/.*/,
+                  /dependabot\/composer\/.*/,
+                  ]
             requires:
               [
                 app_front_build,
@@ -157,8 +183,10 @@ workflows:
             name: end_of_workflow
             filters:
               branches:
-                only: [/dependabot\/.*/]
-                ignore: [/dependabot\/terraform\/.*/]
+                only: [
+                  /dependabot\/npm_and_yarn\/.*/,
+                  /dependabot\/composer\/.*/,
+                  ]
             requires: [codecov_upload]
 
   terraform_only_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,96 +53,96 @@ workflows:
             name: cancel_previous_jobs
             filters:
               branches:
-                ignore: [/dependabot\/terraform\/.*/]
                 only: [/dependabot\/.*/]
+                ignore: [/dependabot\/terraform\/.*/]
 
         - use-my-lpa/lint_terraform:
             name: lint_terraform
             filters:
               branches:
-                ignore: [/dependabot\/terraform\/.*/]
                 only: [/dependabot\/.*/]
+                ignore: [/dependabot\/terraform\/.*/]
 
         - use-my-lpa/node_test_web:
             name: test_web
             filters:
               branches:
-                ignore: [/dependabot\/terraform\/.*/]
                 only: [/dependabot\/.*/]
+                ignore: [/dependabot\/terraform\/.*/]
 
         - use-my-lpa/node_build_web:
             name: build_web
             filters:
               branches:
-                ignore: [/dependabot\/terraform\/.*/]
                 only: [/dependabot\/.*/]
+                ignore: [/dependabot\/terraform\/.*/]
             requires: [test_web]
 
         - use-my-lpa/node_test_service_pdf:
             name: test_pdf
             filters:
               branches:
-                ignore: [/dependabot\/terraform\/.*/]
                 only: [/dependabot\/.*/]
+                ignore: [/dependabot\/terraform\/.*/]
 
         - use-my-lpa/docker_build_front_app:
             name: app_front_build
             filters:
               branches:
-                ignore: [/dependabot\/terraform\/.*/]
                 only: [/dependabot\/.*/]
+                ignore: [/dependabot\/terraform\/.*/]
             requires: [build_web]
 
         - use-my-lpa/docker_build_front_web:
             name: web_front_build
             filters:
               branches:
-                ignore: [/dependabot\/terraform\/.*/]
                 only: [/dependabot\/.*/]
+                ignore: [/dependabot\/terraform\/.*/]
             requires: [build_web]
 
         - use-my-lpa/docker_build_api_app:
             name: app_api_build
             filters:
               branches:
-                ignore: [/dependabot\/terraform\/.*/]
                 only: [/dependabot\/.*/]
+                ignore: [/dependabot\/terraform\/.*/]
 
         - use-my-lpa/docker_build_api_web:
             name: web_api_build
             filters:
               branches:
-                ignore: [/dependabot\/terraform\/.*/]
                 only: [/dependabot\/.*/]
+                ignore: [/dependabot\/terraform\/.*/]
 
         - use-my-lpa/docker_build_pdf:
             name: pdf_build
             filters:
               branches:
-                ignore: [/dependabot\/terraform\/.*/]
                 only: [/dependabot\/.*/]
+                ignore: [/dependabot\/terraform\/.*/]
             requires: [test_pdf]
 
         - use-my-lpa/docker_test_admin:
             name: admin_app_test
             filters:
               branches:
-                ignore: [/dependabot\/terraform\/.*/]
                 only: [/dependabot\/.*/]
+                ignore: [/dependabot\/terraform\/.*/]
 
         - use-my-lpa/docker_build_admin:
             name: admin_app_build
             filters:
               branches:
-                ignore: [/dependabot\/terraform\/.*/]
                 only: [/dependabot\/.*/]
+                ignore: [/dependabot\/terraform\/.*/]
 
         - use-my-lpa/codecov_upload:
             name: codecov_upload
             filters:
               branches:
-                ignore: [/dependabot\/terraform\/.*/]
                 only: [/dependabot\/.*/]
+                ignore: [/dependabot\/terraform\/.*/]
             requires:
               [
                 app_front_build,
@@ -157,8 +157,8 @@ workflows:
             name: end_of_workflow
             filters:
               branches:
-                ignore: [/dependabot\/terraform\/.*/]
                 only: [/dependabot\/.*/]
+                ignore: [/dependabot\/terraform\/.*/]
             requires: [codecov_upload]
 
   dependabot_terraform_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,16 +166,12 @@ workflows:
         - cancel_redundant_builds:
             name: cancel_previous_jobs
             filters:
-              tags:
-                only: [terraform]
               branches:
                 only: [/dependabot\/terraform\/.*/]
 
         - use-my-lpa/lint_terraform:
             name: lint_terraform
             filters:
-              tags:
-                only: [terraform]
               branches:
                 only: [/dependabot\/terraform\/.*/]
 
@@ -183,8 +179,6 @@ workflows:
         - use-my-lpa/plan_shared_terraform:
             name: dev_plan_shared_terraform
             filters:
-              tags:
-                only: [terraform]
               branches:
                 only: [/dependabot\/terraform\/.*/]
             requires: [cancel_previous_jobs,lint_terraform]
@@ -193,8 +187,6 @@ workflows:
             name: dev_apply_environment_terraform
             image_tag_input: latest
             filters:
-              tags:
-                only: [terraform]
               branches:
                 only: [/dependabot\/terraform\/.*/]
             requires:
@@ -206,8 +198,6 @@ workflows:
         - use-my-lpa/seed_database:
             name: dev_seed_database
             filters:
-              tags:
-                only: [terraform]
               branches:
                 only: [/dependabot\/terraform\/.*/]
             requires: [dev_apply_environment_terraform]
@@ -215,8 +205,6 @@ workflows:
         - use-my-lpa/run_behat_suite:
             name: dev_run_behat_tests
             filters:
-              tags:
-                only: [terraform]
               branches:
                 only: [/dependabot\/terraform\/.*/]
             requires: [dev_seed_database]
@@ -225,8 +213,6 @@ workflows:
         - use-my-lpa/end_of_workflow:
             name: end_of_workflow
             filters:
-              tags:
-                only: [terraform]
               branches:
                 only: [/dependabot\/terraform\/.*/]
             requires: [dev_run_behat_tests]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,7 @@ workflows:
                 only: [terraform]
               branches:
                 only: [/dependabot\/terraform\/.*/]
-            requires: [post_environment_domains]
+            requires: [dev_run_behat_tests]
 
   pr_build:
       jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ workflows:
               branches:
                 only: [
                   /dependabot\/terraform\/.*/,
-                  /terraform\/.*/
+                  /tf\/.*/
                   ]
 
         - use-my-lpa/lint_terraform:
@@ -206,7 +206,7 @@ workflows:
               branches:
                 only: [
                   /dependabot\/terraform\/.*/,
-                  /terraform\/.*/
+                  /tf\/.*/
                   ]
 
             # Provision and test development
@@ -216,7 +216,7 @@ workflows:
               branches:
                 only: [
                   /dependabot\/terraform\/.*/,
-                  /terraform\/.*/
+                  /tf\/.*/
                   ]
             requires: [cancel_previous_jobs,lint_terraform]
 
@@ -227,7 +227,7 @@ workflows:
               branches:
                 only: [
                   /dependabot\/terraform\/.*/,
-                  /terraform\/.*/
+                  /tf\/.*/
                   ]
             requires:
               [
@@ -241,7 +241,7 @@ workflows:
               branches:
                 only: [
                   /dependabot\/terraform\/.*/,
-                  /terraform\/.*/
+                  /tf\/.*/
                   ]
             requires: [dev_apply_environment_terraform]
 
@@ -251,7 +251,7 @@ workflows:
               branches:
                 only: [
                   /dependabot\/terraform\/.*/,
-                  /terraform\/.*/
+                  /tf\/.*/
                   ]
             requires: [dev_seed_database]
 
@@ -262,7 +262,7 @@ workflows:
               branches:
                 only: [
                   /dependabot\/terraform\/.*/,
-                  /terraform\/.*/
+                  /tf\/.*/
                   ]
             requires: [dev_run_behat_tests]
 
@@ -273,7 +273,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /terraform\/.*/
+              /tf\/.*/
               ] } }
 
         - use-my-lpa/lint_terraform:
@@ -281,7 +281,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /terraform\/.*/
+              /tf\/.*/
               ] } }
 
         - use-my-lpa/node_test_web:
@@ -289,7 +289,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /terraform\/.*/
+              /tf\/.*/
               ] } }
 
         - use-my-lpa/node_build_web:
@@ -297,7 +297,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /terraform\/.*/
+              /tf\/.*/
               ] } }
             requires: [test_web]
 
@@ -306,7 +306,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /terraform\/.*/
+              /tf\/.*/
               ] } }
 
         - use-my-lpa/docker_build_front_app:
@@ -314,7 +314,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /terraform\/.*/
+              /tf\/.*/
               ] } }
             requires: [build_web]
 
@@ -323,7 +323,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /terraform\/.*/
+              /tf\/.*/
               ] } }
             requires: [build_web]
 
@@ -332,7 +332,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /terraform\/.*/
+              /tf\/.*/
               ] } }
 
         - use-my-lpa/docker_build_api_web:
@@ -340,7 +340,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /terraform\/.*/
+              /tf\/.*/
               ] } }
 
         - use-my-lpa/docker_test_admin:
@@ -348,7 +348,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /terraform\/.*/
+              /tf\/.*/
               ] } }
 
         - use-my-lpa/docker_build_admin:
@@ -356,7 +356,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /terraform\/.*/
+              /tf\/.*/
               ] } }
 
         - use-my-lpa/docker_build_pdf:
@@ -364,7 +364,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /terraform\/.*/
+              /tf\/.*/
               ] } }
             requires: [test_pdf]
 
@@ -373,7 +373,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /terraform\/.*/
+              /tf\/.*/
               ] } }
             requires:
               [
@@ -390,7 +390,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /terraform\/.*/
+              /tf\/.*/
               ] } }
             requires: [cancel_previous_jobs,lint_terraform]
 
@@ -399,7 +399,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /terraform\/.*/
+              /tf\/.*/
               ] } }
             requires:
               [
@@ -418,7 +418,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /terraform\/.*/
+              /tf\/.*/
               ] } }
             requires:
               [
@@ -436,7 +436,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /terraform\/.*/
+              /tf\/.*/
               ] } }
             requires: [dev_apply_environment_terraform]
 
@@ -445,7 +445,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /terraform\/.*/
+              /tf\/.*/
               ] } }
             requires: [dev_seed_database]
 
@@ -456,7 +456,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /terraform\/.*/
+              /tf\/.*/
               ] } }
             requires: [dev_run_behat_tests]
 
@@ -466,7 +466,7 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /terraform\/.*/
+              /tf\/.*/
               ] } }
             requires: [post_environment_domains]
 


### PR DESCRIPTION
# Purpose

When PRs only relate to terraform, we only need to test terraform stages of workflow.

Fixes UML-1900

## Approach

- Create a workflow for terraform only changes
- Only run terraform only workflow if the branch matches the pattern 
  - `dependabot/terraform/*`
  - `tf/*`
- update package update PR filtering to be
  -  `dependabot/npm_and_yarn/*`
  -  `dependabot/composer/*`

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [x] I have performed a self-review of my own code
* [x] The product team have tested these changes
