### PR TITLE
UML-1875 - Notify team in Slack when there is a path to live failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,6 +279,7 @@ workflows:
               - slack/status:
                 fail_only: false
                 failure_message: 'TESTING - Path to Live Failure'
+                success_message: 'TESTING - Path to Live Failure'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
         - use-my-lpa/lint_terraform:
             name: lint_terraform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,7 +277,7 @@ workflows:
               ] } }
             post-steps:
               - slack/status:
-                  fail_only: true
+                  fail_only: false
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
         - use-my-lpa/lint_terraform:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,6 +275,7 @@ workflows:
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
+
         - use-my-lpa/lint_terraform:
             name: lint_terraform
             filters: { branches: { ignore: [

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,7 +279,7 @@ workflows:
               - slack/status:
                   fail_only: false
                   failure_message: 'Path to Live Failure - See job for details'
-                  mentions: 'U5RD73HM5'
+                  mentions: 'S02GWAQC9AP'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/lint_terraform:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,7 +277,9 @@ workflows:
               ] } }
             post-steps:
               - slack/status:
-                fail_only: true
+                fail_only: false
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
         - use-my-lpa/lint_terraform:
             name: lint_terraform
             filters: { branches: { ignore: [

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,6 +275,11 @@ workflows:
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'Path to Live Failure - See job for details'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
         - use-my-lpa/lint_terraform:
             name: lint_terraform
             filters: { branches: { ignore: [

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,7 +279,7 @@ workflows:
               - slack/status:
                   fail_only: false
                   failure_message: 'Path to Live Failure - See job for details'
-                  mentions: 'ual-devs'
+                  mentions: 'U5RD73HM5'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/lint_terraform:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -479,7 +479,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'S02GWAQC9AP'
+                  mentions: '${SLACK_GROUP_ID}'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -490,7 +490,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'S02GWAQC9AP'
+                  mentions: '${SLACK_GROUP_ID}'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -500,7 +500,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'S02GWAQC9AP'
+                  mentions: '${SLACK_GROUP_ID}'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -511,7 +511,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'S02GWAQC9AP'
+                  mentions: '${SLACK_GROUP_ID}'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -522,7 +522,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'S02GWAQC9AP'
+                  mentions: '${SLACK_GROUP_ID}'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -551,7 +551,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'S02GWAQC9AP'
+                  mentions: '${SLACK_GROUP_ID}'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -561,7 +561,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'S02GWAQC9AP'
+                  mentions: '${SLACK_GROUP_ID}'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -571,7 +571,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'S02GWAQC9AP'
+                  mentions: '${SLACK_GROUP_ID}'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -589,7 +589,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'S02GWAQC9AP'
+                  mentions: '${SLACK_GROUP_ID}'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -601,7 +601,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'S02GWAQC9AP'
+                  mentions: '${SLACK_GROUP_ID}'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -616,7 +616,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'S02GWAQC9AP'
+                  mentions: '${SLACK_GROUP_ID}'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -637,7 +637,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'S02GWAQC9AP'
+                  mentions: '${SLACK_GROUP_ID}'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -667,7 +667,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'S02GWAQC9AP'
+                  mentions: '${SLACK_GROUP_ID}'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -679,7 +679,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'S02GWAQC9AP'
+                  mentions: '${SLACK_GROUP_ID}'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -692,7 +692,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'S02GWAQC9AP'
+                  mentions: '${SLACK_GROUP_ID}'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -713,7 +713,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'S02GWAQC9AP'
+                  mentions: '${SLACK_GROUP_ID}'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -724,7 +724,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'S02GWAQC9AP'
+                  mentions: '${SLACK_GROUP_ID}'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -737,7 +737,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'S02GWAQC9AP'
+                  mentions: '${SLACK_GROUP_ID}'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,12 +275,6 @@ workflows:
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
-            post-steps:
-              - slack/status:
-                fail_only: false
-                failure_message: 'TESTING - Path to Live Failure'
-                success_message: 'TESTING - Path to Live Failure'
-                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
         - use-my-lpa/lint_terraform:
             name: lint_terraform
             filters: { branches: { ignore: [
@@ -481,46 +475,96 @@ workflows:
         - use-my-lpa/node_test_web:
             name: test_web
             filters: { branches: { only: [main] } }
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/node_build_web:
             name: build_web
             filters: { branches: { only: [main] } }
             requires: [test_web]
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/node_test_service_pdf:
             name: test_pdf
             filters: { branches: { only: [main] } }
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/docker_build_front_app:
             name: app_front_build
             filters: { branches: { only: [main] } }
             requires: [build_web]
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/docker_build_front_web:
             name: web_front_build
             filters: { branches: { only: [main] } }
             requires: [build_web]
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/docker_build_api_app:
             name: app_api_build
             filters: { branches: { only: [main] } }
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/docker_build_api_web:
             name: web_api_build
             filters: { branches: { only: [main] } }
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/docker_build_pdf:
             name: pdf_build
             filters: { branches: { only: [main] } }
             requires: [test_pdf]
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/docker_test_admin:
             name: admin_app_test
             filters: { branches: { only: [main] } }
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/docker_build_admin:
             name: admin_app_build
             filters: { branches: { only: [main] } }
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/codecov_upload:
             name: codecov_upload
@@ -533,12 +577,22 @@ workflows:
                 test_pdf,
                 admin_app_test,
               ]
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         # Provision and test preproduction
         - use-my-lpa/apply_shared_terraform:
             name: dev_apply_shared_terraform
             workspace: development
             filters: { branches: { only: [main] } }
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/apply_shared_terraform:
             name: preprod_apply_shared_terraform
@@ -548,6 +602,11 @@ workflows:
               [
                 dev_apply_shared_terraform,
               ]
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/apply_environment_terraform:
             name: preprod_apply_environment_terraform
@@ -563,6 +622,12 @@ workflows:
                 pdf_build,
                 admin_app_build,
               ]
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
+
 
         - ecr_scan_results:
             name: ecr_scan_results
@@ -577,17 +642,32 @@ workflows:
                 admin_app_build,
                 preprod_apply_environment_terraform,
               ]
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/seed_database:
             name: preprod_seed_database
             filters: { branches: { only: [main] } }
             requires: [preprod_apply_environment_terraform]
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/run_behat_suite:
             name: preprod_run_behat_tests
             workspace: preproduction
             filters: { branches: { only: [main] } }
             requires: [preprod_seed_database]
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         # Provision and test production
         - use-my-lpa/apply_shared_terraform:
@@ -595,6 +675,11 @@ workflows:
             workspace: production
             filters: { branches: { only: [main] } }
             requires: [preprod_run_behat_tests]
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/apply_environment_terraform:
             name: production_apply_environment_terraform
@@ -610,11 +695,21 @@ workflows:
                 pdf_build,
                 admin_app_build,
               ]
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/run_healthcheck_test:
             name: prod_run_healthcheck_test
             filters: { branches: { only: [main] } }
             requires: [production_apply_environment_terraform]
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - python_templated_slack_notify:
             name: post_production_release_message
@@ -622,6 +717,11 @@ workflows:
             webhook: $PROD_RELEASE_SLACK_WEBHOOK
             filters: { branches: { only: [main] } }
             requires: [prod_run_healthcheck_test]
+            post-steps:
+              - slack/status:
+                fail_only: true
+                failure_message: 'TESTING - Path to Live Failure'
+                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
 
 orbs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,31 +268,34 @@ workflows:
 
   pr_build:
       jobs:
-        - cancel_redundant_builds:
+        - cancel_redundant_builds: *slack-fail-post-step
             name: cancel_previous_jobs
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
+            post-steps: [slack/status]
 
-        - use-my-lpa/lint_terraform:
+        - use-my-lpa/lint_terraform: *slack-fail-post-step
             name: lint_terraform
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
+            post-steps: [slack/status]
 
-        - use-my-lpa/node_test_web:
+        - use-my-lpa/node_test_web: *slack-fail-post-step
             name: test_web
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
+            post-steps: [slack/status]
 
-        - use-my-lpa/node_build_web:
+        - use-my-lpa/node_build_web: *slack-fail-post-step
             name: build_web
             filters: { branches: { ignore: [
               main,
@@ -300,16 +303,18 @@ workflows:
               /tf\/.*/
               ] } }
             requires: [test_web]
+            post-steps: [slack/status]
 
-        - use-my-lpa/node_test_service_pdf:
+        - use-my-lpa/node_test_service_pdf: *slack-fail-post-step
             name: test_pdf
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
+            post-steps: [slack/status]
 
-        - use-my-lpa/docker_build_front_app:
+        - use-my-lpa/docker_build_front_app: *slack-fail-post-step
             name: app_front_build
             filters: { branches: { ignore: [
               main,
@@ -317,8 +322,9 @@ workflows:
               /tf\/.*/
               ] } }
             requires: [build_web]
+            post-steps: [slack/status]
 
-        - use-my-lpa/docker_build_front_web:
+        - use-my-lpa/docker_build_front_web: *slack-fail-post-step
             name: web_front_build
             filters: { branches: { ignore: [
               main,
@@ -326,40 +332,45 @@ workflows:
               /tf\/.*/
               ] } }
             requires: [build_web]
+            post-steps: [slack/status]
 
-        - use-my-lpa/docker_build_api_app:
+        - use-my-lpa/docker_build_api_app: *slack-fail-post-step
             name: app_api_build
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
+            post-steps: [slack/status]
 
-        - use-my-lpa/docker_build_api_web:
+        - use-my-lpa/docker_build_api_web: *slack-fail-post-step
             name: web_api_build
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
+            post-steps: [slack/status]
 
-        - use-my-lpa/docker_test_admin:
+        - use-my-lpa/docker_test_admin: *slack-fail-post-step
             name: admin_app_test
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
+            post-steps: [slack/status]
 
-        - use-my-lpa/docker_build_admin:
+        - use-my-lpa/docker_build_admin: *slack-fail-post-step
             name: admin_app_build
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
+            post-steps: [slack/status]
 
-        - use-my-lpa/docker_build_pdf:
+        - use-my-lpa/docker_build_pdf: *slack-fail-post-step
             name: pdf_build
             filters: { branches: { ignore: [
               main,
@@ -367,8 +378,9 @@ workflows:
               /tf\/.*/
               ] } }
             requires: [test_pdf]
+            post-steps: [slack/status]
 
-        - use-my-lpa/codecov_upload:
+        - use-my-lpa/codecov_upload: *slack-fail-post-step
             name: codecov_upload
             filters: { branches: { ignore: [
               main,
@@ -383,9 +395,10 @@ workflows:
                 test_pdf,
                 admin_app_test,
               ]
+            post-steps: [slack/status]
 
             # Provision and test development
-        - use-my-lpa/plan_shared_terraform:
+        - use-my-lpa/plan_shared_terraform: *slack-fail-post-step
             name: dev_plan_shared_terraform
             filters: { branches: { ignore: [
               main,
@@ -393,8 +406,9 @@ workflows:
               /tf\/.*/
               ] } }
             requires: [cancel_previous_jobs,lint_terraform]
+            post-steps: [slack/status]
 
-        - use-my-lpa/apply_environment_terraform:
+        - use-my-lpa/apply_environment_terraform: *slack-fail-post-step
             name: dev_apply_environment_terraform
             filters: { branches: { ignore: [
               main,
@@ -412,8 +426,9 @@ workflows:
                 pdf_build,
                 admin_app_build,
               ]
+            post-steps: [slack/status]
 
-        - ecr_scan_results:
+        - ecr_scan_results: *slack-fail-post-step
             name: ecr_scan_results
             filters: { branches: { ignore: [
               main,
@@ -430,8 +445,9 @@ workflows:
                 admin_app_build,
                 dev_apply_environment_terraform,
               ]
+            post-steps: [slack/status]
 
-        - use-my-lpa/seed_database:
+        - use-my-lpa/seed_database: *slack-fail-post-step
             name: dev_seed_database
             filters: { branches: { ignore: [
               main,
@@ -439,8 +455,9 @@ workflows:
               /tf\/.*/
               ] } }
             requires: [dev_apply_environment_terraform]
+            post-steps: [slack/status]
 
-        - use-my-lpa/run_behat_suite:
+        - use-my-lpa/run_behat_suite: *slack-fail-post-step
             name: dev_run_behat_tests
             filters: { branches: { ignore: [
               main,
@@ -448,9 +465,10 @@ workflows:
               /tf\/.*/
               ] } }
             requires: [dev_seed_database]
+            post-steps: [slack/status]
 
 
-        - python_templated_slack_notify:
+        - python_templated_slack_notify: *slack-fail-post-step
             name: post_environment_domains
             template: successful_dev_build.txt
             filters: { branches: { ignore: [
@@ -459,8 +477,9 @@ workflows:
               /tf\/.*/
               ] } }
             requires: [dev_run_behat_tests]
+            post-steps: [slack/status]
 
-        - python_templated_slack_on_fail_notify:
+        - python_templated_slack_on_fail_notify: *slack-fail-post-step
             name: on_fail_notification
             template: on_fail.txt
             filters: { branches: { ignore: [
@@ -468,6 +487,7 @@ workflows:
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
+            post-steps: [slack/status]
 
         # Required end of workflow job
         - use-my-lpa/end_of_workflow:
@@ -629,7 +649,7 @@ workflows:
 
 
 orbs:
-  slack: circleci/slack@3.3.0
+  slack: circleci/slack@3.4.2
   use-my-lpa:
     orbs:
       docker: circleci/docker@1.4.0
@@ -1506,32 +1526,37 @@ jobs:
             --template_path ~/project/scripts/pipeline/post_release_slack_notification/<<parameters.template>> \
             --commit_message "$(git log -1 --pretty=%B)"
 
-  python_templated_slack_on_fail_notify:
-    docker:
-      - image: circleci/python
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_ACCESS_TOKEN
-    resource_class: small
-    parameters:
-      template:
-        type: string
-      webhook:
-        type: string
-        default: $SLACK_WEBHOOK
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Notify Slack
-          when: on_fail
-          command: |
-            pip install -r ~/project/scripts/pipeline/requirements.txt
-            python ~/project/scripts/pipeline/post_release_slack_notification/post_release_slack_notification.py \
-            --slack_webhook <<parameters.webhook>> \
-            --template_path ~/project/scripts/pipeline/post_release_slack_notification/<<parameters.template>> \
-            --commit_message "$(git log -1 --pretty=%B)"
+  slack-fail-post-step: &slack-fail-post-step
+  post-steps:
+    - slack/status:
+        fail_only: true
+
+  # python_templated_slack_on_fail_notify:
+  #   docker:
+  #     - image: circleci/python
+  #       auth:
+  #         username: $DOCKER_USER
+  #         password: $DOCKER_ACCESS_TOKEN
+  #   resource_class: small
+  #   parameters:
+  #     template:
+  #       type: string
+  #     webhook:
+  #       type: string
+  #       default: $SLACK_WEBHOOK
+  #   steps:
+  #     - checkout
+  #     - attach_workspace:
+  #         at: /tmp
+  #     - run:
+  #         name: Notify Slack
+  #         when: on_fail
+  #         command: |
+  #           pip install -r ~/project/scripts/pipeline/requirements.txt
+  #           python ~/project/scripts/pipeline/post_release_slack_notification/post_release_slack_notification.py \
+  #           --slack_webhook <<parameters.webhook>> \
+  #           --template_path ~/project/scripts/pipeline/post_release_slack_notification/<<parameters.template>> \
+  #           --commit_message "$(git log -1 --pretty=%B)"
 
 
   slack_notify_stats:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,12 +275,6 @@ workflows:
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
-            post-steps:
-              - slack/status:
-                  fail_only: false
-                  failure_message: 'Path to Live Failure - See job for details'
-                  mentions: 'S02GWAQC9AP'
-                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/lint_terraform:
             name: lint_terraform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,7 +461,7 @@ workflows:
             requires: [dev_run_behat_tests]
 
         - python_templated_slack_on_fail_notify:
-            name: post_environment_domains
+            name: on_fail_notification
             template: on_fail.txt
             filters: { branches: { ignore: [
               main,

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,11 +275,6 @@ workflows:
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
-            post-steps:
-              - slack/status:
-                  fail_only: false
-                  failure_message: 'Path to Live Failure - See job for details'
-                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
         - use-my-lpa/lint_terraform:
             name: lint_terraform
             filters: { branches: { ignore: [

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,5 @@
 version: 2.1
 
-slack-fail-post-step: &slack-fail-post-step
-  post-steps:
-    - slack/status:
-        fail_only: true
-
 workflows:
   keep_demo_environment_up_to_date:
     triggers:
@@ -281,8 +276,8 @@ workflows:
               /tf\/.*/
               ] } }
             post-steps:
-              - slack/status
-
+              - slack/status:
+                fail_only: true
         - use-my-lpa/lint_terraform:
             name: lint_terraform
             filters: { branches: { ignore: [

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -485,7 +485,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'ual-devs'
+                  mentions: 'S02GWAQC9AP'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -496,7 +496,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'ual-devs'
+                  mentions: 'S02GWAQC9AP'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -506,7 +506,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'ual-devs'
+                  mentions: 'S02GWAQC9AP'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -517,7 +517,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'ual-devs'
+                  mentions: 'S02GWAQC9AP'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -528,7 +528,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'ual-devs'
+                  mentions: 'S02GWAQC9AP'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -557,7 +557,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'ual-devs'
+                  mentions: 'S02GWAQC9AP'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -567,7 +567,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'ual-devs'
+                  mentions: 'S02GWAQC9AP'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -577,7 +577,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'ual-devs'
+                  mentions: 'S02GWAQC9AP'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -595,7 +595,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'ual-devs'
+                  mentions: 'S02GWAQC9AP'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -607,7 +607,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'ual-devs'
+                  mentions: 'S02GWAQC9AP'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -622,7 +622,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'ual-devs'
+                  mentions: 'S02GWAQC9AP'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -643,7 +643,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'ual-devs'
+                  mentions: 'S02GWAQC9AP'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -673,7 +673,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'ual-devs'
+                  mentions: 'S02GWAQC9AP'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -685,7 +685,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'ual-devs'
+                  mentions: 'S02GWAQC9AP'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -698,7 +698,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'ual-devs'
+                  mentions: 'S02GWAQC9AP'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -719,7 +719,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'ual-devs'
+                  mentions: 'S02GWAQC9AP'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -730,7 +730,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'ual-devs'
+                  mentions: 'S02GWAQC9AP'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -743,7 +743,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
-                  mentions: 'ual-devs'
+                  mentions: 'S02GWAQC9AP'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,9 +277,9 @@ workflows:
               ] } }
             post-steps:
               - slack/status:
-                fail_only: true
-                failure_message: 'Path to Live Failure - See job for details'
-                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
+                  fail_only: true
+                  failure_message: 'Path to Live Failure - See job for details'
+                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
         - use-my-lpa/lint_terraform:
             name: lint_terraform
             filters: { branches: { ignore: [
@@ -482,9 +482,9 @@ workflows:
             filters: { branches: { only: [main] } }
             post-steps:
               - slack/status:
-                fail_only: true
-                failure_message: 'Path to Live Failure - See job for details'
-                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
+                  fail_only: true
+                  failure_message: 'Path to Live Failure - See job for details'
+                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/node_build_web:
             name: build_web
@@ -492,18 +492,18 @@ workflows:
             requires: [test_web]
             post-steps:
               - slack/status:
-                fail_only: true
-                failure_message: 'Path to Live Failure - See job for details'
-                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
+                  fail_only: true
+                  failure_message: 'Path to Live Failure - See job for details'
+                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/node_test_service_pdf:
             name: test_pdf
             filters: { branches: { only: [main] } }
             post-steps:
               - slack/status:
-                fail_only: true
-                failure_message: 'Path to Live Failure - See job for details'
-                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
+                  fail_only: true
+                  failure_message: 'Path to Live Failure - See job for details'
+                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/docker_build_front_app:
             name: app_front_build
@@ -511,9 +511,9 @@ workflows:
             requires: [build_web]
             post-steps:
               - slack/status:
-                fail_only: true
-                failure_message: 'Path to Live Failure - See job for details'
-                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
+                  fail_only: true
+                  failure_message: 'Path to Live Failure - See job for details'
+                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/docker_build_front_web:
             name: web_front_build
@@ -521,9 +521,9 @@ workflows:
             requires: [build_web]
             post-steps:
               - slack/status:
-                fail_only: true
-                failure_message: 'Path to Live Failure - See job for details'
-                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
+                  fail_only: true
+                  failure_message: 'Path to Live Failure - See job for details'
+                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/docker_build_api_app:
             name: app_api_build
@@ -549,27 +549,27 @@ workflows:
             requires: [test_pdf]
             post-steps:
               - slack/status:
-                fail_only: true
-                failure_message: 'Path to Live Failure - See job for details'
-                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
+                  fail_only: true
+                  failure_message: 'Path to Live Failure - See job for details'
+                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/docker_test_admin:
             name: admin_app_test
             filters: { branches: { only: [main] } }
             post-steps:
               - slack/status:
-                fail_only: true
-                failure_message: 'Path to Live Failure - See job for details'
-                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
+                  fail_only: true
+                  failure_message: 'Path to Live Failure - See job for details'
+                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/docker_build_admin:
             name: admin_app_build
             filters: { branches: { only: [main] } }
             post-steps:
               - slack/status:
-                fail_only: true
-                failure_message: 'Path to Live Failure - See job for details'
-                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
+                  fail_only: true
+                  failure_message: 'Path to Live Failure - See job for details'
+                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/codecov_upload:
             name: codecov_upload
@@ -584,9 +584,9 @@ workflows:
               ]
             post-steps:
               - slack/status:
-                fail_only: true
-                failure_message: 'Path to Live Failure - See job for details'
-                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
+                  fail_only: true
+                  failure_message: 'Path to Live Failure - See job for details'
+                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         # Provision and test preproduction
         - use-my-lpa/apply_shared_terraform:
@@ -595,9 +595,9 @@ workflows:
             filters: { branches: { only: [main] } }
             post-steps:
               - slack/status:
-                fail_only: true
-                failure_message: 'Path to Live Failure - See job for details'
-                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
+                  fail_only: true
+                  failure_message: 'Path to Live Failure - See job for details'
+                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/apply_shared_terraform:
             name: preprod_apply_shared_terraform
@@ -609,9 +609,9 @@ workflows:
               ]
             post-steps:
               - slack/status:
-                fail_only: true
-                failure_message: 'Path to Live Failure - See job for details'
-                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
+                  fail_only: true
+                  failure_message: 'Path to Live Failure - See job for details'
+                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/apply_environment_terraform:
             name: preprod_apply_environment_terraform
@@ -629,10 +629,9 @@ workflows:
               ]
             post-steps:
               - slack/status:
-                fail_only: true
-                failure_message: 'Path to Live Failure - See job for details'
-                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
-
+                  fail_only: true
+                  failure_message: 'Path to Live Failure - See job for details'
+                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - ecr_scan_results:
             name: ecr_scan_results
@@ -659,9 +658,9 @@ workflows:
             requires: [preprod_apply_environment_terraform]
             post-steps:
               - slack/status:
-                fail_only: true
-                failure_message: 'Path to Live Failure - See job for details'
-                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
+                  fail_only: true
+                  failure_message: 'Path to Live Failure - See job for details'
+                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/run_behat_suite:
             name: preprod_run_behat_tests
@@ -670,9 +669,9 @@ workflows:
             requires: [preprod_seed_database]
             post-steps:
               - slack/status:
-                fail_only: true
-                failure_message: 'Path to Live Failure - See job for details'
-                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
+                  fail_only: true
+                  failure_message: 'Path to Live Failure - See job for details'
+                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         # Provision and test production
         - use-my-lpa/apply_shared_terraform:
@@ -682,9 +681,9 @@ workflows:
             requires: [preprod_run_behat_tests]
             post-steps:
               - slack/status:
-                fail_only: true
-                failure_message: 'Path to Live Failure - See job for details'
-                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
+                  fail_only: true
+                  failure_message: 'Path to Live Failure - See job for details'
+                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/apply_environment_terraform:
             name: production_apply_environment_terraform
@@ -702,9 +701,9 @@ workflows:
               ]
             post-steps:
               - slack/status:
-                fail_only: true
-                failure_message: 'Path to Live Failure - See job for details'
-                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
+                  fail_only: true
+                  failure_message: 'Path to Live Failure - See job for details'
+                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/run_healthcheck_test:
             name: prod_run_healthcheck_test
@@ -712,9 +711,9 @@ workflows:
             requires: [production_apply_environment_terraform]
             post-steps:
               - slack/status:
-                fail_only: true
-                failure_message: 'Path to Live Failure - See job for details'
-                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
+                  fail_only: true
+                  failure_message: 'Path to Live Failure - See job for details'
+                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - python_templated_slack_notify:
             name: post_production_release_message
@@ -724,9 +723,9 @@ workflows:
             requires: [prod_run_healthcheck_test]
             post-steps:
               - slack/status:
-                fail_only: true
-                failure_message: 'Path to Live Failure - See job for details'
-                webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
+                  fail_only: true
+                  failure_message: 'Path to Live Failure - See job for details'
+                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
 
 orbs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -460,6 +460,15 @@ workflows:
               ] } }
             requires: [dev_run_behat_tests]
 
+        - python_templated_slack_on_fail_notify:
+            name: post_environment_domains
+            template: on_fail.txt
+            filters: { branches: { ignore: [
+              main,
+              /dependabot\/.*/,
+              /tf\/.*/
+              ] } }
+
         # Required end of workflow job
         - use-my-lpa/end_of_workflow:
             name: end_of_workflow
@@ -1491,7 +1500,32 @@ jobs:
       - run:
           name: Notify Slack
           command: |
+            pip install -r ~/project/scripts/pipeline/requirements.txt
+            python ~/project/scripts/pipeline/post_release_slack_notification/post_release_slack_notification.py \
+            --slack_webhook <<parameters.webhook>> \
+            --template_path ~/project/scripts/pipeline/post_release_slack_notification/<<parameters.template>> \
+            --commit_message "$(git log -1 --pretty=%B)"
 
+  python_templated_slack_on_fail_notify:
+    docker:
+      - image: circleci/python
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_ACCESS_TOKEN
+    resource_class: small
+    parameters:
+      template:
+        type: string
+      webhook:
+        type: string
+        default: $SLACK_WEBHOOK
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp
+      - run:
+          name: Notify Slack
+          command: |
             pip install -r ~/project/scripts/pipeline/requirements.txt
             python ~/project/scripts/pipeline/post_release_slack_notification/post_release_slack_notification.py \
             --slack_webhook <<parameters.webhook>> \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,10 @@
 version: 2.1
 
+slack-fail-post-step: &slack-fail-post-step
+  post-steps:
+    - slack/status:
+        fail_only: true
+
 workflows:
   keep_demo_environment_up_to_date:
     triggers:
@@ -268,34 +273,33 @@ workflows:
 
   pr_build:
       jobs:
-        - cancel_redundant_builds: *slack-fail-post-step
+        - cancel_redundant_builds:
             name: cancel_previous_jobs
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
-            post-steps: [slack/status]
+            post-steps:
+              - slack/status
 
-        - use-my-lpa/lint_terraform: *slack-fail-post-step
+        - use-my-lpa/lint_terraform:
             name: lint_terraform
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
-            post-steps: [slack/status]
 
-        - use-my-lpa/node_test_web: *slack-fail-post-step
+        - use-my-lpa/node_test_web:
             name: test_web
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
-            post-steps: [slack/status]
 
-        - use-my-lpa/node_build_web: *slack-fail-post-step
+        - use-my-lpa/node_build_web:
             name: build_web
             filters: { branches: { ignore: [
               main,
@@ -303,18 +307,16 @@ workflows:
               /tf\/.*/
               ] } }
             requires: [test_web]
-            post-steps: [slack/status]
 
-        - use-my-lpa/node_test_service_pdf: *slack-fail-post-step
+        - use-my-lpa/node_test_service_pdf:
             name: test_pdf
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
-            post-steps: [slack/status]
 
-        - use-my-lpa/docker_build_front_app: *slack-fail-post-step
+        - use-my-lpa/docker_build_front_app:
             name: app_front_build
             filters: { branches: { ignore: [
               main,
@@ -322,9 +324,8 @@ workflows:
               /tf\/.*/
               ] } }
             requires: [build_web]
-            post-steps: [slack/status]
 
-        - use-my-lpa/docker_build_front_web: *slack-fail-post-step
+        - use-my-lpa/docker_build_front_web:
             name: web_front_build
             filters: { branches: { ignore: [
               main,
@@ -332,45 +333,40 @@ workflows:
               /tf\/.*/
               ] } }
             requires: [build_web]
-            post-steps: [slack/status]
 
-        - use-my-lpa/docker_build_api_app: *slack-fail-post-step
+        - use-my-lpa/docker_build_api_app:
             name: app_api_build
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
-            post-steps: [slack/status]
 
-        - use-my-lpa/docker_build_api_web: *slack-fail-post-step
+        - use-my-lpa/docker_build_api_web:
             name: web_api_build
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
-            post-steps: [slack/status]
 
-        - use-my-lpa/docker_test_admin: *slack-fail-post-step
+        - use-my-lpa/docker_test_admin:
             name: admin_app_test
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
-            post-steps: [slack/status]
 
-        - use-my-lpa/docker_build_admin: *slack-fail-post-step
+        - use-my-lpa/docker_build_admin:
             name: admin_app_build
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
-            post-steps: [slack/status]
 
-        - use-my-lpa/docker_build_pdf: *slack-fail-post-step
+        - use-my-lpa/docker_build_pdf:
             name: pdf_build
             filters: { branches: { ignore: [
               main,
@@ -378,9 +374,8 @@ workflows:
               /tf\/.*/
               ] } }
             requires: [test_pdf]
-            post-steps: [slack/status]
 
-        - use-my-lpa/codecov_upload: *slack-fail-post-step
+        - use-my-lpa/codecov_upload:
             name: codecov_upload
             filters: { branches: { ignore: [
               main,
@@ -395,10 +390,9 @@ workflows:
                 test_pdf,
                 admin_app_test,
               ]
-            post-steps: [slack/status]
 
             # Provision and test development
-        - use-my-lpa/plan_shared_terraform: *slack-fail-post-step
+        - use-my-lpa/plan_shared_terraform:
             name: dev_plan_shared_terraform
             filters: { branches: { ignore: [
               main,
@@ -406,9 +400,8 @@ workflows:
               /tf\/.*/
               ] } }
             requires: [cancel_previous_jobs,lint_terraform]
-            post-steps: [slack/status]
 
-        - use-my-lpa/apply_environment_terraform: *slack-fail-post-step
+        - use-my-lpa/apply_environment_terraform:
             name: dev_apply_environment_terraform
             filters: { branches: { ignore: [
               main,
@@ -426,9 +419,8 @@ workflows:
                 pdf_build,
                 admin_app_build,
               ]
-            post-steps: [slack/status]
 
-        - ecr_scan_results: *slack-fail-post-step
+        - ecr_scan_results:
             name: ecr_scan_results
             filters: { branches: { ignore: [
               main,
@@ -445,9 +437,8 @@ workflows:
                 admin_app_build,
                 dev_apply_environment_terraform,
               ]
-            post-steps: [slack/status]
 
-        - use-my-lpa/seed_database: *slack-fail-post-step
+        - use-my-lpa/seed_database:
             name: dev_seed_database
             filters: { branches: { ignore: [
               main,
@@ -455,9 +446,8 @@ workflows:
               /tf\/.*/
               ] } }
             requires: [dev_apply_environment_terraform]
-            post-steps: [slack/status]
 
-        - use-my-lpa/run_behat_suite: *slack-fail-post-step
+        - use-my-lpa/run_behat_suite:
             name: dev_run_behat_tests
             filters: { branches: { ignore: [
               main,
@@ -465,10 +455,9 @@ workflows:
               /tf\/.*/
               ] } }
             requires: [dev_seed_database]
-            post-steps: [slack/status]
 
 
-        - python_templated_slack_notify: *slack-fail-post-step
+        - python_templated_slack_notify:
             name: post_environment_domains
             template: successful_dev_build.txt
             filters: { branches: { ignore: [
@@ -477,9 +466,8 @@ workflows:
               /tf\/.*/
               ] } }
             requires: [dev_run_behat_tests]
-            post-steps: [slack/status]
 
-        - python_templated_slack_on_fail_notify: *slack-fail-post-step
+        - python_templated_slack_on_fail_notify:
             name: on_fail_notification
             template: on_fail.txt
             filters: { branches: { ignore: [
@@ -487,7 +475,6 @@ workflows:
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
-            post-steps: [slack/status]
 
         # Required end of workflow job
         - use-my-lpa/end_of_workflow:
@@ -1526,37 +1513,32 @@ jobs:
             --template_path ~/project/scripts/pipeline/post_release_slack_notification/<<parameters.template>> \
             --commit_message "$(git log -1 --pretty=%B)"
 
-  slack-fail-post-step: &slack-fail-post-step
-  post-steps:
-    - slack/status:
-        fail_only: true
-
-  # python_templated_slack_on_fail_notify:
-  #   docker:
-  #     - image: circleci/python
-  #       auth:
-  #         username: $DOCKER_USER
-  #         password: $DOCKER_ACCESS_TOKEN
-  #   resource_class: small
-  #   parameters:
-  #     template:
-  #       type: string
-  #     webhook:
-  #       type: string
-  #       default: $SLACK_WEBHOOK
-  #   steps:
-  #     - checkout
-  #     - attach_workspace:
-  #         at: /tmp
-  #     - run:
-  #         name: Notify Slack
-  #         when: on_fail
-  #         command: |
-  #           pip install -r ~/project/scripts/pipeline/requirements.txt
-  #           python ~/project/scripts/pipeline/post_release_slack_notification/post_release_slack_notification.py \
-  #           --slack_webhook <<parameters.webhook>> \
-  #           --template_path ~/project/scripts/pipeline/post_release_slack_notification/<<parameters.template>> \
-  #           --commit_message "$(git log -1 --pretty=%B)"
+  python_templated_slack_on_fail_notify:
+    docker:
+      - image: circleci/python
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_ACCESS_TOKEN
+    resource_class: small
+    parameters:
+      template:
+        type: string
+      webhook:
+        type: string
+        default: $SLACK_WEBHOOK
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp
+      - run:
+          name: Notify Slack
+          when: on_fail
+          command: |
+            pip install -r ~/project/scripts/pipeline/requirements.txt
+            python ~/project/scripts/pipeline/post_release_slack_notification/post_release_slack_notification.py \
+            --slack_webhook <<parameters.webhook>> \
+            --template_path ~/project/scripts/pipeline/post_release_slack_notification/<<parameters.template>> \
+            --commit_message "$(git log -1 --pretty=%B)"
 
 
   slack_notify_stats:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -478,7 +478,7 @@ workflows:
             post-steps:
               - slack/status:
                 fail_only: true
-                failure_message: 'TESTING - Path to Live Failure'
+                failure_message: 'Path to Live Failure - See job for details'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/node_build_web:
@@ -488,7 +488,7 @@ workflows:
             post-steps:
               - slack/status:
                 fail_only: true
-                failure_message: 'TESTING - Path to Live Failure'
+                failure_message: 'Path to Live Failure - See job for details'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/node_test_service_pdf:
@@ -497,7 +497,7 @@ workflows:
             post-steps:
               - slack/status:
                 fail_only: true
-                failure_message: 'TESTING - Path to Live Failure'
+                failure_message: 'Path to Live Failure - See job for details'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/docker_build_front_app:
@@ -507,7 +507,7 @@ workflows:
             post-steps:
               - slack/status:
                 fail_only: true
-                failure_message: 'TESTING - Path to Live Failure'
+                failure_message: 'Path to Live Failure - See job for details'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/docker_build_front_web:
@@ -517,7 +517,7 @@ workflows:
             post-steps:
               - slack/status:
                 fail_only: true
-                failure_message: 'TESTING - Path to Live Failure'
+                failure_message: 'Path to Live Failure - See job for details'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/docker_build_api_app:
@@ -526,7 +526,7 @@ workflows:
             post-steps:
               - slack/status:
                 fail_only: true
-                failure_message: 'TESTING - Path to Live Failure'
+                failure_message: 'Path to Live Failure - See job for details'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/docker_build_api_web:
@@ -535,7 +535,7 @@ workflows:
             post-steps:
               - slack/status:
                 fail_only: true
-                failure_message: 'TESTING - Path to Live Failure'
+                failure_message: 'Path to Live Failure - See job for details'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/docker_build_pdf:
@@ -545,7 +545,7 @@ workflows:
             post-steps:
               - slack/status:
                 fail_only: true
-                failure_message: 'TESTING - Path to Live Failure'
+                failure_message: 'Path to Live Failure - See job for details'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/docker_test_admin:
@@ -554,7 +554,7 @@ workflows:
             post-steps:
               - slack/status:
                 fail_only: true
-                failure_message: 'TESTING - Path to Live Failure'
+                failure_message: 'Path to Live Failure - See job for details'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/docker_build_admin:
@@ -563,7 +563,7 @@ workflows:
             post-steps:
               - slack/status:
                 fail_only: true
-                failure_message: 'TESTING - Path to Live Failure'
+                failure_message: 'Path to Live Failure - See job for details'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/codecov_upload:
@@ -580,7 +580,7 @@ workflows:
             post-steps:
               - slack/status:
                 fail_only: true
-                failure_message: 'TESTING - Path to Live Failure'
+                failure_message: 'Path to Live Failure - See job for details'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         # Provision and test preproduction
@@ -591,7 +591,7 @@ workflows:
             post-steps:
               - slack/status:
                 fail_only: true
-                failure_message: 'TESTING - Path to Live Failure'
+                failure_message: 'Path to Live Failure - See job for details'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/apply_shared_terraform:
@@ -605,7 +605,7 @@ workflows:
             post-steps:
               - slack/status:
                 fail_only: true
-                failure_message: 'TESTING - Path to Live Failure'
+                failure_message: 'Path to Live Failure - See job for details'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/apply_environment_terraform:
@@ -625,7 +625,7 @@ workflows:
             post-steps:
               - slack/status:
                 fail_only: true
-                failure_message: 'TESTING - Path to Live Failure'
+                failure_message: 'Path to Live Failure - See job for details'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
 
@@ -645,7 +645,7 @@ workflows:
             post-steps:
               - slack/status:
                 fail_only: true
-                failure_message: 'TESTING - Path to Live Failure'
+                failure_message: 'Path to Live Failure - See job for details'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/seed_database:
@@ -655,7 +655,7 @@ workflows:
             post-steps:
               - slack/status:
                 fail_only: true
-                failure_message: 'TESTING - Path to Live Failure'
+                failure_message: 'Path to Live Failure - See job for details'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/run_behat_suite:
@@ -666,7 +666,7 @@ workflows:
             post-steps:
               - slack/status:
                 fail_only: true
-                failure_message: 'TESTING - Path to Live Failure'
+                failure_message: 'Path to Live Failure - See job for details'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         # Provision and test production
@@ -678,7 +678,7 @@ workflows:
             post-steps:
               - slack/status:
                 fail_only: true
-                failure_message: 'TESTING - Path to Live Failure'
+                failure_message: 'Path to Live Failure - See job for details'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/apply_environment_terraform:
@@ -698,7 +698,7 @@ workflows:
             post-steps:
               - slack/status:
                 fail_only: true
-                failure_message: 'TESTING - Path to Live Failure'
+                failure_message: 'Path to Live Failure - See job for details'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/run_healthcheck_test:
@@ -708,7 +708,7 @@ workflows:
             post-steps:
               - slack/status:
                 fail_only: true
-                failure_message: 'TESTING - Path to Live Failure'
+                failure_message: 'Path to Live Failure - See job for details'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - python_templated_slack_notify:
@@ -720,7 +720,7 @@ workflows:
             post-steps:
               - slack/status:
                 fail_only: true
-                failure_message: 'TESTING - Path to Live Failure'
+                failure_message: 'Path to Live Failure - See job for details'
                 webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,6 +291,12 @@ workflows:
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
+            post-steps:
+              - slack/status:
+                  fail_only: false
+                  mentions: '${SLACK_GROUP_ID}'
+                  failure_message: 'Path to Live Failure - See job for details'
+                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/node_build_web:
             name: build_web

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1525,6 +1525,7 @@ jobs:
           at: /tmp
       - run:
           name: Notify Slack
+          when: on_fail
           command: |
             pip install -r ~/project/scripts/pipeline/requirements.txt
             python ~/project/scripts/pipeline/post_release_slack_notification/post_release_slack_notification.py \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,6 +275,12 @@ workflows:
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
+            post-steps:
+              - slack/status:
+                  fail_only: false
+                  failure_message: 'Path to Live Failure - See job for details'
+                  mentions: 'ual-devs'
+                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/lint_terraform:
             name: lint_terraform
@@ -479,6 +485,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
+                  mentions: 'ual-devs'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -489,6 +496,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
+                  mentions: 'ual-devs'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -498,6 +506,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
+                  mentions: 'ual-devs'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -508,6 +517,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
+                  mentions: 'ual-devs'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -518,6 +528,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
+                  mentions: 'ual-devs'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -546,6 +557,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
+                  mentions: 'ual-devs'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -555,6 +567,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
+                  mentions: 'ual-devs'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -564,6 +577,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
+                  mentions: 'ual-devs'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -581,6 +595,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
+                  mentions: 'ual-devs'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -592,6 +607,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
+                  mentions: 'ual-devs'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -606,6 +622,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
+                  mentions: 'ual-devs'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -626,6 +643,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
+                  mentions: 'ual-devs'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -655,6 +673,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
+                  mentions: 'ual-devs'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -666,6 +685,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
+                  mentions: 'ual-devs'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -678,6 +698,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
+                  mentions: 'ual-devs'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -698,6 +719,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
+                  mentions: 'ual-devs'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -708,6 +730,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
+                  mentions: 'ual-devs'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
@@ -720,6 +743,7 @@ workflows:
             post-steps:
               - slack/status:
                   fail_only: true
+                  mentions: 'ual-devs'
                   failure_message: 'Path to Live Failure - See job for details'
                   webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -465,15 +465,6 @@ workflows:
               ] } }
             requires: [dev_run_behat_tests]
 
-        - python_templated_slack_on_fail_notify:
-            name: on_fail_notification
-            template: on_fail.txt
-            filters: { branches: { ignore: [
-              main,
-              /dependabot\/.*/,
-              /tf\/.*/
-              ] } }
-
         # Required end of workflow job
         - use-my-lpa/end_of_workflow:
             name: end_of_workflow
@@ -1510,34 +1501,6 @@ jobs:
             --slack_webhook <<parameters.webhook>> \
             --template_path ~/project/scripts/pipeline/post_release_slack_notification/<<parameters.template>> \
             --commit_message "$(git log -1 --pretty=%B)"
-
-  python_templated_slack_on_fail_notify:
-    docker:
-      - image: circleci/python
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_ACCESS_TOKEN
-    resource_class: small
-    parameters:
-      template:
-        type: string
-      webhook:
-        type: string
-        default: $SLACK_WEBHOOK
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /tmp
-      - run:
-          name: Notify Slack
-          when: on_fail
-          command: |
-            pip install -r ~/project/scripts/pipeline/requirements.txt
-            python ~/project/scripts/pipeline/post_release_slack_notification/post_release_slack_notification.py \
-            --slack_webhook <<parameters.webhook>> \
-            --template_path ~/project/scripts/pipeline/post_release_slack_notification/<<parameters.template>> \
-            --commit_message "$(git log -1 --pretty=%B)"
-
 
   slack_notify_stats:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,12 +291,6 @@ workflows:
               /dependabot\/.*/,
               /tf\/.*/
               ] } }
-            post-steps:
-              - slack/status:
-                  fail_only: false
-                  mentions: '${SLACK_GROUP_ID}'
-                  failure_message: 'Path to Live Failure - See job for details'
-                  webhook: '${PROD_RELEASE_SLACK_WEBHOOK}'
 
         - use-my-lpa/node_build_web:
             name: build_web

--- a/scripts/pipeline/post_release_slack_notification/on_fail.txt
+++ b/scripts/pipeline/post_release_slack_notification/on_fail.txt
@@ -1,7 +1,0 @@
-:star: *Failed Workflow* :star:
-*User:* {{ user }}
-*Links*
-    *CircleCI build url:* {{ circleci_build_url }}
-
-*Commit message:*
-{{ commit_message }}

--- a/scripts/pipeline/post_release_slack_notification/on_fail.txt
+++ b/scripts/pipeline/post_release_slack_notification/on_fail.txt
@@ -1,0 +1,7 @@
+:star: *Failed Workflow* :star:
+*User:* {{ user }}
+*Links*
+    *CircleCI build url:* {{ circleci_build_url }}
+
+*Commit message:*
+{{ commit_message }}


### PR DESCRIPTION
# Purpose

Let the team know in Slack when the path to live fails

Fixes UML-1875

## Approach

- add post-step to each job on path to live
- call slack/status with fail_only condition to notify team channel of path to live failures

## Learning

- https://circleci.com/docs/2.0/configuration-reference/#pre-steps-and-post-steps-requires-version-21
- https://circleci.com/developer/orbs/orb/circleci/slack
- https://support.circleci.com/hc/en-us/articles/360047082992-Send-slack-notification-at-end-of-workflow

## Checklist

* [x] I have performed a self-review of my own code