### PR TITLE
Removed the inclusion to the maintenance downtime banner from pages

### DIFF
--- a/service-front/app/src/Actor/templates/actor/home-page.html.twig
+++ b/service-front/app/src/Actor/templates/actor/home-page.html.twig
@@ -14,7 +14,9 @@
         <main class="govuk-main-wrapper" id="main-content" role="main">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
-                    
+
+                    {{ include('@actor/partials/lpas-registered-after.html.twig') }}
+
                     {{ govuk_error_summary(form) }}
                     {{ govuk_form_open(form) }}
 

--- a/service-front/app/src/Actor/templates/actor/home-page.html.twig
+++ b/service-front/app/src/Actor/templates/actor/home-page.html.twig
@@ -14,9 +14,7 @@
         <main class="govuk-main-wrapper" id="main-content" role="main">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
-
-                    {{ include('@actor/partials/lpas-registered-after.html.twig') }}
-
+                    
                     {{ govuk_error_summary(form) }}
                     {{ govuk_form_open(form) }}
 

--- a/service-front/app/src/Actor/templates/actor/lpa-blank-dashboard.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-blank-dashboard.html.twig
@@ -12,8 +12,6 @@
 
         <main class="govuk-main-wrapper" id="main-content" role="main">
 
-            {{ include('@actor/partials/upcoming-service-downtime.html.twig') }}
-
             {{ include('@actor/partials/flash-message.html.twig', {flash_obj: flash, flash_key:'Actor\\Handler\\RemoveLpaHandler::REMOVE_LPA_FLASH_MSG'}) }}
 
             <div class="govuk-grid-row">

--- a/service-front/app/src/Actor/templates/actor/lpa-dashboard.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-dashboard.html.twig
@@ -11,9 +11,6 @@
         </div>
 
         <main class="govuk-main-wrapper" id="main-content" role="main">
-
-            {{ include('@actor/partials/upcoming-service-downtime.html.twig') }}
-
             {{ include('@actor/partials/flash-message.html.twig', {flash_obj: flash, flash_key:'Actor\\Handler\\CheckLpaHandler::ADD_LPA_FLASH_MSG'}) }}
             {{ include('@actor/partials/flash-message.html.twig', {flash_obj: flash, flash_key:'Actor\\Handler\\RemoveLpaHandler::REMOVE_LPA_FLASH_MSG'}) }}
 

--- a/service-front/app/src/Actor/templates/actor/partials/lpas-registered-after.html.twig
+++ b/service-front/app/src/Actor/templates/actor/partials/lpas-registered-after.html.twig
@@ -6,11 +6,6 @@
     </div>
     <div class="govuk-notification-banner__content">
         <p class="govuk-notification-banner__heading">
-            {% trans %}This service will be unavailable between 3pm on Friday 8 April and 6pm on Sunday 10 April 2022.{% endtrans %}
-        </p>
-        <p class="govuk-body">{% trans %}If you need to use your lasting power of attorney during this time you can still use the paper LPA document.{% endtrans %}</p>
-
-        <p class="govuk-notification-banner__heading">
         {% if feature_enabled('allow_older_lpas') %}
             {% trans %}You can only use this service if your LPA was registered on or after 1 January 2016.{% endtrans %}
         {%  endif %}

--- a/service-front/app/src/Actor/templates/actor/partials/lpas-registered-after.html.twig
+++ b/service-front/app/src/Actor/templates/actor/partials/lpas-registered-after.html.twig
@@ -8,6 +8,8 @@
         <p class="govuk-notification-banner__heading">
         {% if feature_enabled('allow_older_lpas') %}
             {% trans %}You can only use this service if your LPA was registered on or after 1 January 2016.{% endtrans %}
+        {% else %}
+            {% trans %}You can only use this service if your LPA was registered on or after 1 September 2019.{% endtrans %}
         {%  endif %}
         </p>
     </div>

--- a/service-front/app/src/Viewer/templates/viewer/enter-code.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/enter-code.html.twig
@@ -12,8 +12,6 @@
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
 
-                {{ include('@viewer/partials/upcoming-service-downtime.html.twig') }}
-
                 {{ govuk_error_summary(form) }}
 
                 {{ govuk_form_open(form) }}


### PR DESCRIPTION
# Purpose

https://opgtransform.atlassian.net/browse/UML-2231

Fixes UML-2231

## Approach

Removed the maintenance page inclusions from the pages. The pages and translations are left behind.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
