### PR TITLE
UML-1986 - Exit on boto3 client and waiter errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -428,7 +428,6 @@ workflows:
                 app_api_build,
                 pdf_build,
                 admin_app_build,
-                dev_apply_environment_terraform,
               ]
 
         - use-my-lpa/seed_database:

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -108,10 +108,17 @@ class ECRScanChecker:
                             image, tag, severity, cve, description, link)
                         self.report += result
                     print(self.report)
-            except:
-                print(findings)
-                print("Unable to get ECR image scan results for image {0}, tag {1}".format(
-                    image, tag))
+            except botocore.exceptions.ClientError as error:
+                if error.response['Error']['Code'] == 'AccessDeniedException':
+                    print(error.response['Error']['Code'])
+                print(error.response['Error']['Message'])
+
+                # print("Unable to get ECR image scan results for image {0}, tag {1}".format(
+                #     image, tag))
+            # except:
+            #     print(findings)
+            #     print("Unable to get ECR image scan results for image {0}, tag {1}".format(
+            #         image, tag))
 
     def get_ecr_scan_findings(self, image, tag):
         response = self.aws_ecr_client.describe_image_scan_findings(
@@ -164,7 +171,7 @@ def main():
 
     args = parser.parse_args()
     work = ECRScanChecker(args.result_limit, args.search)
-    work.recursive_wait(args.tag)
+    # work.recursive_wait(args.tag)
     work.recursive_check_make_report(args.tag)
     if args.slack_webhook is None:
         print("No slack webhook provided, skipping post of results to slack")

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -79,7 +79,7 @@ class ECRScanChecker:
                 },
                 WaiterConfig={
                     'Delay': 5,
-                    'MaxAttempts': 1
+                    'MaxAttempts': 60
                 }
             )
         except botocore.exceptions.WaiterError as error:
@@ -227,6 +227,7 @@ def main():
 
     args = parser.parse_args()
     work = ECRScanChecker(args.search)
