### PR TITLE
UML-2015 Ensure we check both ID types when showing CreatedBy

### DIFF
--- a/service-api/seeding/dynamodb.py
+++ b/service-api/seeding/dynamodb.py
@@ -122,28 +122,28 @@ userLpaActorMap = [
     {
         'Id': '806f3720-5b43-49ce-ac66-c670860bf4ee',
         'SiriusUid': '700000000138',
-        'ActorId': '23',
+        'ActorId': 23,
         'Added': '2020-08-19T15:22:32.838097Z ',
         'UserId': 'bf9e7e77-f283-49c6-a79c-65d5d309ef77'
     },
     {
         'Id': 'f1315df5-b7c3-430a-baa0-9b96cc629648',
         'SiriusUid': '700000000344',
-        'ActorId': '59',
+        'ActorId': 59,
         'Added': '2020-08-20T14:37:49.522828Z',
         'UserId': 'bf9e7e77-f283-49c6-a79c-65d5d309ef77'
     },
     {
         'Id': '085b6474-d61e-41a4-9778-acb5870c5084',
         'SiriusUid': '700000000047',
-        'ActorId': '9',
+        'ActorId': 9,
         'Added': '2021-04-22T15:01:11.548361Z',
         'UserId': 'bf9e7e77-f283-49c6-a79c-65d5d309ef77'
     },
     {
         'Id': 'e69a80db-0001-45a1-a4c5-06bd7ecf8d2e',
         'SiriusUid': '700000000435',
-        'ActorId': '78' ,
+        'ActorId': 78,
         'Added': '2021-04-22T15:01:11.548361Z',
         'UserId': 'bf9e7e77-f283-49c6-a79c-65d5d309ef77',
         'ActivateBy': activateBy
@@ -151,7 +151,7 @@ userLpaActorMap = [
     {
         'Id': '1600be0d-727c-41aa-a9cb-45857a73ba4f',
         'SiriusUid': '700000000252',
-        'ActorId': '43',
+        'ActorId': 43,
         'Added': '2021-04-23T11:44:11.324804Z',
         'UserId': 'bf9e7e77-f283-49c6-a79c-65d5d309ef77'
     }

--- a/service-front/app/features/context/UI/LpaContext.php
+++ b/service-front/app/features/context/UI/LpaContext.php
@@ -472,7 +472,14 @@ class LpaContext implements Context
     public function iCanSeeAllOfMyAccessCodesAndTheirDetails()
     {
         $this->ui->assertPageContainsText('Active codes');
-        $this->ui->assertPageContainsText('V - XYZ3 - 21AB - C987');
+        $this->ui->assertElementContainsText(
+            '#accordion-default-content-1 dl.govuk-summary-list',
+            'V - XYZ3 - 21AB - C987'
+        );
+        $this->ui->assertElementContainsText(
+            '#accordion-default-content-1 dl.govuk-summary-list',
+            'Ian Deputy'
+        );
     }
 
     /**
@@ -481,10 +488,16 @@ class LpaContext implements Context
     public function iCanSeeAllOfMyActiveAndInactiveAccessCodesAndTheirDetails($activeTitle, $inactiveTitle)
     {
         $this->ui->assertPageContainsText($activeTitle);
-        $this->ui->assertPageContainsText('V - XYZ3 - 21AB - C987');
+        $this->ui->assertElementContainsText(
+            '#accordion-default-content-1 dl.govuk-summary-list',
+            'V - XYZ3 - 21AB - C987'
+        );
 
         $this->ui->assertPageContainsText($inactiveTitle);
-        $this->ui->assertPageContainsText('V - ABC3 - 21AB - CXYZ');
+        $this->ui->assertElementContainsText(
+            '#accordion-default-content-2 dl.govuk-summary-list',
+            'V - ABC3 - 21AB - CXYZ'
+        );
     }
 
     /**

--- a/service-front/app/src/Actor/src/Handler/CheckAccessCodesHandler.php
+++ b/service-front/app/src/Actor/src/Handler/CheckAccessCodesHandler.php
@@ -103,7 +103,7 @@ class CheckAccessCodesHandler extends AbstractHandler implements UserAware, Csrf
                 $shareCodes[$key]['form'] = $form;
             }
 
-            $this->logger->info(
+            $this->logger->debug(
                 'Resolved actor id to {type}:{actor_id}',
                 [
                     'actor_id' => $code['ActorId'],
@@ -111,7 +111,7 @@ class CheckAccessCodesHandler extends AbstractHandler implements UserAware, Csrf
                 ]
             );
 
-            $this->logger->info(
+            $this->logger->debug(
                 'Donor Id is {type}:{donor_id}',
                 [
                     'donor_id' => $lpa->getDonor()->getUId(),
@@ -128,7 +128,7 @@ class CheckAccessCodesHandler extends AbstractHandler implements UserAware, Csrf
             }
 
             foreach ($lpa->getAttorneys() as $attorney) {
-                $this->logger->info(
+                $this->logger->debug(
                     'Attorney Id is {type}:{attorney_id}',
                     [
                         'attorney_id' => $attorney->getUId(),
@@ -144,7 +144,7 @@ class CheckAccessCodesHandler extends AbstractHandler implements UserAware, Csrf
                 }
             }
 
-            $this->logger->info(
+            $this->logger->debug(
                 'Created by resolved to {actor_name}',
                 [
                     'actor_name' => $shareCodes[$key]['CreatedBy'] ?? 'NULL',

--- a/service-front/app/src/Actor/src/Handler/CheckAccessCodesHandler.php
+++ b/service-front/app/src/Actor/src/Handler/CheckAccessCodesHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Actor\Handler;
 
 use Actor\Form\CancelCode;
+use Common\Entity\Lpa;
 use Common\Exception\InvalidRequestException;
 use Common\Handler\{AbstractHandler, CsrfGuardAware, Traits\CsrfGuard, Traits\Session, Traits\User, UserAware};
 use Common\Service\Lpa\{LpaService, ViewerCodeService};
@@ -16,6 +17,7 @@ use Mezzio\Flash\FlashMessagesInterface;
 use Mezzio\Helper\UrlHelper;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Http\Message\{ResponseInterface, ServerRequestInterface};
+use Psr\Log\LoggerInterface;
 
 /**
  * Class CheckAccessCodesHandler
@@ -36,9 +38,10 @@ class CheckAccessCodesHandler extends AbstractHandler implements UserAware, Csrf
         UrlHelper $urlHelper,
         AuthenticationInterface $authenticator,
         LpaService $lpaService,
-        ViewerCodeService $viewerCodeService
+        ViewerCodeService $viewerCodeService,
+        LoggerInterface $logger
     ) {
-        parent::__construct($renderer, $urlHelper);
+        parent::__construct($renderer, $urlHelper, $logger);
 
         $this->setAuthenticator($authenticator);
         $this->lpaService = $lpaService;
@@ -54,6 +57,7 @@ class CheckAccessCodesHandler extends AbstractHandler implements UserAware, Csrf
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
+        /** @var string $actorLpaToken */
         $actorLpaToken = $request->getQueryParams()['lpa'];
 
         if (is_null($actorLpaToken)) {
@@ -65,10 +69,16 @@ class CheckAccessCodesHandler extends AbstractHandler implements UserAware, Csrf
 
         $lpaData = $this->lpaService->getLpaById($identity, $actorLpaToken);
 
-        //UML-1394 TO BE REMOVED IN FUTURE TO SHOW PAGE NOT FOUND WITH APPROPRIATE CONTENT
+        // TODO UML-1394 TO BE REMOVED IN FUTURE TO SHOW PAGE NOT FOUND WITH APPROPRIATE CONTENT
         if (is_null($lpaData)) {
             return $this->redirectToRoute('lpa.dashboard');
         }
+
+        /**
+         * @var Lpa $lpa
+         * @psalm-suppress UndefinedPropertyFetch # Psalm doesn't like ArrayObjects, and why should it?
+         */
+        $lpa = $lpaData->lpa;
 
         $shareCodes = $this->viewerCodeService->getShareCodes(
             $identity,
@@ -93,15 +103,39 @@ class CheckAccessCodesHandler extends AbstractHandler implements UserAware, Csrf
                 $shareCodes[$key]['form'] = $form;
             }
 
+            $this->logger->info(
+                'Resolved actor id to {type}:{actor_id}',
+                [
+                    'actor_id' => $code['ActorId'],
+                    'type' => gettype($code['ActorId']),
+                ]
+            );
+
+            $this->logger->info(
+                'Donor Id is {type}:{donor_id}',
+                [
+                    'donor_id' => $lpa->getDonor()->getUId(),
+                    'type' => gettype($lpa->getDonor()->getUId()),
+                ]
+            );
+
             if (
-                $lpaData->lpa->getDonor()->getId() === intval($code['ActorId'])
-                || $lpaData->lpa->getDonor()->getUId() === $code['ActorId']
+                $lpa->getDonor()->getId() === intval($code['ActorId'])
+                || $lpa->getDonor()->getUId() === $code['ActorId']
             ) {
                 $shareCodes[$key]['CreatedBy'] =
-                    $lpaData->lpa->getDonor()->getFirstname() . ' ' . $lpaData->lpa->getDonor()->getSurname();
+                    $lpa->getDonor()->getFirstname() . ' ' . $lpa->getDonor()->getSurname();
             }
 
-            foreach ($lpaData->lpa->getAttorneys() as $attorney) {
+            foreach ($lpa->getAttorneys() as $attorney) {
+                $this->logger->info(
+                    'Attorney Id is {type}:{attorney_id}',
+                    [
+                        'attorney_id' => $attorney->getUId(),
+                        'type' => gettype($attorney->getUId()),
+                    ]
+                );
+
                 if (
                     $attorney->getId() === intval($code['ActorId'])
                     || $attorney->getUId() === $code['ActorId']
@@ -109,6 +143,13 @@ class CheckAccessCodesHandler extends AbstractHandler implements UserAware, Csrf
                     $shareCodes[$key]['CreatedBy'] = $attorney->getFirstname() . ' ' . $attorney->getSurname();
                 }
             }
+
+            $this->logger->info(
+                'Created by resolved to {actor_name}',
+                [
+                    'actor_name' => $shareCodes[$key]['CreatedBy'] ?? 'NULL',
+                ]
+            );
         }
 
         /** @var FlashMessagesInterface $flash */
@@ -117,7 +158,7 @@ class CheckAccessCodesHandler extends AbstractHandler implements UserAware, Csrf
         return new HtmlResponse($this->renderer->render('actor::check-access-codes', [
             'actorToken'    => $actorLpaToken,
             'user'          => $user,
-            'lpa'           => $lpaData->lpa,
+            'lpa'           => $lpa,
             'shareCodes'    => $shareCodes,
             'flash'         => $flash
         ]));

--- a/service-front/app/src/Actor/src/Handler/CheckAccessCodesHandler.php
+++ b/service-front/app/src/Actor/src/Handler/CheckAccessCodesHandler.php
@@ -120,8 +120,8 @@ class CheckAccessCodesHandler extends AbstractHandler implements UserAware, Csrf
             );
 
             if (
-                $lpa->getDonor()->getId() === intval($code['ActorId'])
-                || $lpa->getDonor()->getUId() === $code['ActorId']
+                $lpa->getDonor()->getId() === $code['ActorId']
+                || intval($lpa->getDonor()->getUId()) === $code['ActorId']
             ) {
                 $shareCodes[$key]['CreatedBy'] =
                     $lpa->getDonor()->getFirstname() . ' ' . $lpa->getDonor()->getSurname();
@@ -137,8 +137,8 @@ class CheckAccessCodesHandler extends AbstractHandler implements UserAware, Csrf
                 );
 
                 if (
-                    $attorney->getId() === intval($code['ActorId'])
-                    || $attorney->getUId() === $code['ActorId']
+                    $attorney->getId() === $code['ActorId']
+                    || intval($attorney->getUId()) === $code['ActorId']
                 ) {
                     $shareCodes[$key]['CreatedBy'] = $attorney->getFirstname() . ' ' . $attorney->getSurname();
                 }

--- a/service-front/app/src/Actor/src/Handler/CheckAccessCodesHandler.php
+++ b/service-front/app/src/Actor/src/Handler/CheckAccessCodesHandler.php
@@ -28,15 +28,8 @@ class CheckAccessCodesHandler extends AbstractHandler implements UserAware, Csrf
     use Session;
     use CsrfGuard;
 
-    /**
-     * @var ViewerCodeService
-     */
-    private $viewerCodeService;
-
-    /**
-     * @var LpaService
-     */
-    private $lpaService;
+    private ViewerCodeService $viewerCodeService;
+    private LpaService $lpaService;
 
     public function __construct(
         TemplateRendererInterface $renderer,
@@ -100,13 +93,19 @@ class CheckAccessCodesHandler extends AbstractHandler implements UserAware, Csrf
                 $shareCodes[$key]['form'] = $form;
             }
 
-            if ($lpaData->lpa->getDonor()->getId() == $code['ActorId']) {
+            if (
+                $lpaData->lpa->getDonor()->getId() === intval($code['ActorId'])
+                || $lpaData->lpa->getDonor()->getUId() === $code['ActorId']
+            ) {
                 $shareCodes[$key]['CreatedBy'] =
                     $lpaData->lpa->getDonor()->getFirstname() . ' ' . $lpaData->lpa->getDonor()->getSurname();
             }
 
             foreach ($lpaData->lpa->getAttorneys() as $attorney) {
-                if ($attorney->getId() == $code['ActorId']) {
+                if (
+                    $attorney->getId() === intval($code['ActorId'])
+                    || $attorney->getUId() === $code['ActorId']
+                ) {
                     $shareCodes[$key]['CreatedBy'] = $attorney->getFirstname() . ' ' . $attorney->getSurname();
                 }
             }


### PR DESCRIPTION
# Purpose

The created by field is broken for LPAs added to accounts after the end of December. This adds additional checking logic so that we check the right place.

Fixes UML-2015

## Approach

Check both the Uid and Id for a case actor when doing a comparison

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [x] The product team have tested these changes
