### PR TITLE
UML-2014: Handle requests that may not have a due by date

### DIFF
--- a/service-api/app/features/context/Acceptance/LpaContext.php
+++ b/service-api/app/features/context/Acceptance/LpaContext.php
@@ -13,6 +13,8 @@ use DateTime;
 use DateTimeZone;
 use Fig\Http\Message\StatusCodeInterface;
 use GuzzleHttp\Psr7\Response;
+use DateTimeImmutable;
+use DateInterval;
 
 /**
  * @property mixed lpa
@@ -611,6 +613,11 @@ class LpaContext implements Context
     {
         $createdDate = (new DateTime())->modify('-14 days');
 
+        $activationKeyDueDate = DateTimeImmutable::createFromMutable($createdDate);
+        $activationKeyDueDate = $activationKeyDueDate
+            ->add(new DateInterval('P10D'))
+            ->format('Y-m-d');
+
         // UserLpaActorMap::getAllForUser / getUsersLpas
         $this->awsFixtures->append(
             new Result(
@@ -703,10 +710,7 @@ class LpaContext implements Context
                 'surname'       => $this->lpa->donor->surname,
             ],
             'caseSubtype' => $this->lpa->caseSubtype,
-            'activationKeyDueDate' => date(
-                'Y-m-d',
-                strtotime($createdDate->format('Y-m-d') . ' + 10 days')
-            )
+            'activationKeyDueDate' => $activationKeyDueDate
         ];
 
         $this->ui->assertSession()->statusCodeEquals(StatusCodeInterface::STATUS_BAD_REQUEST);
@@ -2817,6 +2821,11 @@ class LpaContext implements Context
     {
         $createdDate = (new DateTime())->modify('-14 days');
 
+        $activationKeyDueDate = DateTimeImmutable::createFromMutable($createdDate);
+        $activationKeyDueDate = $activationKeyDueDate
+            ->add(new DateInterval('P10D'))
+            ->format('Y-m-d');
+
         //UserLpaActorMap: getAllForUser
         $this->awsFixtures->append(
             new Result([])
@@ -2867,10 +2876,7 @@ class LpaContext implements Context
             ],
             'caseSubtype'           => $this->lpa->caseSubtype,
             'activationKeyDueDate'  => $createdDate->format('c'),
-            'activationKeyDueDate'  => date(
-                'Y-m-d',
-                strtotime($createdDate->format('c') . ' + 10 days')
-            )
+            'activationKeyDueDate'  => $activationKeyDueDate
         ];
         $this->ui->assertSession()->statusCodeEquals(StatusCodeInterface::STATUS_BAD_REQUEST);
         $this->ui->assertSession()->responseContains('LPA has an activation key already');

--- a/service-api/app/features/context/Integration/LpaContext.php
+++ b/service-api/app/features/context/Integration/LpaContext.php
@@ -31,6 +31,8 @@ use GuzzleHttp\Psr7\Response;
 use JSHayes\FakeRequests\MockHandler;
 use PHPUnit\Framework\ExpectationFailedException;
 use stdClass;
+use DateTimeImmutable;
+use DateInterval;
 
 /**
  * Class LpaContext
@@ -1775,6 +1777,12 @@ class LpaContext extends BaseIntegrationContext
 
         $codeExists = new stdClass();
         $createdDate = (new DateTime())->modify('-14 days');
+
+        $activationKeyDueDate = DateTimeImmutable::createFromMutable($createdDate);
+        $activationKeyDueDate = $activationKeyDueDate
+            ->add(new DateInterval('P10D'))
+            ->format('Y-m-d');
+
         $codeExists->Created = $createdDate->format('Y-m-d');
 
         $this->pactPostInteraction(
@@ -1804,10 +1812,7 @@ class LpaContext extends BaseIntegrationContext
                         'surname'       => $this->lpa->donor->surname
                     ],
                     'caseSubtype'           => $this->lpa->caseSubtype,
-                    'activationKeyDueDate'  => date(
-                        'Y-m-d',
-                        strtotime($createdDate->format('c') . ' + 10 days')
-                    )
+                    'activationKeyDueDate'  => $activationKeyDueDate
                 ],
                 $ex->getAdditionalData()
             );
@@ -2595,6 +2600,12 @@ class LpaContext extends BaseIntegrationContext
 
         $codeExists = new stdClass();
         $createdDate = (new DateTime())->modify('-14 days');
+
+        $activationKeyDueDate = DateTimeImmutable::createFromMutable($createdDate);
+        $activationKeyDueDate = $activationKeyDueDate
+            ->add(new DateInterval('P10D'))
+            ->format('Y-m-d');
+
         $codeExists->Created = $createdDate->format('Y-m-d');
 
         $this->pactPostInteraction(
@@ -2616,10 +2627,7 @@ class LpaContext extends BaseIntegrationContext
                 'surname'       => $this->lpa->donor->surname,
             ],
             'caseSubtype' => $this->lpa->caseSubtype,
-            'activationKeyDueDate' => date(
-                'Y-m-d',
-                strtotime($codeExists->Created . ' + 10 days')
-            )
+            'activationKeyDueDate' => $activationKeyDueDate
         ];
 
         $addOlderLpa = $this->container->get(AddOlderLpa::class);

--- a/service-api/app/features/context/Integration/LpaContext.php
+++ b/service-api/app/features/context/Integration/LpaContext.php
@@ -2536,6 +2536,8 @@ class LpaContext extends BaseIntegrationContext
      */
     public function iProvideTheDetailsFromAValidPaperLPAWhichIHaveAlreadyRequestedAnActivationKeyFor()
     {
+        $createdDate = (new DateTime())->modify('-14 days');
+
         $data = [
             'reference_number' => $this->lpaUid,
             'dob' => $this->userDob,
@@ -2591,6 +2593,21 @@ class LpaContext extends BaseIntegrationContext
             $this->lpa
         );
 
+        $codeExists = new stdClass();
+        $createdDate = (new DateTime())->modify('-14 days');
+        $codeExists->Created = $createdDate->format('Y-m-d');
+
+        $this->pactPostInteraction(
+            $this->codesApiPactProvider,
+            '/v1/exists',
+            [
+                'lpa' => $this->lpaUid,
+                'actor' => $this->actorLpaId,
+            ],
+            StatusCodeInterface::STATUS_OK,
+            $codeExists
+        );
+
         $expectedResponse = [
             'donor'         => [
                 'uId'           => $this->lpa->donor->uId,
@@ -2599,7 +2616,10 @@ class LpaContext extends BaseIntegrationContext
                 'surname'       => $this->lpa->donor->surname,
             ],
             'caseSubtype' => $this->lpa->caseSubtype,
-            'activationKeyDueDate' => null
+            'activationKeyDueDate' => date(
+                'Y-m-d',
+                strtotime($codeExists->Created . ' + 10 days')
+            )
         ];
 
         $addOlderLpa = $this->container->get(AddOlderLpa::class);

--- a/service-api/app/src/App/src/Service/Lpa/AddOlderLpa.php
+++ b/service-api/app/src/App/src/Service/Lpa/AddOlderLpa.php
@@ -6,7 +6,10 @@ namespace App\Service\Lpa;
 
 use App\Exception\BadRequestException;
 use App\Exception\NotFoundException;
+use DateInterval;
 use DateTime;
+use DateTimeImmutable;
+use DateTimeZone;
 use Psr\Log\LoggerInterface;
 use App\Service\Features\FeatureEnabled;
 
@@ -164,11 +167,9 @@ class AddOlderLpa
                         $resolvedActor['lpa-id'],
                         $resolvedActor['actor']['uId']
                     );
