### PR TITLE
UML-2001 - Fix Date Assertions in API App Acceptance Text

### DIFF
--- a/service-api/app/features/context/Acceptance/LpaContext.php
+++ b/service-api/app/features/context/Acceptance/LpaContext.php
@@ -1077,7 +1077,7 @@ class LpaContext implements Context
                             [
                                 'SiriusUid' => $this->lpaUid,
                                 'Added' => '2021-01-05 12:34:56',
-                                'Expires' => '2022-01-05 12:34:56',
+                                'Expires' => (new DateTime('tomorrow'))->format('Y-m-d\TH:i:s.u\Z'),
                                 'UserLpaActor' => $this->userLpaActorToken,
                                 'Organisation' => $this->organisation,
                                 'ViewerCode' => $this->accessCode,
@@ -1341,7 +1341,7 @@ class LpaContext implements Context
                             [
                                 'SiriusUid' => $this->lpaUid,
                                 'Added' => '2021-01-05 12:34:56',
-                                'Expires' => '2022-01-05 12:34:56',
+                                'Expires' => (new DateTime('tomorrow'))->format('Y-m-d\TH:i:s.u\Z'),
                                 'UserLpaActor' => $this->userLpaActorToken,
                                 'Organisation' => $this->organisation,
                                 'ViewerCode' => $this->accessCode,

--- a/service-api/app/features/context/Acceptance/LpaContext.php
+++ b/service-api/app/features/context/Acceptance/LpaContext.php
@@ -3518,5 +3518,4 @@ class LpaContext implements Context
             $this->ui->assertSession()->statusCodeEquals(StatusCodeInterface::STATUS_BAD_REQUEST);
         }
     }
-
 }


### PR DESCRIPTION
# Purpose

API app acceptance tests are failing with an assertion on an explicitely written date.

Fixes UML-2001

## Approach

- set expiry of code to tomorrow using DateTime function

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* The product team have tested these changes
