### PR TITLE
UML-2200 - limit env name length in reference name

### DIFF
--- a/terraform/environment/dns_health_check.tf
+++ b/terraform/environment/dns_health_check.tf
@@ -19,7 +19,7 @@ resource "aws_cloudwatch_metric_alarm" "viewer_health_check_alarm" {
 
 resource "aws_route53_health_check" "viewer_health_check" {
   fqdn              = aws_route53_record.viewer-use-my-lpa.fqdn
-  reference_name    = "${local.environment_name}-viewer"
+  reference_name    = "${substr(local.environment_name, 0, 20)}-viewer"
   port              = 443
   type              = "HTTPS"
   failure_threshold = 1
@@ -50,7 +50,7 @@ resource "aws_cloudwatch_metric_alarm" "actor_health_check_alarm" {
 
 resource "aws_route53_health_check" "actor_health_check" {
   fqdn              = aws_route53_record.actor-use-my-lpa.fqdn
-  reference_name    = "${local.environment_name}-actor"
+  reference_name    = "${substr(local.environment_name, 0, 20)}-actor"
   port              = 443
   type              = "HTTPS"
   failure_threshold = 1


### PR DESCRIPTION
# Purpose

expected length of reference_name in aws_route53_health_check to be in the range (0 - 27)

Fixes UML-2200

## Approach

- use a substring, the first 20 characters to keep full reference name under 27


## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* ~The product team have tested these changes~
