### PR TITLE
UML-2284 - Admin Development only workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,6 @@ workflows:
             requires:
               [
                 cancel_previous_jobs,
-                dev_plan_shared_terraform,
               ]
 
         - use-my-lpa/seed_database:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,6 +265,34 @@ workflows:
                   /admin\/.*/
                   ]
 
+        - use-my-lpa/docker_test_admin:
+            name: admin_app_test
+            filters:
+              branches:
+                only: [
+                  /admin\/.*/
+                  ]
+
+        - use-my-lpa/docker_build_admin:
+            name: admin_app_build
+            filters:
+              branches:
+                only: [
+                  /admin\/.*/
+                  ]
+
+        - use-my-lpa/codecov_upload:
+            name: codecov_upload
+            filters:
+              branches:
+                only: [
+                  /admin\/.*/
+                  ]
+            requires:
+              [
+                admin_app_test,
+              ]
+
             # Provision and test development
         - use-my-lpa/plan_shared_terraform:
             name: dev_plan_shared_terraform
@@ -286,6 +314,7 @@ workflows:
             requires:
               [
                 cancel_previous_jobs,
+                admin_app_build
               ]
 
         - use-my-lpa/seed_database:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1242,6 +1242,10 @@ orbs:
             description: Inputs to use for setting image tags
             type: string
             default: "${CIRCLE_BRANCH} ${CIRCLE_SHA1}"
+          admin_image_tag_input:
+            description: Inputs to use for setting admin app image tags
+            type: string
+            default: "${CIRCLE_BRANCH} ${CIRCLE_SHA1}"
         steps:
           - checkout
           - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,6 @@ workflows:
             requires:
               [
                 cancel_previous_jobs,
-                dev_plan_shared_terraform,
               ]
 
         - use-my-lpa/seed_database:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ workflows:
           name: demo_apply_environment_terraform
           workspace: demo
           image_tag_input: latest
+          admin_image_tag_input: latest
       - use-my-lpa/redeploy_latest:
           name: redeploy_demo
           environment: demo
@@ -203,6 +204,7 @@ workflows:
         - use-my-lpa/apply_environment_terraform:
             name: dev_apply_environment_terraform
             image_tag_input: latest
+            admin_image_tag_input: latest
             filters:
               branches:
                 only: [

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1265,7 +1265,7 @@ orbs:
                   export IMAGE_TAG=$(~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh <<parameters.image_tag_input>>) >> $BASH_ENV
                 fi
                 echo $IMAGE_TAG
-                terraform apply -lock-timeout=300s --auto-approve -var container_version=${IMAGE_TAG}
+                terraform apply -lock-timeout=300s --auto-approve -var container_version=${IMAGE_TAG} -var admin_container_version=${IMAGE_TAG}
                 mv cluster_config.json /tmp/
           - persist_to_workspace:
               root: /tmp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1259,13 +1259,22 @@ orbs:
                 export TF_WORKSPACE=$(~/project/scripts/pipeline/set_environment_variables/set_workspace.sh <<parameters.workspace>>) >> $BASH_ENV
                 echo $TF_WORKSPACE
                 ~/project/scripts/pipeline/workspace_cleanup/put_workspace_linux -workspace=$TF_WORKSPACE
+
                 if [ "<<parameters.image_tag_input>>" == "latest" ]; then
                   export IMAGE_TAG="latest"
                 else
                   export IMAGE_TAG=$(~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh <<parameters.image_tag_input>>) >> $BASH_ENV
                 fi
                 echo $IMAGE_TAG
-                terraform apply -lock-timeout=300s --auto-approve -var container_version=${IMAGE_TAG} -var admin_container_version=${IMAGE_TAG}
+
+                if [ "<<parameters.admin_image_tag_input>>" == "latest" ]; then
+                  export ADMIN_IMAGE_TAG="latest"
+                else
+                  export ADMIN_IMAGE_TAG=$(~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh <<parameters.image_tag_input>>) >> $BASH_ENV
+                fi
+                echo $ADMIN_IMAGE_TAG
+
+                terraform apply -lock-timeout=300s --auto-approve -var container_version=${IMAGE_TAG} -var admin_container_version=${ADMIN_IMAGE_TAG}
                 mv cluster_config.json /tmp/
           - persist_to_workspace:
               root: /tmp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,6 +280,10 @@ workflows:
                 only: [
                   /admin\/.*/
                   ]
+            requires:
+              [
+                admin_app_test,
+              ]
 
         - use-my-lpa/codecov_upload:
             name: codecov_upload
@@ -1294,14 +1298,14 @@ orbs:
                 else
                   export IMAGE_TAG=$(~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh <<parameters.image_tag_input>>) >> $BASH_ENV
                 fi
-                echo $IMAGE_TAG
+                echo "deploying service version ${IMAGE_TAG}"
 
                 if [ "<<parameters.admin_image_tag_input>>" == "latest" ]; then
                   export ADMIN_IMAGE_TAG="latest"
                 else
                   export ADMIN_IMAGE_TAG=$(~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh <<parameters.admin_image_tag_input>>) >> $BASH_ENV
                 fi
-                echo $ADMIN_IMAGE_TAG
+                echo "deploying admin app version ${ADMIN_IMAGE_TAG}"
 
                 terraform apply -lock-timeout=300s --auto-approve -var container_version=${IMAGE_TAG} -var admin_container_version=${ADMIN_IMAGE_TAG}
                 mv cluster_config.json /tmp/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,6 +246,76 @@ workflows:
                   ]
             requires: [dev_run_behat_tests]
 
