### PR TITLE
UML-2165 - add a global secondary index to UserLpaActorMap for SiriusUids

### DIFF
--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -181,9 +181,14 @@ resource "aws_dynamodb_table" "user_lpa_actor_map" {
   }
 
   attribute {
-      name = "ActivationCode"
-      type = "S"
+    name = "ActivationCode"
+    type = "S"
   }
+
+  # attribute {
+  #   name = "SiriusUid"
+  #   type = "S"
+  # }
 
   global_secondary_index {
     name            = "ActivationCodeIndex"
@@ -196,6 +201,12 @@ resource "aws_dynamodb_table" "user_lpa_actor_map" {
     hash_key        = "UserId"
     projection_type = "ALL"
   }
+
+  # global_secondary_index {
+  #   name            = "SiriusUidIndex"
+  #   hash_key        = "SiriusUid"
+  #   projection_type = "ALL"
+  # }
 
   ttl {
     attribute_name = "ActivateBy"


### PR DESCRIPTION
# Purpose

To speed up queries and searches for LPAs.

Fixes UML-2165

## Approach

- Define SiriusUid attribute
- Create a Global Secondary index for SiriusUids

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