+    work.recursive_wait(args.tag)
     work.recursive_check_make_report(
         args.tag,
         args.ecr_pushed_date_inclusive,

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -140,8 +140,8 @@ class ECRScanChecker:
                 ],
                 'ecrImagePushedAt': [
                     {
-                        'endInclusive': self.date_start_inclusive,
-                        'startInclusive': self.date_end_inclusive
+                        'endInclusive': self.date_end_inclusive
+                        'startInclusive': self.date_start_inclusive
                     },
                 ],
                 'ecrImageRepositoryName': [

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -237,7 +237,7 @@ def main():
 
     args = parser.parse_args()
     work = ECRScanChecker(args.search)
-    # work.recursive_wait(args.tag)
+    work.recursive_wait(args.tag)
     report = work.recursive_check_make_report(
         args.tag,
         args.ecr_pushed_date_inclusive,

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -17,19 +17,26 @@ class ECRScanChecker:
     def __init__(self, search_term):
         self.aws_account_id = 311462405659  # management account id
         aws_iam_session = self.set_iam_role_session()
-        self.aws_ecr_client = boto3.client(
+
+        self.aws_ecr_client = self.get_aws_client(
             'ecr',
-            region_name='eu-west-1',
-            aws_access_key_id=aws_iam_session['Credentials']['AccessKeyId'],
-            aws_secret_access_key=aws_iam_session['Credentials']['SecretAccessKey'],
-            aws_session_token=aws_iam_session['Credentials']['SessionToken'])
-        self.aws_inspector2_client = boto3.client(
+            aws_iam_session)
+
+        self.aws_inspector2_client = self.get_aws_client(
             'inspector2',
-            region_name='eu-west-1',
+            aws_iam_session)
+
+        self.images_to_check = self.get_repositories(search_term)
+
+    @staticmethod
+    def get_aws_client(client_type, aws_iam_session, region="eu-west-1"):
+        client = boto3.client(
+            client_type,
+            region_name=region,
             aws_access_key_id=aws_iam_session['Credentials']['AccessKeyId'],
             aws_secret_access_key=aws_iam_session['Credentials']['SecretAccessKey'],
             aws_session_token=aws_iam_session['Credentials']['SessionToken'])
-        self.images_to_check = self.get_repositories(search_term)
+        return client
 
     def set_iam_role_session(self):
         if os.getenv('CI'):

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -100,6 +100,7 @@ class ECRScanChecker:
     def recursive_check_make_report(self, tag, date_inclusive, report_limit, print_to_terminal):
         print('Checking ECR scan results...')
         for image in self.images_to_check:
+            print(image)
             try:
                 findings = self.list_findings(
                     image, tag, date_inclusive, report_limit)
@@ -212,7 +213,7 @@ def main():
                         default=date.today(),
                         help='ECR Image push datetime in format YYYY-MM-dd')
     parser.add_argument('--result_limit',
-                        default=5,
+                        default=50,
                         help='How many results for each image to return. Defaults to 5')
     parser.add_argument('--slack_webhook',
                         default=os.getenv('SLACK_WEBHOOK'),

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -42,7 +42,7 @@ class ECRScanChecker:
         return session
 
     @staticmethod
-    def get_aws_client(client_type, aws_iam_session, region="eu-west-1"):
+    def get_aws_client(client_type, aws_iam_session, region='eu-west-1'):
         client = boto3.client(
             client_type,
             region_name=region,

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -140,7 +140,7 @@ class ECRScanChecker:
                 ],
                 'ecrImagePushedAt': [
                     {
-                        'endInclusive': self.date_end_inclusive
+                        'endInclusive': self.date_end_inclusive,
                         'startInclusive': self.date_start_inclusive
                     },
                 ],

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -74,9 +74,14 @@ class ECRScanChecker:
                 }
             )
         except botocore.exceptions.WaiterError as error:
-            print(error.last_response['Error']['Code'],
-                  error.last_response['Error']['Message'])
-            exit(1)
+            if error.last_response['Error']['Code'] == "AccessDeniedException":
+                print(error.last_response['Error']['Code'],
+                      error.last_response['Error']['Message'])
+                exit(1)
+            else:
+                print(error.last_response['Error']['Code'],
+                      error.last_response['Error']['Message'])
+
         else:
             print("No ECR image scan results for image {0}, tag {1}".format(
                 image, tag))

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -1,12 +1,12 @@
-import botocore
-import boto3
 import argparse
-import requests
 import json
 import os
-import pprint
 from datetime import date
 from datetime import datetime
+import sys
+import botocore
+import boto3
+import requests
 
 
 class ECRScanChecker:
@@ -57,16 +57,16 @@ class ECRScanChecker:
     def get_repositories(self, search_term):
         images_to_check = []
         response = self.aws_ecr_client.describe_repositories()
-        for repository in response["repositories"]:
-            if search_term in repository["repositoryName"]:
-                images_to_check.append(repository["repositoryName"])
+        for repository in response['repositories']:
+            if search_term in repository['repositoryName']:
+                images_to_check.append(repository['repositoryName'])
         return images_to_check
 
     def recursive_wait(self, tag):
-        print("Waiting for ECR scans to complete...")
+        print('Waiting for ECR scans to complete...')
         for image in self.images_to_check:
             self.wait_for_scan_completion(image, tag)
-        print("ECR image scans complete")
+        print('ECR image scans complete')
 
     def wait_for_scan_completion(self, image, tag):
         try:
@@ -82,40 +82,57 @@ class ECRScanChecker:
                 }
             )
         except botocore.exceptions.WaiterError as error:
-            if 'Error' in error.last_response and 'ScanNotFoundException' in error.last_response['Error']['Code']:
-                print(
-                    f"No ECR image scan results for image {image}, tag {tag}")
-            if 'Error' in error.last_response and not 'ScanNotFoundException' in error.last_response['Error']['Code']:
+            if (
+                'Error' in error.last_response
+                and not 'ScanNotFoundException' in error.last_response['Error']['Code']
+            ):
                 print(error.last_response['Error']['Code'],
                       error.last_response['Error']['Message'])
