### PR TITLE
UML-1964 - create an AWS WAF Web ACL with managed rules

### DIFF
--- a/terraform/account/.terraform.lock.hcl
+++ b/terraform/account/.terraform.lock.hcl
@@ -2,21 +2,21 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.65.0"
+  version     = "3.69.0"
   constraints = "~> 3.0"
   hashes = [
-    "h1:ru8cxkvHaLrVIE0hSDyO4npDIPpHsKr7z8jMwLvvu3U=",
-    "zh:108aeaf5e18087d9ac852737a5be1347a28e40825817cc1a29ec523d40268294",
-    "zh:1a719c0c9754f906b2220d3bbf90d483ec0a74cf87768a464d2d657b7901ec6b",
-    "zh:21acdc35ae70a626cbc81eff06181a78843f1ddc2d9200f80fabf2e0466ecbda",
-    "zh:28846628e1a4227a1f2db256d6b22ed36922f37632999af7404aa74703cd9bfb",
-    "zh:32455550dbf86ae07d9782650e86d23c4fa13d7872e48680044692894e8da6ea",
-    "zh:4241246274627c752f9aef2806e810053306001e80fc5b51d27cbe997f75f95e",
-    "zh:5ca0fab3ceb3f41a97c1ebd29561a034cb83fda04da35fd5f8c3c5cb97bb3ea8",
-    "zh:5fed3b79d4ed6424055e8bbfb7a4393e8db5102cdba04b4590f8e0f4194637fb",
-    "zh:99a0bc325b0a59ded1152546c004953a2bb0e110978bf0cc55e1804384941bdb",
-    "zh:e74f9190a417c891992210f9af937ef55749d86a04762d982260fbbc989342a7",
-    "zh:fb6984405ca63d0373bd992ce157e933b8ae9dd94d74b1c5691632f062fe60b2",
+    "h1:PBvQ5w86YSJqL5x7lAwKYxdd7NRyNCTlXz3S61VQWZk=",
+    "zh:0cedd84ba908ba7190052b16cd7f70c41b0e2c2e914e54eecf2e3dae193f47fa",
+    "zh:14b89bac6412e20d415fe67d5f2eaa1414d9bbf75a5bd8fc963f6ab8e3b8b1a0",
+    "zh:159131129edab7ea118dee7d6daf1bfe4615f200a2d5120deb8369cbd2c4b598",
+    "zh:32a3a35964c9becb167180df905f34eb0cae7c30e00452527a0e600ee95c033f",
+    "zh:5330374066ca27d9a00ca667c81183c1dbfa0fcfdd5c1797a6185b76bc7c13bc",
+    "zh:78b75c45b7c660efaf89428ca988a77a4f55eba359f95ed7a54efe87fad1ab8b",
+    "zh:81f723c3f33dc0761ed12b025c1f411fe22f2c6a97e22f4adeb10f7668a5df8f",
+    "zh:98053adb091233fea8c1a82768dfce994e8407e2cb948d28ff88865d2d9a4dcd",
+    "zh:a52866826b51c0b4cb6b970cb3328542846e108c8f4d24c090d7ca0ffa341e44",
+    "zh:a9923cbdf30e9b66f889fef22e1f4b657d9ac1a48812f476ef841405a3c11525",
+    "zh:c079f98be9b8456e6eae6c07c5dcb84ecbcbb70b2f361f1c6f9c3ba90366d905",
   ]
 }
 
