### PR TITLE
Shade colour rather than defining our own

### DIFF
--- a/service-front/web/src/scss/_lpa-ticket-panel.scss
+++ b/service-front/web/src/scss/_lpa-ticket-panel.scss
@@ -1,12 +1,12 @@
 .moj-ticket-panel {
 
   .lpa-account-delete {
-    color: $higher-contrast-red;
+    color: govuk-shade(govuk-colour("red"), 20);
   }
 
   .moj-badge--red {
-    color: $higher-contrast-red;
-    border-color: $higher-contrast-red;
+    color: govuk-shade(govuk-colour("red"), 20);
+    border-color: govuk-shade(govuk-colour("red"), 20);
   }
 
   @include govuk-media-query($from: desktop) {

--- a/service-front/web/src/scss/lpa.scss
+++ b/service-front/web/src/scss/lpa.scss
@@ -3,7 +3,6 @@
 @import "../../node_modules/govuk-frontend/govuk/helpers/all";
 @import "../../node_modules/govuk-frontend/govuk/objects/all";
 
-@import "ulpa-colours";
 @import 'lpa-account-menu';
 @import 'govuk-panel';
 @import 'lpa-typography';

--- a/service-front/web/src/scss/ulpa-colours.scss
+++ b/service-front/web/src/scss/ulpa-colours.scss
@@ -1,1 +1,0 @@
-$higher-contrast-red: #aa2a16;


### PR DESCRIPTION
# Purpose

Red should be shaded so that if gov colours ever change our system also updates

## Approach

govuk-shade 

## Learning

govuk-shade exists. There should be a discussion at some point if shade should be the 25% suggested by GDS

## Checklist

* [x] I have performed a self-review of my own code