-                exit(1)
+                sys.exit(1)
+            if (
+                'Error' in error.last_response
+                and 'ScanNotFoundException' in error.last_response['Error']['Code']
+            ):
+                print(
+                    f'No ECR image scan results for image {image}, tag {tag}')
 
     def recursive_check_make_report(self, tag, report_limit, print_to_terminal):
-        print("Checking ECR scan results...")
+        print('Checking ECR scan results...')
         for image in self.images_to_check:
             try:
                 findings = self.list_findings(image, tag, report_limit)
-                if findings["findings"] != []:
+                if findings['findings'] != []:
 
-                    self.report = f"\n\n:warning: *AWS ECR Scan found results for {image}:* \n" + \
-                        f"Vulnerability Reports Found.\nDisplaying the first {report_limit} in order of severity\n\n"
+                    self.report = (
+                        f'\n\n:warning: *AWS ECR Scan found results for {image}:* \n'
+                        f'Vulnerability Reports Found.\n'
+                        f'Displaying the first {report_limit} in order of severity\n\n'
+                    )
 
-                    for finding in findings["findings"]:
-                        cve = finding["title"]
-                        severity = finding["severity"]
-                        description = "None"
-                        if "description" in finding:
-                            description = finding["description"]
-                        link = finding["packageVulnerabilityDetails"]["sourceUrl"]
-                        vuln_type = finding["type"]
-                        result = f"*Image:* {image} \n*Tag:* {tag} \n*Severity:* {severity} \n*CVE:* {cve} \n*Description:* {description} \n*Link:* `{link}`\n*Type:* `{vuln_type}`\n\n"
+                    for finding in findings['findings']:
+                        cve = finding['title']
+                        severity = finding['severity']
+                        description = 'None'
+                        if 'description' in finding:
+                            description = finding['description']
+                        link = finding['packageVulnerabilityDetails']['sourceUrl']
+                        vuln_type = finding['type']
+                        result = (
+                            f'*Image:* {image} \n'
+                            f'*Tag: * {tag} \n'
+                            f'*Severity:* {severity} \n'
+                            f'*Type:* `{vuln_type}`\n'
+                            f'*CVE:* {cve} \n'
+                            f'*Description:* {description} \n'
+                            f'*Link:* `{link}`\n\n'
+                        )
                         self.report += result
                     if print_to_terminal:
                         print(self.report)
             except botocore.exceptions.ClientError as error:
                 print(error.response['Error']['Code'],
                       error.response['Error']['Message'])
-                exit(1)
+                sys.exit(1)
 
     def list_findings(self, image, tag, report_limit):
         response = self.aws_inspector2_client.list_findings(
@@ -154,47 +171,50 @@ class ECRScanChecker:
         return response
 
     def post_to_slack(self, slack_webhook):
-        if self.report != "":
-            build_url = os.getenv('CIRCLE_BUILD_URL', "")
-            circleci_branch = os.getenv('CIRCLE_BRANCH', "")
-            branch_info = f"*Github Branch:* {circleci_branch}\n*CircleCI Job Link:* {build_url}\n\n"
+        if self.report != '':
+            build_url = os.getenv('CIRCLE_BUILD_URL', '')
+            circleci_branch = os.getenv('CIRCLE_BRANCH', '')
+            branch_info = (
+                f'*Github Branch:* {circleci_branch}\n'
+                f'*CircleCI Job Link:* {build_url}\n\n'
+            )
             self.report += branch_info
 
-            post_data = json.dumps({"text": self.report})
+            post_data = json.dumps({'text': self.report})
             response = requests.post(
                 slack_webhook, data=post_data,
                 headers={'Content-Type': 'application/json'}
             )
             if response.status_code != 200:
                 raise ValueError(
-                    'Request to slack returned an error %s, the response is:\n%s'
-                    % (response.status_code, response.text)
+                    f'Request to slack returned an error {response.status_code}, the response is:\n'
+                    f'{response.text}'
                 )
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Check ECR Scan results for all service container images.")
-    parser.add_argument("--search",
-                        default="",
-                        help="The root part oof the ECR repositry path, for example online-lpa")
-    parser.add_argument("--tag",
-                        default="latest",
-                        help="Image tag to check scan results for.")
-    parser.add_argument("--ecr_pushed_date_inclusive",
+        description='Check ECR Scan results for all service container images.')
+    parser.add_argument('--search',
+                        default='',
+                        help='The root part oof the ECR repositry path, for example online-lpa')
+    parser.add_argument('--tag',
+                        default='latest',
+                        help='Image tag to check scan results for.')
+    parser.add_argument('--ecr_pushed_date_inclusive',
                         default=date.today(),
-                        help="ECR Image push datetime in format YYYY-MM-dd")
-    parser.add_argument("--result_limit",
+                        help='ECR Image push datetime in format YYYY-MM-dd')
+    parser.add_argument('--result_limit',
                         default=5,
-                        help="How many results for each image to return. Defaults to 5")
-    parser.add_argument("--slack_webhook",
+                        help='How many results for each image to return. Defaults to 5')
+    parser.add_argument('--slack_webhook',
                         default=os.getenv('SLACK_WEBHOOK'),
-                        help="Webhook to use, determines what channel to post to")
+                        help='Webhook to use, determines what channel to post to')
     parser.add_argument('--print_to_terminal', dest='print_to_terminal', action='store_const',
                         const=True, default=False,
                         help='print findings to terminal')
