### PR TITLE
Start logging a bitfield describing what fields failed to match when …

### DIFF
--- a/service-api/app/src/App/src/Service/Lpa/FindActorInLpa.php
+++ b/service-api/app/src/App/src/Service/Lpa/FindActorInLpa.php
@@ -115,9 +115,9 @@ class FindActorInLpa
         $match = self::MATCH;
 
         $match = $actor['dob'] !== $matchData['dob'] ? $match | self::NO_MATCH__DOB : $match;
-        $match = $actor['first_names'] !== $matchData['first_names'] ? $match | self::NO_MATCH__FIRSTNAMES : $match;
-        $match = $actor['last_name'] !== $matchData['last_name'] ? $match | self::NO_MATCH__SURNAME : $match;
-        $match = $actor['postcode'] !== $matchData['postcode'] ? $match | self::NO_MATCH__POSTCODE : $match;
+        $match = $actorData['first_names'] !== $matchData['first_names'] ? $match | self::NO_MATCH__FIRSTNAMES : $match;
+        $match = $actorData['last_name'] !== $matchData['last_name'] ? $match | self::NO_MATCH__SURNAME : $match;
+        $match = $actorData['postcode'] !== $matchData['postcode'] ? $match | self::NO_MATCH__POSTCODE : $match;
 
         if ($match === self::MATCH) {
             $this->logger->info(

--- a/service-api/app/src/App/src/Service/Lpa/FindActorInLpa.php
+++ b/service-api/app/src/App/src/Service/Lpa/FindActorInLpa.php
@@ -8,6 +8,13 @@ use Psr\Log\LoggerInterface;
 
 class FindActorInLpa
 {
+    public const MATCH = 0;
+    public const NO_MATCH__MULTIPLE_ADDRESSES = 1;
+    public const NO_MATCH__DOB = 2;
+    public const NO_MATCH__FIRSTNAMES = 4;
+    public const NO_MATCH__SURNAME = 8;
+    public const NO_MATCH__POSTCODE = 16;
+
     private GetAttorneyStatus $getAttorneyStatus;
     private LoggerInterface $logger;
 
@@ -27,8 +34,8 @@ class FindActorInLpa
                 if (($this->getAttorneyStatus)($attorney) === GetAttorneyStatus::ACTIVE_ATTORNEY) {
                     $actorMatchResponse = $this->checkForActorMatch($attorney, $matchData);
                     // if not null, an actor match has been found
-                    if ($actorMatchResponse !== null) {
-                        $actor = $actorMatchResponse;
+                    if ($actorMatchResponse === self::MATCH) {
+                        $actor = $attorney;
                         $role = 'attorney';
                         break;
                     }
@@ -48,8 +55,8 @@ class FindActorInLpa
         if ($actor === null && isset($lpa['donor']) && is_array($lpa['donor'])) {
             $donorMatchResponse = $this->checkForActorMatch($lpa['donor'], $matchData);
 
-            if ($donorMatchResponse !== null) {
-                $actor = $donorMatchResponse;
+            if ($donorMatchResponse === self::MATCH) {
+                $actor = $lpa['donor'];
                 $role = 'donor';
             }
         }
@@ -72,9 +79,9 @@ class FindActorInLpa
      * @param array $actor     The actor details being compared against
      * @param array $matchData The user provided data we're searching for a match against
      *
-     * @return ?array A data structure containing the matched actor id and lpa id
+     * @return int A bitfield containing the failure to match reasons, or 0 if it matched.
      */
-    private function checkForActorMatch(array $actor, array $matchData): ?array
+    private function checkForActorMatch(array $actor, array $matchData): int
     {
         // Check if the actor has more than one address
         if (count($actor['addresses']) > 1) {
@@ -84,7 +91,7 @@ class FindActorInLpa
                     'id' => $actor['uId'],
                 ]
             );
-            return null;
+            return self::NO_MATCH__MULTIPLE_ADDRESSES;
         }
 
         $matchData = $this->normaliseComparisonData($matchData);
@@ -105,22 +112,33 @@ class FindActorInLpa
             ]
         );
 
-        if (
-            $actor['dob'] === $matchData['dob'] &&
-            $actorData['first_names'] === $matchData['first_names'] &&
-            $actorData['last_name'] === $matchData['last_name'] &&
-            $actorData['postcode'] === $matchData['postcode']
-        ) {
+        $match = self::MATCH;
+
+        $match = $actor['dob'] !== $matchData['dob'] ? $match | self::NO_MATCH__DOB : $match;
+        $match = $actor['first_names'] !== $matchData['first_names'] ? $match | self::NO_MATCH__FIRSTNAMES : $match;
+        $match = $actor['last_name'] !== $matchData['last_name'] ? $match | self::NO_MATCH__SURNAME : $match;
+        $match = $actor['postcode'] !== $matchData['postcode'] ? $match | self::NO_MATCH__POSTCODE : $match;
+
+        if ($match === self::MATCH) {
             $this->logger->info(
                 'User entered data matches for LPA {uId}',
                 [
                     'uId' => $matchData['reference_number'],
                 ]
             );
-            return $actor;
+        } else {
+            $this->logger->info(
+                'User entered data failed to match for LPA {uId} and actor {actor_id}. '
+                    . 'Fields in error: {fields_in_error}',
+                [
+                    'uId' => $matchData['reference_number'],
+                    'actor_id' => $actor['uId'],
+                    'fields_in_error' => $match
+                ]
+            );
         }
 
-        return null;
+        return $match;
     }
 
     /**


### PR DESCRIPTION
…finding an actor in an LPA

# Purpose

Logging additional information will let us figure out why matches are matching

## Approach

Log the reason for the match failure to INFO. Uses a bitfield integer to reduce the amount of identifiable information logged.

NO_MATCH__MULTIPLE_ADDRESSES = 1;
NO_MATCH__DOB = 2;
NO_MATCH__FIRSTNAMES = 4;
NO_MATCH__SURNAME = 8;
NO_MATCH__POSTCODE = 16;

i.e. a logged value of 30 implies all fields failed to match. But at least I don't have multiple addresses.

Because we check each attorney until we find a match, then donor. It will be the case that *many* failures will be logged. Much of it will be noise but it will allow us to find out our bug when it occurs again.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* The product team have tested these changes
