### PR TITLE
UML 2261 cookie banner should not display in pdf

### DIFF
--- a/service-front/web/src/pdf.scss
+++ b/service-front/web/src/pdf.scss
@@ -18,3 +18,7 @@
   font-style: normal;
   font-display: fallback;
 }
+
+.govuk-cookie-banner {
+  display: none !important;
+}

--- a/service-front/web/src/scss/_cookie-banner.scss
+++ b/service-front/web/src/scss/_cookie-banner.scss
@@ -1,33 +1,5 @@
-.cookie-banner {
-  display: none;
-  @include govuk-font(16);
-
-  box-sizing: border-box;
-
-  padding-top: govuk-spacing(3);
-  padding-bottom: govuk-spacing(3);
-  left: govuk-spacing(3);
-  padding-right: govuk-spacing(3);
-  background-color: lighten(desaturate(govuk-colour('light-blue'), 8.46), 42.55);
-
-  &--show {
-    display: block !important;
-  }
-
-  &__message {
-    margin: 0;
-    @include govuk-width-container;
-  }
-
-  &__button .govuk-button {
-    @include govuk-media-query($from: tablet) {
-      width: 90%;
-    }
-  }
-}
-
 @include govuk-media-query($media-type: print) {
-  .cookie-banner {
+  .govuk-cookie-banner {
     display: none !important;
   }
 }

--- a/service-front/web/webpack.pdf.development.js
+++ b/service-front/web/webpack.pdf.development.js
@@ -1,12 +1,13 @@
 const { merge } = require('webpack-merge');
 const common = require('./webpack.pdf.common.js');
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
+const path = require('path');
 
 module.exports = merge(common, {
   mode: "development",
   target: ["web", "es5"],
   output: {
-    path: '/dist',
+    path: path.resolve(__dirname, 'dist'),
     filename: 'javascript/pdf.bundle.js',
     sourceMapFilename: 'pdf.[name].js.map',
   },


### PR DESCRIPTION
# Purpose

Cookie banner is displaying when downloaded. This needs to be fixed so it is not viewable in the HTML sent to pdfservice
Fixes UML-2261

## Approach

Display logic is now inversed with cookie banner, it is displayed until it is hidden, this means we need to give an extra CSS rule in pdf.scss to hide the banner.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] The product team have tested these changes