+  admin_only_pr:
+      jobs:
+        - cancel_redundant_builds:
+            name: cancel_previous_jobs
+            filters:
+              branches:
+                only: [
+                  /admin\/.*/
+                  ]
+
+        - use-my-lpa/lint_terraform:
+            name: lint_terraform
+            filters:
+              branches:
+                only: [
+                  /admin\/.*/
+                  ]
+
+            # Provision and test development
+        - use-my-lpa/plan_shared_terraform:
+            name: dev_plan_shared_terraform
+            filters:
+              branches:
+                only: [
+                  /admin\/.*/
+                  ]
+            requires: [cancel_previous_jobs,lint_terraform]
+
+        - use-my-lpa/apply_environment_terraform:
+            name: dev_apply_environment_terraform
+            image_tag_input: latest
+            filters:
+              branches:
+                only: [
+                  /admin\/.*/
+                  ]
+            requires:
+              [
+                cancel_previous_jobs,
+                dev_plan_shared_terraform,
+              ]
+
+        - use-my-lpa/seed_database:
+            name: dev_seed_database
+            filters:
+              branches:
+                only: [
+                  /admin\/.*/
+                  ]
+            requires: [dev_apply_environment_terraform]
+
+        - use-my-lpa/run_behat_suite:
+            name: dev_run_behat_tests
+            filters:
+              branches:
+                only: [
+                  /admin\/.*/
+                  ]
+            requires: [dev_seed_database]
+
+        # Required end of workflow job
+        - use-my-lpa/end_of_workflow:
+            name: end_of_workflow
+            filters:
+              branches:
+                only: [
+                  /admin\/.*/
+                  ]
+            requires: [dev_run_behat_tests]
+
   pr_build:
       jobs:
         - cancel_redundant_builds:
@@ -253,7 +323,8 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /tf\/.*/
+              /tf\/.*/,
+              /admin\/.*/
               ] } }
 
         - use-my-lpa/lint_terraform:
@@ -261,7 +332,8 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /tf\/.*/
+              /tf\/.*/,
+              /admin\/.*/
               ] } }
 
         - use-my-lpa/node_test_web:
@@ -269,7 +341,8 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /tf\/.*/
+              /tf\/.*/,
+              /admin\/.*/
               ] } }
 
         - use-my-lpa/node_build_web:
@@ -277,7 +350,8 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /tf\/.*/
+              /tf\/.*/,
+              /admin\/.*/
               ] } }
             requires: [test_web]
 
@@ -286,7 +360,8 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /tf\/.*/
+              /tf\/.*/,
+              /admin\/.*/
               ] } }
             requires: [build_web]
 
