### PR TITLE
Use correct npm invocation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -674,7 +674,7 @@ orbs:
               name: Install dependencies
               command: |
                 if [ ! -d service-front/web/node_modules ]; then
-                  cd service-front/web/ && npm install
+                  cd service-front/web/ && npm ci
                 fi
           - run:
               name: Run tests with Jest
@@ -714,12 +714,12 @@ orbs:
           - checkout
           - restore_cache:
               name: Restore node modules cache
-              key: node_modules-{{ checksum "service-front/web/package-lock.json" }}
+              key: node_modules-{{ checksum "service-front/web/package-lock.json" }}-{{ arch }}
           - run:
               name: Install dependencies
               command: |
                 if [ ! -d service-front/web/node_modules ]; then
-                  cd service-front/web/ && npm install
+                  cd service-front/web/ && npm ci
                 fi
           - run:
               name: Build assets
@@ -727,7 +727,7 @@ orbs:
                 cd service-front/web/ && npm run build && npm run build:pdf_production
           - save_cache:
               name: Save node modules cache
-              key: node_modules-{{ checksum "service-front/web/package-lock.json" }}
+              key: node_modules-{{ checksum "service-front/web/package-lock.json" }}-{{ arch }}
               paths:
                 - service-front/web/node_modules
           - persist_to_workspace:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       context: .
       dockerfile: service-front/web/Dockerfile
     entrypoint: >
-      sh -c "npm i && npm run build-scss && npm run build:pdf && npm run watch"
+      sh -c "npm ci && npm run build-scss && npm run build:pdf && npm run watch"
     volumes:
       - ./service-front/web:/web:rw,delegated
       - webpack_dist:/dist


### PR DESCRIPTION
# Purpose

We're using the wrong installation command and it could result in dependencies not exactly matching what we're expecting. The correct command to use is `ci`. This PR replaces instances of `install` so that we're doing the right thing.

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* The product team have tested these changes
