### PR TITLE
UML-2224 - Refactor application flags into a variable object

### DIFF
--- a/terraform/environment/actor_ecs.tf
+++ b/terraform/environment/actor_ecs.tf
@@ -296,23 +296,23 @@ locals {
         },
         {
           name  = "USE_OLDER_LPA_JOURNEY",
-          value = tostring(local.environment.use_older_lpa_journey)
+          value = tostring(local.environment.application_flags.use_older_lpa_journey)
         },
         {
           name  = "DELETE_LPA_FEATURE",
-          value = tostring(local.environment.delete_lpa_feature)
+          value = tostring(local.environment.application_flags.delete_lpa_feature)
         },
         {
           name  = "ALLOW_OLDER_LPAS",
-          value = tostring(local.environment.allow_older_lpas)
+          value = tostring(local.environment.application_flags.allow_older_lpas)
         },
         {
           name  = "ALLOW_MERIS_LPAS",
-          value = tostring(local.environment.allow_meris_lpas)
+          value = tostring(local.environment.application_flags.allow_meris_lpas)
         },
         {
           name  = "DONT_SEND_LPAS_REGISTERED_AFTER_SEP_2019_TO_CLEANSING_TEAM",
-          value = tostring(local.environment.dont_send_lpas_registered_after_sep_2019_to_cleansing_team)
+          value = tostring(local.environment.application_flags.dont_send_lpas_registered_after_sep_2019_to_cleansing_team)
         },
       ]
   })