+
                     if ($hasActivationCode instanceof DateTime) {
-                        $activationKeyDueDate = date(
-                            'Y-m-d',
-                            strtotime($hasActivationCode->format('c') . ' + 10 days')
-                        );
+                        $activationKeyDueDate = $hasActivationCode->add(new DateInterval('P10D'));
                     }
                 }
                 throw new BadRequestException(
@@ -176,7 +177,7 @@ class AddOlderLpa
                     [
                         'donor'                => $lpaAddedData['donor'],
                         'caseSubtype'          => $lpaAddedData['caseSubtype'],
-                        'activationKeyDueDate' => $activationKeyDueDate
+                        'activationKeyDueDate' => $activationKeyDueDate->format('Y-m-d')
                     ]
                 );
             }
@@ -190,12 +191,10 @@ class AddOlderLpa
                 throw new BadRequestException(
                     'LPA has an activation key already',
                     [
-                        'donor'         => $resolvedActor['donor'],
-                        'caseSubtype'   => $resolvedActor['caseSubtype'],
-                        'activationKeyDueDate' => date(
-                            'Y-m-d',
-                            strtotime($hasActivationCode->format('c') . ' + 10 days')
-                        ),
+                        'donor'                 => $resolvedActor['donor'],
+                        'caseSubtype'           => $resolvedActor['caseSubtype'],
+                        'activationKeyDueDate'  =>
+                            $hasActivationCode->add(new DateInterval('P10D'))->format('Y-m-d')
                     ]
                 );
             }

--- a/service-api/app/src/App/src/Service/Lpa/AddOlderLpa.php
+++ b/service-api/app/src/App/src/Service/Lpa/AddOlderLpa.php
@@ -9,7 +9,6 @@ use App\Exception\NotFoundException;
 use DateInterval;
 use DateTime;
 use DateTimeImmutable;