-    parser.add_argument('--post_to_slack', dest='post_to_slack', action='store_const',
-                        const=True, default=False,
+    parser.add_argument('--skip_post_to_slack', dest='skip_post_to_slack', action='store_const',
+                        const=False, default=True,
                         help='Optionally turn off posting messages to slack')
 
     args = parser.parse_args()
@@ -202,11 +222,11 @@ def main():
     # work.recursive_wait(args.tag)
     work.recursive_check_make_report(
         args.tag, args.result_limit, args.print_to_terminal)
-    if args.slack_webhook is None:
-        print("No slack webhook provided, skipping post of results to slack")
-    if args.post_to_slack and args.slack_webhook is not None:
+    if args.skip_post_to_slack and args.slack_webhook is not None:
         work.post_to_slack(args.slack_webhook)
+    else:
+        print('Skipping post of results to slack')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -170,7 +170,8 @@ class ECRScanChecker:
             )
             if response.status_code != 200:
                 raise ValueError(
-                    f'Request to slack returned an error {response.status_code}, the response is:\n'
+                    f'Request to slack returned an error {response.status_code},'
+                    f'the response is:\n'
                     f'{response.text}'
                 )
 

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -83,8 +83,8 @@ class ECRScanChecker:
             )
         except botocore.exceptions.WaiterError as error:
             if 'Error' in error.last_response and 'ScanNotFoundException' in error.last_response['Error']['Code']:
-                print("No ECR image scan results for image {0}, tag {1}".format(
-                    image, tag))
+                print(
+                    f"No ECR image scan results for image {image}, tag {tag}")
             if 'Error' in error.last_response and not 'ScanNotFoundException' in error.last_response['Error']['Code']:
                 print(error.last_response['Error']['Code'],
                       error.last_response['Error']['Message'])
@@ -96,20 +96,16 @@ class ECRScanChecker:
             try:
                 findings = self.list_findings(image, tag, report_limit)
                 if findings["findings"] != []:
-                    title = f"\n\n:warning: *AWS ECR Scan found results for {image}:* \n"
 
-                    severity_counts = f"Vulnerability Reports Found.\nDisplaying the first {report_limit} in order of severity\n\n"
-
-                    self.report = title + severity_counts
+                    self.report = f"\n\n:warning: *AWS ECR Scan found results for {image}:* \n" + \
+                        f"Vulnerability Reports Found.\nDisplaying the first {report_limit} in order of severity\n\n"
 
                     for finding in findings["findings"]:
                         cve = finding["title"]
                         severity = finding["severity"]
-
                         description = "None"
                         if "description" in finding:
                             description = finding["description"]
-
                         link = finding["packageVulnerabilityDetails"]["sourceUrl"]
                         vuln_type = finding["type"]
                         result = f"*Image:* {image} \n*Tag:* {tag} \n*Severity:* {severity} \n*CVE:* {cve} \n*Description:* {description} \n*Link:* `{link}`\n*Type:* `{vuln_type}`\n\n"
