### PR TITLE
UML-1947 - configure Service Front App development build targets to report all errors and warnings

### DIFF
--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -37,12 +37,7 @@ FROM production as development
 
 COPY --from=composer-dev /app/vendor /app/vendor
 
-COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
-
-RUN set -xe \
-  && install-php-extensions xdebug \
-  && rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
-  && rm /usr/bin/install-php-extensions
+COPY service-front/docker/app/app-php-development.ini /usr/local/etc/php/conf.d/app-php.ini
 
 CMD ([[ -z "${ENABLE_XDEBUG}" ]] || docker-php-ext-enable xdebug) \
   && php-fpm

--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -37,6 +37,13 @@ FROM production as development
 
 COPY --from=composer-dev /app/vendor /app/vendor
 
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
+
+RUN set -xe \
+  && install-php-extensions xdebug \
+  && rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+  && rm /usr/bin/install-php-extensions
+
 COPY service-front/docker/app/app-php-development.ini /usr/local/etc/php/conf.d/app-php.ini
 
 CMD ([[ -z "${ENABLE_XDEBUG}" ]] || docker-php-ext-enable xdebug) \

--- a/service-front/docker/app/app-php-development.ini
+++ b/service-front/docker/app/app-php-development.ini
@@ -1,3 +1,4 @@
 log_errors = On
 expose_php = Off
-display_errors = On
+display_errors = stderr
+error_reporting = E_ALL

--- a/service-front/docker/app/app-php-development.ini
+++ b/service-front/docker/app/app-php-development.ini
@@ -1,3 +1,3 @@
 log_errors = On
 expose_php = Off
-display_errors = Off
+display_errors = On


### PR DESCRIPTION
# Purpose

Configure Service-Front App PHP to provide useful information during local development

Fixes UML-1947

## Approach

- overwrite app-php.ini at develpment build target for service-front

## Learning

- https://www.php.net/manual/en/errorfunc.configuration.php#ini.error-reporting
- https://www.php.net/manual/en/errorfunc.constants.php#122640

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [x] The product team have tested these changes
