### PR TITLE
UML-2285 missing analytics

### DIFF
--- a/service-front/app/src/Common/templates/partials/govuk_error.html.twig
+++ b/service-front/app/src/Common/templates/partials/govuk_error.html.twig
@@ -29,7 +29,7 @@
         {# ... display the errors for a single field #}
         {%- for error in errors -%}
             <span class="govuk-error-message">
-                <span data-gaEventType="onLoad" data-gaCategory="Form errors" data-gaAction="{{ element.label }}" data-gaLabel="#{{ element.getName() }} - {{ error }}" class="govuk-visually-hidden">{% trans %}Error:{% endtrans %}</span> {{ error | trans([], null, 'error') | raw }}
+                <span data-gaEventType="onLoad" data-gaCategory="Form errors" data-gaAction="{{ (element.label != '') ? element.label : element.getName() }}" data-gaLabel="#{{ element.getName() }} - {{ error }}" class="govuk-visually-hidden">{% trans %}Error:{% endtrans %}</span> {{ error | trans([], null, 'error') | raw }}
             </span>
         {%- endfor -%}
     {% endif %}


### PR DESCRIPTION
# Purpose

When gaAction is empty string then analytics isn't reported

Fixes UML-2285

## Approach

Set action to element name when the label doesn't exist

## Learning

Gaaction is required :D 

## Checklist

* [x] I have performed a self-review of my own code
* [ ] The product team have tested these changes