@@ -25,6 +25,7 @@ provider "registry.terraform.io/hashicorp/local" {
   constraints = "~> 2.1.0"
   hashes = [
     "h1:EYZdckuGU3n6APs97nS2LxZm3dDtGqyM4qaIvsmac8o=",
+    "h1:KfieWtVyGWwplSoLIB5usKAUnrIkDQBkWaR5TI+4WYg=",
     "zh:0f1ec65101fa35050978d483d6e8916664b7556800348456ff3d09454ac1eae2",
     "zh:36e42ac19f5d68467aacf07e6adcf83c7486f2e5b5f4339e9671f68525fc87ab",
     "zh:6db9db2a1819e77b1642ec3b5e95042b202aee8151a0256d289f2e141bf3ceb3",
@@ -43,6 +44,7 @@ provider "registry.terraform.io/pagerduty/pagerduty" {
   version     = "2.1.1"
   constraints = "~> 2.1.1"
   hashes = [
+    "h1:1ipUpu+f3KYR8Fnp9VVbjQehg4irsi3QAsF1AsL2Mxk=",
     "h1:DX7kUvkhT9XHS14b4GxvvlRf7gbWfUF7GrBDyOGPRCo=",
     "zh:0ccd9ebc0dad5f4864b021b400392aeb17aa2317207690cbac211037123dc7dc",
     "zh:17c8be1ab2ba071849df71b497ebad68c9cfccc2b86b790c87f3eb5e1a63f841",

--- a/terraform/account/waf.tf
+++ b/terraform/account/waf.tf
@@ -1,5 +1,5 @@
 resource "aws_wafv2_web_acl" "main" {
-  name        = "development-web-acl"
+  name        = "${local.account_name}-web-acl"
   description = "Managed rules"
   scope       = "REGIONAL"
 
@@ -25,6 +25,27 @@ resource "aws_wafv2_web_acl" "main" {
     visibility_config {
       cloudwatch_metrics_enabled = true
       metric_name                = "AWS-AWSManagedRulesPHPRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+  rule {
+    name     = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
       sampled_requests_enabled   = true
     }
   }

--- a/terraform/account/waf.tf
+++ b/terraform/account/waf.tf
@@ -1,0 +1,129 @@
+resource "aws_wafv2_web_acl" "main" {
+  name        = "development-web-acl"
+  description = "Managed rules"
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesPHPRuleSet"
+    priority = 0
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesPHPRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesPHPRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${local.account_name}-web-acl"
+    sampled_requests_enabled   = true
+  }
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "main" {
+  log_destination_configs = [aws_cloudwatch_log_group.waf_web_acl.arn]
+  resource_arn            = aws_wafv2_web_acl.main.arn
+}
+
+resource "aws_cloudwatch_log_group" "waf_web_acl" {
+  name              = "aws-waf-logs-${local.account_name}"
+  retention_in_days = 120
+  kms_key_id        = aws_kms_key.waf_cloudwatch_log_encryption.arn
+  tags = {
+    "Name" = "${local.account_name}-web-acl"
+  }
+}
+
+resource "aws_kms_key" "waf_cloudwatch_log_encryption" {
+  description             = "AWS WAF Cloudwatch encryption ${local.account_name}"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.waf_cloudwatch_log_encryption_kms.json
+}
+
+resource "aws_kms_alias" "waf_cloudwatch_log_encryption" {
+  name          = "alias/waf_cloudwatch_log_encryption"
+  target_key_id = aws_kms_key.waf_cloudwatch_log_encryption.key_id
+}
+
+# See the following link for further information
+# https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html
+data "aws_iam_policy_document" "waf_cloudwatch_log_encryption_kms" {
+  statement {
+    sid       = "Enable Root account permissions on Key"
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
+      ]
+    }
+  }
+
+  statement {
+    sid       = "Allow Key to be used for Encryption"
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "logs.${data.aws_region.current.name}.amazonaws.com",
+        "events.amazonaws.com"
+      ]
+    }
+  }
+
+  statement {
+    sid       = "Key Administrator"
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion"
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/breakglass"]
+    }
+  }
+}

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -64,6 +64,7 @@ variable "environments" {
       save_older_lpa_requests                   = bool
       load_balancer_deletion_protection_enabled = bool
       notify_key_secret_name                    = string
+      aws_waf_enabled                           = bool
     })
   )
 }

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -64,7 +64,7 @@ variable "environments" {
       save_older_lpa_requests                   = bool
       load_balancer_deletion_protection_enabled = bool
       notify_key_secret_name                    = string
-      associate_waf_web_acl_with_alb_enabled    = bool
+      associate_alb_with_waf_web_acl_enabled    = bool
     })
   )
 }

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -64,7 +64,7 @@ variable "environments" {
       save_older_lpa_requests                   = bool
       load_balancer_deletion_protection_enabled = bool
       notify_key_secret_name                    = string
-      aws_waf_enabled                           = bool
+      associate_waf_web_acl_with_alb_enabled    = bool
     })
   )
 }

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -46,7 +46,8 @@
       "allow_meris_lpas": false,
       "save_older_lpa_requests": true,
       "load_balancer_deletion_protection_enabled": false,