--- a/terraform/environment/api_ecs.tf
+++ b/terraform/environment/api_ecs.tf
@@ -349,7 +349,7 @@ locals {
         },
         {
           name  = "USE_LEGACY_CODES_SERVICE",
-          value = tostring(local.environment.use_legacy_codes_service)
+          value = tostring(local.environment.application_flags.use_legacy_codes_service)
         },
         {
           name  = "LOGGING_LEVEL",
@@ -357,19 +357,19 @@ locals {
         },
         {
           name  = "ALLOW_OLDER_LPAS",
-          value = tostring(local.environment.allow_older_lpas)
+          value = tostring(local.environment.application_flags.allow_older_lpas)
         },
         {
           name  = "ALLOW_MERIS_LPAS",
-          value = tostring(local.environment.allow_meris_lpas)
+          value = tostring(local.environment.application_flags.allow_meris_lpas)
         },
         {
           name  = "SAVE_OLDER_LPA_REQUESTS",
-          value = tostring(local.environment.save_older_lpa_requests)
+          value = tostring(local.environment.application_flags.save_older_lpa_requests)
         },
         {
           name  = "DONT_SEND_LPAS_REGISTERED_AFTER_SEP_2019_TO_CLEANSING_TEAM",
-          value = tostring(local.environment.dont_send_lpas_registered_after_sep_2019_to_cleansing_team)
+          value = tostring(local.environment.application_flags.dont_send_lpas_registered_after_sep_2019_to_cleansing_team)
         }
       ]
   })

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -68,6 +68,16 @@ variable "environments" {
       dont_send_lpas_registered_after_sep_2019_to_cleansing_team = bool
       pdf_container_version                                      = string
       deploy_opentelemetry_sidecar                               = bool
+      application_flags = object({
+        use_legacy_codes_service                                   = bool
+        use_older_lpa_journey                                      = bool
+        delete_lpa_feature                                         = bool
+        allow_older_lpas                                           = bool
+        allow_meris_lpas                                           = bool
+        save_older_lpa_requests                                    = bool
+        dont_send_lpas_registered_after_sep_2019_to_cleansing_team = bool
+
+      })
       dynamodb_tables = object({
         actor_codes = object({
           name = string

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -38,36 +38,29 @@ variable "environments" {
           maximum = number
         })
       })
-      build_admin                                                = bool
-      cookie_expires_use                                         = number
-      cookie_expires_view                                        = number
-      google_analytics_id_use                                    = string
-      google_analytics_id_view                                   = string
-      have_a_backup_plan                                         = bool
-      is_production                                              = bool
-      log_retention_in_days                                      = number
-      logging_level                                              = number
-      lpa_codes_endpoint                                         = string
-      lpas_collection_endpoint                                   = string
-      pagerduty_service_name                                     = string
-      session_expires_use                                        = number
-      session_expires_view                                       = number
-      session_expires_admin                                      = number
-      session_expiry_warning                                     = number
-      ship_metrics_queue_enabled                                 = bool
-      sirius_account_id                                          = string
-      use_legacy_codes_service                                   = bool
-      use_older_lpa_journey                                      = bool
-      delete_lpa_feature                                         = bool
-      allow_older_lpas                                           = bool
-      allow_meris_lpas                                           = bool
-      save_older_lpa_requests                                    = bool
-      load_balancer_deletion_protection_enabled                  = bool
-      notify_key_secret_name                                     = string
-      associate_alb_with_waf_web_acl_enabled                     = bool
-      dont_send_lpas_registered_after_sep_2019_to_cleansing_team = bool
-      pdf_container_version                                      = string
-      deploy_opentelemetry_sidecar                               = bool
+      build_admin                               = bool
+      cookie_expires_use                        = number
+      cookie_expires_view                       = number
+      google_analytics_id_use                   = string
+      google_analytics_id_view                  = string
+      have_a_backup_plan                        = bool
+      is_production                             = bool
+      log_retention_in_days                     = number
+      logging_level                             = number
+      lpa_codes_endpoint                        = string
+      lpas_collection_endpoint                  = string
+      pagerduty_service_name                    = string
+      session_expires_use                       = number
+      session_expires_view                      = number
+      session_expires_admin                     = number
+      session_expiry_warning                    = number
+      ship_metrics_queue_enabled                = bool
+      sirius_account_id                         = string
+      load_balancer_deletion_protection_enabled = bool
+      notify_key_secret_name                    = string
+      associate_alb_with_waf_web_acl_enabled    = bool
+      pdf_container_version                     = string
+      deploy_opentelemetry_sidecar              = bool
       application_flags = object({
         use_legacy_codes_service                                   = bool
         use_older_lpa_journey                                      = bool
@@ -76,7 +69,6 @@ variable "environments" {
         allow_meris_lpas                                           = bool
         save_older_lpa_requests                                    = bool
         dont_send_lpas_registered_after_sep_2019_to_cleansing_team = bool
-
       })
       dynamodb_tables = object({
         actor_codes = object({

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -39,18 +39,20 @@
       "session_expiry_warning": 5,
       "ship_metrics_queue_enabled": true,
       "sirius_account_id": "288342028542",
-      "use_legacy_codes_service": false,
-      "use_older_lpa_journey": true,
-      "delete_lpa_feature": true,
-      "allow_older_lpas": false,
-      "allow_meris_lpas": false,
-      "save_older_lpa_requests": true,
       "load_balancer_deletion_protection_enabled": false,
       "notify_key_secret_name": "notify-api-key",
-      "dont_send_lpas_registered_after_sep_2019_to_cleansing_team": false,
       "associate_alb_with_waf_web_acl_enabled": false,
       "pdf_container_version": "latest",
       "deploy_opentelemetry_sidecar":false,
+      "application_flags": {
+        "use_legacy_codes_service": false,
+        "use_older_lpa_journey": true,
+        "delete_lpa_feature": true,
+        "allow_older_lpas": false,
+        "allow_meris_lpas": false,
+        "save_older_lpa_requests": true,
+        "dont_send_lpas_registered_after_sep_2019_to_cleansing_team": false
+      },
       "dynamodb_tables": {
         "actor_codes": {
           "name": "ActorCodes"
@@ -108,18 +110,20 @@
       "session_expiry_warning": 5,
       "ship_metrics_queue_enabled": true,
       "sirius_account_id": "288342028542",
-      "use_legacy_codes_service": false,
-      "use_older_lpa_journey": true,
-      "delete_lpa_feature": true,
-      "allow_older_lpas": false,
-      "allow_meris_lpas": false,
-      "save_older_lpa_requests": true,
       "load_balancer_deletion_protection_enabled": false,
       "notify_key_secret_name": "notify-api-key-demo",
-      "dont_send_lpas_registered_after_sep_2019_to_cleansing_team": false,
       "associate_alb_with_waf_web_acl_enabled": true,
       "pdf_container_version": "latest",
       "deploy_opentelemetry_sidecar":false,
+      "application_flags": {
+        "use_legacy_codes_service": false,
+        "use_older_lpa_journey": true,
+        "delete_lpa_feature": true,
+        "allow_older_lpas": false,
+        "allow_meris_lpas": false,
+        "save_older_lpa_requests": true,
+        "dont_send_lpas_registered_after_sep_2019_to_cleansing_team": false
+      },
       "dynamodb_tables": {
         "actor_codes": {
           "name": "ActorCodes"
@@ -177,18 +181,20 @@
       "session_expiry_warning": 5,
       "ship_metrics_queue_enabled": false,
       "sirius_account_id": "288342028542",
-      "use_legacy_codes_service": false,
-      "use_older_lpa_journey": true,
-      "delete_lpa_feature": true,
-      "allow_older_lpas": false,
-      "allow_meris_lpas": false,
-      "save_older_lpa_requests": true,
       "load_balancer_deletion_protection_enabled": true,
       "notify_key_secret_name": "notify-api-key",
-      "dont_send_lpas_registered_after_sep_2019_to_cleansing_team": false,
       "associate_alb_with_waf_web_acl_enabled": true,
       "pdf_container_version": "latest",
       "deploy_opentelemetry_sidecar":false,
+      "application_flags": {
+        "use_legacy_codes_service": false,
+        "use_older_lpa_journey": true,
+        "delete_lpa_feature": true,
+        "allow_older_lpas": false,
+        "allow_meris_lpas": false,
+        "save_older_lpa_requests": true,
+        "dont_send_lpas_registered_after_sep_2019_to_cleansing_team": false
+      },
       "dynamodb_tables": {
         "actor_codes": {
           "name": "ActorCodes"
@@ -246,18 +252,20 @@
       "session_expiry_warning": 5,
       "ship_metrics_queue_enabled": false,
       "sirius_account_id": "649098267436",
-      "use_legacy_codes_service": false,
-      "use_older_lpa_journey": true,
-      "delete_lpa_feature": true,
-      "allow_older_lpas": false,
-      "allow_meris_lpas": false,
-      "save_older_lpa_requests": true,
       "load_balancer_deletion_protection_enabled": true,
       "notify_key_secret_name": "notify-api-key",
-      "dont_send_lpas_registered_after_sep_2019_to_cleansing_team": false,
       "associate_alb_with_waf_web_acl_enabled": true,
       "pdf_container_version": "latest",
       "deploy_opentelemetry_sidecar":false,
+      "application_flags": {
+        "use_legacy_codes_service": false,
+        "use_older_lpa_journey": true,
+        "delete_lpa_feature": true,
+        "allow_older_lpas": false,
+        "allow_meris_lpas": false,
+        "save_older_lpa_requests": true,
+        "dont_send_lpas_registered_after_sep_2019_to_cleansing_team": false
+      },
       "dynamodb_tables": {
         "actor_codes": {
           "name": "ActorCodes"


### PR DESCRIPTION
# Purpose

Make it easier to organise and locate application flags

Fixes UML-2224

## Approach

- Create an object variable called application_flags in the accounts variable object
- move all aapplication flags into new object
- update ecs env vars to use new object address

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* ~The product team have tested these changes~