-use DateTimeZone;
 use Psr\Log\LoggerInterface;
 use App\Service\Features\FeatureEnabled;
 
@@ -192,13 +191,17 @@ class AddOlderLpa
             );
 
             if ($hasActivationCode instanceof DateTime) {
+                $activationKeyDueDate = DateTimeImmutable::createFromMutable($hasActivationCode);
+                $activationKeyDueDate = $activationKeyDueDate
+                    ->add(new DateInterval('P10D'))
+                    ->format('Y-m-d');
+
                 throw new BadRequestException(
                     'LPA has an activation key already',
                     [
                         'donor'                 => $resolvedActor['donor'],
                         'caseSubtype'           => $resolvedActor['caseSubtype'],
-                        'activationKeyDueDate'  =>
-                            $hasActivationCode->add(new DateInterval('P10D'))->format('Y-m-d')
+                        'activationKeyDueDate'  => $activationKeyDueDate
                     ]
                 );
             }

--- a/service-api/app/src/App/src/Service/Lpa/AddOlderLpa.php
+++ b/service-api/app/src/App/src/Service/Lpa/AddOlderLpa.php
@@ -169,15 +169,19 @@ class AddOlderLpa
                     );
 
                     if ($hasActivationCode instanceof DateTime) {
-                        $activationKeyDueDate = $hasActivationCode->add(new DateInterval('P10D'));
+                        $activationKeyDueDate = DateTimeImmutable::createFromMutable($hasActivationCode);
+                        $activationKeyDueDate = $activationKeyDueDate
+                            ->add(new DateInterval('P10D'))
+                            ->format('Y-m-d');
                     }
                 }
+
                 throw new BadRequestException(
                     'Activation key already requested for LPA',
                     [
                         'donor'                => $lpaAddedData['donor'],
                         'caseSubtype'          => $lpaAddedData['caseSubtype'],
-                        'activationKeyDueDate' => $activationKeyDueDate->format('Y-m-d')
+                        'activationKeyDueDate' => $activationKeyDueDate
                     ]
                 );
             }

--- a/service-api/app/src/App/src/Service/Lpa/AddOlderLpa.php
+++ b/service-api/app/src/App/src/Service/Lpa/AddOlderLpa.php
@@ -159,7 +159,7 @@ class AddOlderLpa
                 $activationKeyDueDate = $lpaAddedData['activationKeyDueDate'] ?? null;
 
                 //if activation key due date is null, check activation code exist in sirius
-                if ($activationKeyDueDate == null) {
+                if ($activationKeyDueDate === null) {
                     $hasActivationCode = $this->olderLpaService->hasActivationCode(
                         $resolvedActor['lpa-id'],
                         $resolvedActor['actor']['uId']

--- a/service-api/app/src/App/src/Service/Lpa/AddOlderLpa.php
+++ b/service-api/app/src/App/src/Service/Lpa/AddOlderLpa.php
@@ -155,12 +155,28 @@ class AddOlderLpa
                         'uId' => $matchData['reference_number'],
                     ]
                 );
+
+                $activationKeyDueDate = $lpaAddedData['activationKeyDueDate'] ?? null;
+
+                //if activation key due date is null, check activation code exist in sirius
+                if ($activationKeyDueDate == null) {
+                    $hasActivationCode = $this->olderLpaService->hasActivationCode(
+                        $resolvedActor['lpa-id'],
+                        $resolvedActor['actor']['uId']
+                    );
+                    if ($hasActivationCode instanceof DateTime) {
+                        $activationKeyDueDate = date(
+                            'Y-m-d',
+                            strtotime($hasActivationCode->format('c') . ' + 10 days')
+                        );
+                    }
+                }
                 throw new BadRequestException(
                     'Activation key already requested for LPA',
                     [
                         'donor'                => $lpaAddedData['donor'],
                         'caseSubtype'          => $lpaAddedData['caseSubtype'],
-                        'activationKeyDueDate' => $lpaAddedData['activationKeyDueDate']
+                        'activationKeyDueDate' => $activationKeyDueDate
                     ]
                 );
             }

--- a/service-api/app/test/AppTest/Service/Lpa/AddOlderLpaTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/AddOlderLpaTest.php
@@ -191,6 +191,7 @@ class AddOlderLpaTest extends TestCase
             ],
             'caseSubtype' => 'hw',
             'lpaActorToken' => 'qwerty-54321',
+            'activationKeyDueDate' => null,
             'notActivated'  => true
         ];
 
@@ -209,7 +210,18 @@ class AddOlderLpaTest extends TestCase
             ->__invoke($this->lpaData, $this->dataToMatch)
             ->willReturn($this->resolvedActor);
 