-      "notify_key_secret_name": "notify-api-key"
+      "notify_key_secret_name": "notify-api-key",
+      "aws_waf_enabled": false
     },
     "demo": {
       "account_id": "367815980639",
@@ -94,7 +95,8 @@
       "allow_meris_lpas": false,
       "save_older_lpa_requests": true,
       "load_balancer_deletion_protection_enabled": false,
-      "notify_key_secret_name": "notify-api-key-demo"
+      "notify_key_secret_name": "notify-api-key-demo",
+      "aws_waf_enabled": true
     },
     "preproduction": {
       "account_id": "888228022356",
@@ -142,7 +144,8 @@
       "allow_meris_lpas": false,
       "save_older_lpa_requests": true,
       "load_balancer_deletion_protection_enabled": true,
-      "notify_key_secret_name": "notify-api-key"
+      "notify_key_secret_name": "notify-api-key",
+      "aws_waf_enabled": false
     },
     "production": {
       "account_id": "690083044361",
@@ -190,7 +193,8 @@
       "allow_meris_lpas": false,
       "save_older_lpa_requests": true,
       "load_balancer_deletion_protection_enabled": true,
-      "notify_key_secret_name": "notify-api-key"
+      "notify_key_secret_name": "notify-api-key",
+      "aws_waf_enabled": true
     }
   }
 }

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -47,7 +47,7 @@
       "save_older_lpa_requests": true,
       "load_balancer_deletion_protection_enabled": false,
       "notify_key_secret_name": "notify-api-key",
-      "associate_waf_web_acl_with_alb_enabled": false
+      "associate_alb_with_waf_web_acl_enabled": false
     },
     "demo": {
       "account_id": "367815980639",
@@ -96,7 +96,7 @@
       "save_older_lpa_requests": true,
       "load_balancer_deletion_protection_enabled": false,
       "notify_key_secret_name": "notify-api-key-demo",
-      "associate_waf_web_acl_with_alb_enabled": true
+      "associate_alb_with_waf_web_acl_enabled": true
     },
     "preproduction": {
       "account_id": "888228022356",
@@ -145,7 +145,7 @@
       "save_older_lpa_requests": true,
       "load_balancer_deletion_protection_enabled": true,
       "notify_key_secret_name": "notify-api-key",
-      "associate_waf_web_acl_with_alb_enabled": true
+      "associate_alb_with_waf_web_acl_enabled": true
     },
     "production": {
       "account_id": "690083044361",
@@ -194,7 +194,7 @@
       "save_older_lpa_requests": true,
       "load_balancer_deletion_protection_enabled": true,
       "notify_key_secret_name": "notify-api-key",
-      "associate_waf_web_acl_with_alb_enabled": false
+      "associate_alb_with_waf_web_acl_enabled": false
     }
   }
 }

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -47,7 +47,7 @@
       "save_older_lpa_requests": true,
       "load_balancer_deletion_protection_enabled": false,
       "notify_key_secret_name": "notify-api-key",
-      "aws_waf_enabled": false
+      "associate_waf_web_acl_with_alb_enabled": false
     },
     "demo": {
       "account_id": "367815980639",
@@ -96,7 +96,7 @@
       "save_older_lpa_requests": true,
       "load_balancer_deletion_protection_enabled": false,
       "notify_key_secret_name": "notify-api-key-demo",
-      "aws_waf_enabled": true
+      "associate_waf_web_acl_with_alb_enabled": true
     },
     "preproduction": {
       "account_id": "888228022356",
@@ -145,7 +145,7 @@
       "save_older_lpa_requests": true,
       "load_balancer_deletion_protection_enabled": true,
       "notify_key_secret_name": "notify-api-key",
-      "aws_waf_enabled": true
+      "associate_waf_web_acl_with_alb_enabled": true
     },
     "production": {
       "account_id": "690083044361",
@@ -194,7 +194,7 @@
       "save_older_lpa_requests": true,
       "load_balancer_deletion_protection_enabled": true,
       "notify_key_secret_name": "notify-api-key",
-      "aws_waf_enabled": false
+      "associate_waf_web_acl_with_alb_enabled": false
     }
   }
 }

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -145,7 +145,7 @@
       "save_older_lpa_requests": true,
       "load_balancer_deletion_protection_enabled": true,
       "notify_key_secret_name": "notify-api-key",
