### PR TITLE
Uml 2127 users cannot request activation key

### DIFF
--- a/service-front/app/features/context/UI/RequestActivationKeyContext.php
+++ b/service-front/app/features/context/UI/RequestActivationKeyContext.php
@@ -17,6 +17,7 @@ use Psr\Http\Message\RequestInterface;
  * @property mixed  $lpa
  * @property string $userLpaActorToken
  * @property int    $actorId
+ * @property string $actorUId
  * @property array  $lpaData
  * @property string $organisation
  * @property string $accessCode
@@ -496,6 +497,7 @@ class RequestActivationKeyContext implements Context
 
         $this->userLpaActorToken = '987654321';
         $this->actorId = 9;
+        $this->actorUId = '700000000054';
 
         $this->lpaData = [
             'user-lpa-actor-token' => $this->userLpaActorToken,
@@ -1153,7 +1155,7 @@ class RequestActivationKeyContext implements Context
                                 'title' => 'Bad request',
                                 'details' => 'LPA needs cleansing',
                                 'data' => [
-                                    'actor_id' => $this->actorId
+                                    'actor_id' => $this->actorUId
                                 ],
                             ]
                         )

--- a/service-front/app/src/Actor/src/Handler/RequestActivationKey/CreateActivationKeyHandler.php
+++ b/service-front/app/src/Actor/src/Handler/RequestActivationKey/CreateActivationKeyHandler.php
@@ -110,7 +110,7 @@ class CreateActivationKeyHandler extends AbstractHandler implements UserAware, C
                     );
                 case OlderLpaApiResponse::OLDER_LPA_NEEDS_CLEANSING:
                     $state->needsCleansing = true;
-                    $state->actorUid = $result->getData()['actor_id'];
+                    $state->actorUid = (int) $result->getData()['actor_id'];
 
                     return $this->redirectToRoute('lpa.add.contact-details');
             }


### PR DESCRIPTION
# Purpose

Fixes UML-2127

## Approach

Cast string to integer

## Learning

Make sure our test mocks actually return the right data.

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] The product team have tested these changes