-        $expectedException = new BadRequestException('Activation key already requested for LPA', $alreadyAddedData);
+        $this->olderLpaServiceProphecy
+            ->hasActivationCode($this->lpaUid, $this->lpaData['attorneys'][1]['uId'])
+            ->willReturn(new DateTime());
+
+        $expectedException = new BadRequestException(
+            'Activation key already requested for LPA',
+            [
+                'donor'                => $this->resolvedActor['donor'],
+                'caseSubtype'          => $this->resolvedActor['caseSubtype'],
+                'activationKeyDueDate' => new DateTime()
+            ]
+        );
 
         $this->expectExceptionObject($expectedException);
         $this->getSut()->validateRequest($this->userId, $this->dataToMatch);

--- a/service-api/app/test/AppTest/Service/Lpa/AddOlderLpaTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/AddOlderLpaTest.php
@@ -20,6 +20,8 @@ use Fig\Http\Message\StatusCodeInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\LoggerInterface;
+use DateTimeImmutable;
+use DateInterval;
 
 class AddOlderLpaTest extends TestCase
 {
@@ -179,6 +181,13 @@ class AddOlderLpaTest extends TestCase
     /** @test */
     public function older_lpa_lookup_throws_an_exception_if_lpa_already_requested()
     {
+        $createdDate = (new DateTime())->modify('-14 days');
+
+        $activationKeyDueDate = DateTimeImmutable::createFromMutable($createdDate);
+        $activationKeyDueDate = $activationKeyDueDate
+            ->add(new DateInterval('P10D'))
+            ->format('Y-m-d');
+
         $this->featureEnabledProphecy
             ->__invoke('dont_send_lpas_registered_after_sep_2019_to_cleansing_team')
             ->willReturn(false);
@@ -212,14 +221,14 @@ class AddOlderLpaTest extends TestCase
 
         $this->olderLpaServiceProphecy
             ->hasActivationCode($this->lpaUid, $this->lpaData['attorneys'][1]['uId'])
-            ->willReturn(new DateTime());
+            ->willReturn($createdDate);
 
         $expectedException = new BadRequestException(
             'Activation key already requested for LPA',
             [
                 'donor'                => $this->resolvedActor['donor'],
                 'caseSubtype'          => $this->resolvedActor['caseSubtype'],
-                'activationKeyDueDate' => new DateTime()
+                'activationKeyDueDate' => $activationKeyDueDate
             ]
         );
 
@@ -400,6 +409,13 @@ class AddOlderLpaTest extends TestCase
     /** @test */
     public function older_lpa_lookup_throws_exception_if_lpa_already_has_activation_key()
     {
+        $createdDate = (new DateTime())->modify('-14 days');
+
+        $activationKeyDueDate = DateTimeImmutable::createFromMutable($createdDate);
+        $activationKeyDueDate = $activationKeyDueDate
+            ->add(new DateInterval('P10D'))
+            ->format('Y-m-d');
+
         $this->featureEnabledProphecy
             ->__invoke('dont_send_lpas_registered_after_sep_2019_to_cleansing_team')
             ->willReturn(false);
@@ -420,14 +436,14 @@ class AddOlderLpaTest extends TestCase
 
         $this->olderLpaServiceProphecy
             ->hasActivationCode($this->lpaUid, $this->lpaData['attorneys'][1]['uId'])
-            ->willReturn(new DateTime());
+            ->willReturn($createdDate);
 
         $expectedException = new BadRequestException(
             'LPA has an activation key already',
             [
                 'donor'                => $this->resolvedActor['donor'],
                 'caseSubtype'          => $this->resolvedActor['caseSubtype'],
-                'activationKeyDueDate' => new DateTime()
+                'activationKeyDueDate' => $activationKeyDueDate
             ]
         );
 

--- a/service-front/app/src/Actor/src/Handler/RequestActivationKey/CheckYourAnswersHandler.php
+++ b/service-front/app/src/Actor/src/Handler/RequestActivationKey/CheckYourAnswersHandler.php
@@ -179,12 +179,17 @@ class CheckYourAnswersHandler extends AbstractHandler implements UserAware, Csrf
                         $this->urlHelper->generate('lpa.confirm-activation-key-generation')
                     );
 
+                    $activationKeyDueDate = date(
+                        'Y-m-d',
+                        strtotime(($result->getData()->getDueDate()))
+                    );
+
                     return new HtmlResponse(
                         $this->renderer->render(
                             'actor::already-have-activation-key',
                             [
                                 'user'      => $this->user,
-                                'dueDate'   => $result->getData()->getDueDate(),
+                                'dueDate'   => $activationKeyDueDate,
                                 'form'      => $form
                             ]
                         )


### PR DESCRIPTION
# Purpose

https://opgtransform.atlassian.net/browse/UML-2014

Fixes UML-2014

## Approach

When requests [LPA records] do not have a due by date, check for activation code in Sirius to get the created date before sending exception

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [X] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