@@ -295,7 +370,8 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /tf\/.*/
+              /tf\/.*/,
+              /admin\/.*/
               ] } }
             requires: [build_web]
 
@@ -304,7 +380,8 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /tf\/.*/
+              /tf\/.*/,
+              /admin\/.*/
               ] } }
 
         - use-my-lpa/docker_build_api_web:
@@ -312,7 +389,8 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /tf\/.*/
+              /tf\/.*/,
+              /admin\/.*/
               ] } }
 
         - use-my-lpa/docker_test_admin:
@@ -320,7 +398,8 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /tf\/.*/
+              /tf\/.*/,
+              /admin\/.*/
               ] } }
 
         - use-my-lpa/docker_build_admin:
@@ -328,7 +407,8 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /tf\/.*/
+              /tf\/.*/,
+              /admin\/.*/
               ] } }
 
         - use-my-lpa/codecov_upload:
@@ -336,7 +416,8 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /tf\/.*/
+              /tf\/.*/,
+              /admin\/.*/
               ] } }
             requires:
               [
@@ -352,7 +433,8 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /tf\/.*/
+              /tf\/.*/,
+              /admin\/.*/
               ] } }
             requires: [cancel_previous_jobs,lint_terraform]
 
@@ -361,7 +443,8 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /tf\/.*/
+              /tf\/.*/,
+              /admin\/.*/
               ] } }
             requires:
               [
@@ -379,7 +462,8 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /tf\/.*/
+              /tf\/.*/,
+              /admin\/.*/
               ] } }
             requires:
               [
@@ -395,7 +479,8 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /tf\/.*/
+              /tf\/.*/,
+              /admin\/.*/
               ] } }
             requires: [dev_apply_environment_terraform]
 
@@ -404,7 +489,8 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /tf\/.*/
+              /tf\/.*/,
+              /admin\/.*/
               ] } }
             requires: [dev_seed_database]
 
@@ -415,7 +501,8 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /tf\/.*/
+              /tf\/.*/,
+              /admin\/.*/
               ] } }
             requires: [dev_run_behat_tests]
 
@@ -425,7 +512,8 @@ workflows:
             filters: { branches: { ignore: [
               main,
               /dependabot\/.*/,
-              /tf\/.*/
+              /tf\/.*/,
+              /admin\/.*/
               ] } }
             requires: [post_environment_domains]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1270,7 +1270,7 @@ orbs:
                 if [ "<<parameters.admin_image_tag_input>>" == "latest" ]; then
                   export ADMIN_IMAGE_TAG="latest"
                 else
-                  export ADMIN_IMAGE_TAG=$(~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh <<parameters.image_tag_input>>) >> $BASH_ENV
+                  export ADMIN_IMAGE_TAG=$(~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh <<parameters.admin_image_tag_input>>) >> $BASH_ENV
                 fi
                 echo $ADMIN_IMAGE_TAG
 

--- a/terraform/environment/admin_ecs.tf
+++ b/terraform/environment/admin_ecs.tf
@@ -171,7 +171,7 @@ locals {
     {
       cpu         = 1,
       essential   = true,
-      image       = "${data.aws_ecr_repository.use_an_lpa_admin_app.repository_url}:${var.container_version}",
+      image       = "${data.aws_ecr_repository.use_an_lpa_admin_app.repository_url}:${var.admin_container_version}",
       mountPoints = [],
       name        = "app",
       portMappings = [

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -7,8 +7,17 @@ variable "container_version" {
   default = "latest"
 }
 
+variable "admin_container_version" {
+  type    = string
+  default = "latest"
+}
+
 output "container_version" {
   value = var.container_version
+}
+
+output "admin_container_version" {
+  value = var.admin_container_version
 }
 
 output "workspace_name" {


### PR DESCRIPTION
# Purpose

Make Admin only development pipelines quicker

Fixes UML-2284

## Approach

- Create a branch name filter for `admin/`
- Allow terraform to accept an image tag for Admin

## Learning

- https://circleci.com/docs/2.0/configuration-reference/#jobfilters
- https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3470622721/UaL+Filtered+Pipelines

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* ~New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* ~The product team have tested these changes~