-      "aws_waf_enabled": false
+      "aws_waf_enabled": true
     },
     "production": {
       "account_id": "690083044361",
@@ -194,7 +194,7 @@
       "save_older_lpa_requests": true,
       "load_balancer_deletion_protection_enabled": true,
       "notify_key_secret_name": "notify-api-key",
-      "aws_waf_enabled": true
+      "aws_waf_enabled": false
     }
   }
 }

--- a/terraform/environment/waf.tf
+++ b/terraform/environment/waf.tf
@@ -4,13 +4,13 @@ data "aws_wafv2_web_acl" "main" {
 }
 
 resource "aws_wafv2_web_acl_association" "actor" {
-  count        = local.environment.associate_waf_web_acl_with_alb_enabled ? 1 : 0
+  count        = local.environment.associate_alb_with_waf_web_acl_enabled ? 1 : 0
   resource_arn = aws_lb.actor.arn
   web_acl_arn  = data.aws_wafv2_web_acl.main.arn
 }
 
 resource "aws_wafv2_web_acl_association" "viewer" {
-  count        = local.environment.associate_waf_web_acl_with_alb_enabled ? 1 : 0
+  count        = local.environment.associate_alb_with_waf_web_acl_enabled ? 1 : 0
   resource_arn = aws_lb.viewer.arn
   web_acl_arn  = data.aws_wafv2_web_acl.main.arn
 }

--- a/terraform/environment/waf.tf
+++ b/terraform/environment/waf.tf
@@ -4,13 +4,13 @@ data "aws_wafv2_web_acl" "main" {
 }
 
 resource "aws_wafv2_web_acl_association" "actor" {
-  count        = local.environment.associate_waf_web_acl_with_alb_enabled == true ? 1 : 0
+  count        = local.environment.associate_waf_web_acl_with_alb_enabled ? 1 : 0
   resource_arn = aws_lb.actor.arn
   web_acl_arn  = data.aws_wafv2_web_acl.main.arn
 }
 
 resource "aws_wafv2_web_acl_association" "viewer" {
-  count        = local.environment.associate_waf_web_acl_with_alb_enabled == true ? 1 : 0
+  count        = local.environment.associate_waf_web_acl_with_alb_enabled ? 1 : 0
   resource_arn = aws_lb.viewer.arn
   web_acl_arn  = data.aws_wafv2_web_acl.main.arn
 }

--- a/terraform/environment/waf.tf
+++ b/terraform/environment/waf.tf
@@ -1,0 +1,16 @@
+data "aws_wafv2_web_acl" "main" {
+  name  = "${local.environment.account_name}-web-acl"
+  scope = "REGIONAL"
+}
+
+resource "aws_wafv2_web_acl_association" "actor" {
+  count        = local.environment.aws_waf_enabled == true ? 1 : 0
+  resource_arn = aws_lb.actor.arn
+  web_acl_arn  = data.aws_wafv2_web_acl.main.arn
+}
+
+resource "aws_wafv2_web_acl_association" "viewer" {
+  count        = local.environment.aws_waf_enabled == true ? 1 : 0
+  resource_arn = aws_lb.viewer.arn
+  web_acl_arn  = data.aws_wafv2_web_acl.main.arn
+}

--- a/terraform/environment/waf.tf
+++ b/terraform/environment/waf.tf
@@ -4,13 +4,13 @@ data "aws_wafv2_web_acl" "main" {
 }
 
 resource "aws_wafv2_web_acl_association" "actor" {
-  count        = local.environment.aws_waf_enabled == true ? 1 : 0
+  count        = local.environment.associate_waf_web_acl_with_alb_enabled == true ? 1 : 0
   resource_arn = aws_lb.actor.arn
   web_acl_arn  = data.aws_wafv2_web_acl.main.arn
 }
 
 resource "aws_wafv2_web_acl_association" "viewer" {
-  count        = local.environment.aws_waf_enabled == true ? 1 : 0
+  count        = local.environment.associate_waf_web_acl_with_alb_enabled == true ? 1 : 0
   resource_arn = aws_lb.viewer.arn
   web_acl_arn  = data.aws_wafv2_web_acl.main.arn
 }


### PR DESCRIPTION
# Purpose

Prevent unwanted requests from reaching the service applications.

Fixes UML-1964

## Approach

- Create a WAF Web ACL for an account
- Create resources for encrypted logging
- Use managed rules
- Conditionally associate an environment's ALBs


## Learning
- https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
