### PR TITLE
UML-1947 - configure Service API App development build targets to report all errors and warnings

### DIFF
--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -32,6 +32,7 @@ CMD php-fpm
 FROM production as development
 
 COPY --from=composer-dev /app/vendor /app/vendor
+COPY service-api/docker/app/app-php-development.ini /usr/local/etc/php/conf.d/app-php.ini
 
 CMD ([[ -z "${ENABLE_XDEBUG}" ]] || docker-php-ext-enable xdebug) \
   && php-fpm

--- a/service-api/docker/app/app-php-development.ini
+++ b/service-api/docker/app/app-php-development.ini
@@ -1,4 +1,4 @@
 log_errors = On
 expose_php = Off
 display_errors = stderr
-error_reporting = E_ALL
+error_reporting = E_ALL & ~E_DEPRECATED

--- a/service-api/docker/app/app-php-development.ini
+++ b/service-api/docker/app/app-php-development.ini
@@ -1,0 +1,4 @@
+log_errors = On
+expose_php = Off
+display_errors = stderr
+error_reporting = E_ALL

--- a/service-api/docker/app/app-php-development.ini
+++ b/service-api/docker/app/app-php-development.ini
@@ -1,4 +1,4 @@
 log_errors = On
 expose_php = Off
 display_errors = stderr
-error_reporting = E_ALL & ~E_DEPRECATED
+error_reporting = E_ALL

--- a/service-api/docker/app/app-php.ini
+++ b/service-api/docker/app/app-php.ini
@@ -1,2 +1,3 @@
 log_errors = On
 expose_php = Off
+display_errors = Off


### PR DESCRIPTION
# Purpose

Configure Service-API App PHP to provide useful information during local development

Fixes UML-1947

## Approach

- overwrite app-php.ini at develpment build target for service-front

## Learning

- https://www.php.net/manual/en/errorfunc.configuration.php#ini.error-reporting
- https://www.php.net/manual/en/errorfunc.constants.php#122640

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [x] The product team have tested these changes