@@ -196,10 +192,10 @@ def main():
                         help="Webhook to use, determines what channel to post to")
     parser.add_argument('--print_to_terminal', dest='print_to_terminal', action='store_const',
                         const=True, default=False,
-                        help='add host IP address to security group ci ingress rule (default: remove all ci ingress rules)')
-    parser.add_argument("--post_to_slack",
-                        default=True,
-                        help="Optionally turn off posting messages to slack")
+                        help='print findings to terminal')
+    parser.add_argument('--post_to_slack', dest='post_to_slack', action='store_const',
+                        const=True, default=False,
+                        help='Optionally turn off posting messages to slack')
 
     args = parser.parse_args()
     work = ECRScanChecker(args.ecr_pushed_date_inclusive, args.search)
@@ -208,7 +204,7 @@ def main():
         args.tag, args.result_limit, args.print_to_terminal)
     if args.slack_webhook is None:
         print("No slack webhook provided, skipping post of results to slack")
-    if args.post_to_slack == True and args.slack_webhook is not None:
+    if args.post_to_slack and args.slack_webhook is not None:
         work.post_to_slack(args.slack_webhook)
 
 

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -213,7 +213,10 @@ def main():
         print(report)
 
     if args.skip_post_to_slack and args.slack_webhook is not None:
-        work.post_to_slack(args.slack_webhook, report)
+        work.post_to_slack(
+            args.slack_webhook,
+            report,
+        )
     else:
         print('Skipping post of results to slack')
 

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -52,13 +52,13 @@ class ECRScanChecker:
         return client
 
     def get_repositories(self, search_term):
-        images_to_check = []
+        repositories = []
         response = self.aws_ecr_client.describe_repositories()
         for repository in response['repositories']:
             if search_term in repository['repositoryName']:
-                images_to_check.append(repository['repositoryName'])
+                repositories.append(repository['repositoryName'])
 
-        return images_to_check
+        return repositories
 
     def list_findings_for_each_repository(self, repositories, tag, date_inclusive, report_limit):
         print('Checking ECR scan results...')
@@ -130,7 +130,7 @@ class ECRScanChecker:
         return response
 
     @classmethod
-    def summarise_finding(cls, image, tag, finding):
+    def summarise_finding(cls, repository, tag, finding):
         severity = finding['severity']
         vuln_type = finding['type']
         cve = finding['title']
@@ -140,7 +140,7 @@ class ECRScanChecker:
         updated = finding['updatedAt']
         link = finding['packageVulnerabilityDetails']['sourceUrl']
         result = (
-            f'*Repository:* {image} \n'
+            f'*Repository:* {repository} \n'
             f'*Tag:* {tag} \n'
             f'*Severity:* {severity} \n'
             f'*Type:* `{vuln_type}`\n'

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -95,9 +95,15 @@ class ECRScanChecker:
                 and 'ScanNotFoundException' in error.last_response['Error']['Code']
             ):
                 print(
-                    f'No ECR image scan results for image {image}, tag {tag}')
+                    f'Image scan does not exist for image {image}, tag {tag}')
             else:
-                print("somethig else went wrong")
+                print(
+                    f'{error}',
+                    f'While waiting for image {image}, tag {tag}')
+        except botocore.exceptions.ClientError as error:
+            print(error.response['Error']['Code'],
+                  error.response['Error']['Message'])
+            sys.exit(1)
 
     def recursive_check_make_report(self, tag, date_inclusive, report_limit):
         print('Checking ECR scan results...')
@@ -231,7 +237,7 @@ def main():
 
     args = parser.parse_args()
     work = ECRScanChecker(args.search)
-    work.recursive_wait(args.tag)
+    # work.recursive_wait(args.tag)
     report = work.recursive_check_make_report(
         args.tag,
         args.ecr_pushed_date_inclusive,

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -61,6 +61,7 @@ class ECRScanChecker:
         for repository in response['repositories']:
             if search_term in repository['repositoryName']:
                 images_to_check.append(repository['repositoryName'])
+
         return images_to_check
 
     def recursive_wait(self, tag):
@@ -79,7 +80,7 @@ class ECRScanChecker:
                 },
                 WaiterConfig={
                     'Delay': 5,
-                    'MaxAttempts': 6
+                    'MaxAttempts': 10
                 }
             )
         except botocore.exceptions.WaiterError as error:
