### PR TITLE
Ignore large dependency folders when building images locally

### DIFF
--- a/service-api/app/.dockerignore
+++ b/service-api/app/.dockerignore
@@ -1,0 +1,2 @@
+vendor/
+build/

--- a/service-front/app/.dockerignore
+++ b/service-front/app/.dockerignore
@@ -1,0 +1,2 @@
+vendor/
+build/


### PR DESCRIPTION
# Purpose

Speed up local builds (marginally)

## Approach

Adding .dockerignore files to exclude the large dependency folders means I don't wait 30seconds per image to upload context that gets ignored.

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* The product team have tested these changes
