### PR TITLE
UML-2236 - use latest tag when deploying pdf

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
 
   service-pdf:
     container_name: service-pdf
-    image: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/pdf_service:v1.37.0
+    image: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/pdf_service:latest
     ports:
       - 9004:80
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - webpack_dist:/dist
 
   # ---------------------------
-  # Viewer Front
+  # PDF Generator
 
   service-pdf:
     container_name: service-pdf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,16 +80,6 @@ services:
       COOKIE_SECURE: "false"
     depends_on:
       - redis
-#    healthcheck:
-#      test:
-#        [
-#          "CMD-SHELL",
-#          "SCRIPT_NAME=/ping SCRIPT_FILENAME=/ping REQUEST_METHOD=GET cgi-fcgi -bind -connect 127.0.0.1:9000"
-#        ]
-#      interval: 10s
-#      timeout: 30s
-#      retries: 3
-#      start_period: 90s
 
   # ---------------------------
   # Actor Front
@@ -149,16 +139,6 @@ services:
       COOKIE_EXPIRES: 1440 # cookie expiry for complete logout - initial value to be 24 hours.
       COOKIE_SECURE: "false"
       NOTIFY_API_KEY:
-#    healthcheck:
-#      test:
-#        [
-#          "CMD-SHELL",
-#          "SCRIPT_NAME=/ping SCRIPT_FILENAME=/ping REQUEST_METHOD=GET cgi-fcgi -bind -connect 127.0.0.1:9000"
-#        ]
-#      interval: 10s
-#      timeout: 30s
-#      retries: 3
-#      start_period: 90s
 
   # ---------------------------
   # Front Composer (Shared)
@@ -239,16 +219,6 @@ services:
       XDEBUG_MODE: develop,debug,coverage
       XDEBUG_TRIGGER: "true"
       NOTIFY_API_KEY:
-#    healthcheck:
-#      test:
-#        [
-#          "CMD-SHELL",
-#          "SCRIPT_NAME=/ping SCRIPT_FILENAME=/ping REQUEST_METHOD=GET cgi-fcgi -bind -connect 127.0.0.1:9000"
-#        ]
-#      interval: 10s
-#      timeout: 30s
-#      retries: 3
-#      start_period: 90s
 
   api-composer:
     image: api-app

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -49,7 +49,7 @@
       "notify_key_secret_name": "notify-api-key",
       "dont_send_lpas_registered_after_sep_2019_to_cleansing_team": false,
       "associate_alb_with_waf_web_acl_enabled": false,
-      "pdf_container_version": "v1.37.0",
+      "pdf_container_version": "latest",
       "deploy_opentelemetry_sidecar":false,
       "dynamodb_tables": {
         "actor_codes": {
@@ -118,7 +118,7 @@
       "notify_key_secret_name": "notify-api-key-demo",
       "dont_send_lpas_registered_after_sep_2019_to_cleansing_team": false,
       "associate_alb_with_waf_web_acl_enabled": true,
-      "pdf_container_version": "v1.37.0",
+      "pdf_container_version": "latest",
       "deploy_opentelemetry_sidecar":false,
       "dynamodb_tables": {
         "actor_codes": {
@@ -187,7 +187,7 @@
       "notify_key_secret_name": "notify-api-key",
       "dont_send_lpas_registered_after_sep_2019_to_cleansing_team": false,
       "associate_alb_with_waf_web_acl_enabled": true,
-      "pdf_container_version": "v1.37.0",
+      "pdf_container_version": "latest",
       "deploy_opentelemetry_sidecar":false,
       "dynamodb_tables": {
         "actor_codes": {
@@ -256,7 +256,7 @@
       "notify_key_secret_name": "notify-api-key",
       "dont_send_lpas_registered_after_sep_2019_to_cleansing_team": false,
       "associate_alb_with_waf_web_acl_enabled": true,
-      "pdf_container_version": "v1.37.0",
+      "pdf_container_version": "latest",
       "deploy_opentelemetry_sidecar":false,
       "dynamodb_tables": {
         "actor_codes": {


### PR DESCRIPTION
# Purpose

Retrive the image digest for latest and deploy that version.

Fixes UML-2236

## Approach

- pick the tag latest

## Learning

! Read the notes in the ticket reference above

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