@@ -140,12 +141,15 @@ class ECRScanChecker:
                             f'*Link:* `{link}`\n\n'
                         )
                         self.report += result
-                return self.report
 
             except botocore.exceptions.ClientError as error:
                 print(error.response['Error']['Code'],
                       error.response['Error']['Message'])
                 sys.exit(1)
+            except:
+                print("error")
+
+        return self.report
 
     def list_findings(self, image, tag, date_inclusive, report_limit):
         date_start_inclusive = datetime.combine(
@@ -153,6 +157,7 @@ class ECRScanChecker:
 
         date_end_inclusive = datetime.combine(
             date_inclusive, datetime.max.time())
+
         response = self.aws_inspector2_client.list_findings(
             filterCriteria={
                 'awsAccountId': [

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -242,7 +242,7 @@ def main():
 
     args = parser.parse_args()
     work = ECRScanChecker(args.search)
-    work.recursive_wait(args.tag)
+    # work.recursive_wait(args.tag)
     report = work.recursive_check_make_report(
         args.tag,
         args.ecr_pushed_date_inclusive,

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -120,6 +120,7 @@ class ECRScanChecker:
                             description = finding['description']
                         link = finding['packageVulnerabilityDetails']['sourceUrl']
                         vuln_type = finding['type']
+                        updated = finding['updatedAt']
                         result = (
                             f'*Image:* {image} \n'
                             f'*Tag: * {tag} \n'
@@ -127,6 +128,7 @@ class ECRScanChecker:
                             f'*Type:* `{vuln_type}`\n'
                             f'*CVE:* {cve} \n'
                             f'*Description:* {description} \n'
+                            f'*Updated:* `{updated}`\n'
                             f'*Link:* `{link}`\n\n'
                         )
                         self.report += result
@@ -227,7 +229,7 @@ def main():
 
     args = parser.parse_args()
     work = ECRScanChecker(args.search)
-    work.recursive_wait(args.tag)
+    # work.recursive_wait(args.tag)
     work.recursive_check_make_report(
         args.tag,
         args.ecr_pushed_date_inclusive,

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -1,3 +1,4 @@
+import botocore
 import boto3
 import argparse
 import requests
@@ -72,7 +73,10 @@ class ECRScanChecker:
                     'MaxAttempts': 60
                 }
             )
-        except:
+        except botocore.exceptions.WaiterError as error:
+            print(error)
+            exit(1)
+        else:
             print("No ECR image scan results for image {0}, tag {1}".format(
                 image, tag))
 
@@ -105,6 +109,7 @@ class ECRScanChecker:
                         self.report += result
                     print(self.report)
             except:
+                print(findings)
                 print("Unable to get ECR image scan results for image {0}, tag {1}".format(
                     image, tag))
 

--- a/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
+++ b/scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py
@@ -118,7 +118,7 @@ class ECRScanChecker:
                             description = finding["description"]
 
                         link = finding["findingArn"]
-                        result = "*Image:* {0} \n*Tag:* {1} \n*Severity:* {2} \n*CVE:* {3} \n*Description:* {4} \n*Link:* {5}\n\n".format(
+                        result = "*Image:* {0} \n*Tag:* {1} \n*Severity:* {2} \n*CVE:* {3} \n*Description:* {4} \n*Link:* `{5}`\n\n".format(
                             image, tag, severity, cve, description, link)
                         self.report += result
                     print(self.report)

--- a/scripts/pipeline/requirements.txt
+++ b/scripts/pipeline/requirements.txt
@@ -1,3 +1,4 @@
+botocore
 boto3
 requests
 jinja2


### PR DESCRIPTION
# Purpose

The check scan results job was silently failing due to changes in permissions

Fixes UML-1986

## Approach

- capture boto client exceptions
- refactor to bring up to pylint spec

## Learning

- https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* The product team have tested these changes
