### PR TITLE
UML-2237 - BUG - fix logging cloudtrail data events

### DIFF
--- a/terraform/account/modules/dynamodb_cloudtrail/cloudtrail.tf
+++ b/terraform/account/modules/dynamodb_cloudtrail/cloudtrail.tf
@@ -51,6 +51,7 @@ data "aws_iam_policy_document" "cloudtrail_role_policy" {
   statement {
     actions = [
       "logs:CreateLogStream",
+      "logs:CreateLogGroup",
       "logs:PutLogEvents",
       "logs:DescribeLogGroups",
       "logs:DescribeLogStreams"


### PR DESCRIPTION
# Purpose

Missing permissions causing silent failure of pushing events to logstream

Fixes UML-2237

## Approach

- Add permission
- recreate logstream pushing

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* ~The product team have tested these changes~
