### PR TITLE
UML-2235 - Ensure all LPA items are getting added to results

### DIFF
--- a/scripts/analysis_scripts/lookup_account.py
+++ b/scripts/analysis_scripts/lookup_account.py
@@ -69,6 +69,20 @@ class AccountLookup:
         ):
             yield from page["Items"]
 
+    def get_lpas_by_index(self, sirius_uid):
+        logging.info('getting User for LPA: %s', sirius_uid)
+        response = self.aws_dynamodb_client.query(
+            IndexName='SiriusUidIndex',
+            TableName=f'{self.environment}-UserLpaActorMap',
+            KeyConditionExpression='SiriusUid = :sirius_uid',
+            ExpressionAttributeValues={
+                ':sirius_uid': {'S': sirius_uid}
+            },
+            ProjectionExpression='SiriusUid,Added,ActorId,DueBy'
+        )
+        logging.info(response)
+        return response
+
     def get_lpas_by_user_id(self, user_id):
         logging.info('getting LPAs for user id: %s', user_id)
         response = self.aws_dynamodb_client.query(
@@ -130,7 +144,10 @@ class AccountLookup:
     def get_by_lpa(self, lpa_id):
         output_json = []
         logging.info('looking up account for LPA: %s', lpa_id)
-        lpas = self.get_lpas()
+        lpas = self.get_lpas_by_index(lpa_id)
+        logging.info(lpas)
+        exit()
+        # lpas = self.get_lpas()
 
         for item in lpas:
             if item['SiriusUid']['S'] in lpa_id:

--- a/scripts/analysis_scripts/lookup_account.py
+++ b/scripts/analysis_scripts/lookup_account.py
@@ -61,14 +61,6 @@ class AccountLookup:
         logging.info(response)
         return response
 
-    def get_lpas(self):
-        paginator = self.aws_dynamodb_client.get_paginator("scan")
-        for page in paginator.paginate(
-                TableName=f'{self.environment}-UserLpaActorMap',
-                FilterExpression="attribute_exists(SiriusUid)",
-        ):
-            yield from page["Items"]
-
     def get_lpas_by_index(self, sirius_uid):
         logging.info('getting User for LPA: %s', sirius_uid)
         response = self.aws_dynamodb_client.query(
@@ -78,10 +70,10 @@ class AccountLookup:
             ExpressionAttributeValues={
                 ':sirius_uid': {'S': sirius_uid}
             },
-            ProjectionExpression='SiriusUid,Added,ActorId,DueBy'
+            ProjectionExpression='SiriusUid,Added,ActorId,DueBy,UserId'
         )
         logging.info(response)
-        return response
+        return response['Items']
 
     def get_lpas_by_user_id(self, user_id):
         logging.info('getting LPAs for user id: %s', user_id)
@@ -145,10 +137,6 @@ class AccountLookup:
         output_json = []
         logging.info('looking up account for LPA: %s', lpa_id)
         lpas = self.get_lpas_by_index(lpa_id)
-        logging.info(lpas)
-        exit()
-        # lpas = self.get_lpas()
-
         for item in lpas:
             if item['SiriusUid']['S'] in lpa_id:
                 user = self.get_users_by_id(item['UserId']['S'])

--- a/scripts/analysis_scripts/lookup_account.py
+++ b/scripts/analysis_scripts/lookup_account.py
@@ -58,7 +58,7 @@ class AccountLookup:
             },
             ProjectionExpression='Id,Email,LastLogin,ActivationToken'
         )
-        logging.info(response)
+        logging.info('found: %s', response['Count'])
         return response
 
     def get_lpas_by_index(self, sirius_uid):
@@ -72,7 +72,7 @@ class AccountLookup:
             },
             ProjectionExpression='SiriusUid,Added,ActorId,DueBy,UserId'
         )
-        logging.info(response)
+        logging.info('found: %s', response['Count'])
         return response['Items']
 
     def get_lpas_by_user_id(self, user_id):
@@ -86,10 +86,8 @@ class AccountLookup:
             },
             ProjectionExpression='SiriusUid,Added,ActorId,DueBy'
         )
-        logging.info('found :%s', response['Count'])
-        lpas = {}
-        lpas['Items'] = response['Items']
-        return lpas
+        logging.info('found: %s', response['Count'])
+        return response['Items']
 
     def get_users_by_id(self, user_id):
         response = self.aws_dynamodb_client.query(

--- a/scripts/analysis_scripts/lookup_account.py
+++ b/scripts/analysis_scripts/lookup_account.py
@@ -80,9 +80,9 @@ class AccountLookup:
             },
             ProjectionExpression='SiriusUid,Added,ActorId,DueBy'
         )
+        logging.info('found :%s', response['Count'])
         lpas = {}
-        for lpa in response['Items']:
-            lpas.update(lpa)
+        lpas['Items'] = response['Items']
         return lpas
 
     def get_users_by_id(self, user_id):


### PR DESCRIPTION
# Purpose

Script would replace each item returning only the last found in a list.

Fixes UML-2235

Now much quicker!

## Approach

- during lookup, append entire list don't use for each
- use query on SiriusUid index for lookups by LPA ID

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* ~The product team have tested these changes~
