### PR TITLE
Uml 2286 cookies page always turns cookies off

### DIFF
--- a/service-front/web/src/javascript/cookieConsent.js
+++ b/service-front/web/src/javascript/cookieConsent.js
@@ -11,7 +11,7 @@ export default class CookieConsent {
 
     this._toggleCookieMessage(!isAnalyticsCookieSet && !isInCookiesPath);
 
-    if (isInCookiesPath) { 
+    if (!isAnalyticsCookieSet && isInCookiesPath) { 
       setConsentCookie(false);
     }
 

--- a/service-front/web/src/javascript/cookieConsent.test.js
+++ b/service-front/web/src/javascript/cookieConsent.test.js
@@ -131,16 +131,28 @@ describe('When the cookie banner is initiated', () => {
 
 describe('When the cookie banner is initiated on the cookies page', () => {
   describe('and I am on the cookies page but have not seen the message', () => {
-    beforeEach(() => {
-      getCookie.mockReturnValueOnce(null);
-      getCookie.mockReturnValueOnce(null);
-    });
     test('it should setup useAnaltics', () => {
+
+      getCookie.mockReturnValueOnce(null);
+      getCookie.mockReturnValueOnce(null);
+
       document.body.innerHTML = cookieBannerHtml;
       new cookieConsent(document.querySelector('.govuk-cookie-banner'), true);
       const cookieBanner = document.querySelector('.govuk-cookie-banner');
 
       expect(setConsentCookie).toHaveBeenCalledWith(false);
+      expect(cookieBanner.getAttribute('hidden')).not.toBe(null);
+    });
+    test('When analytics is already set up nothing is called', () => {
+
+      getCookie.mockReturnValueOnce('{ "essential": true, "usage": true }');
+      getCookie.mockReturnValueOnce('{ "essential": true, "usage": true }');
+
+      document.body.innerHTML = cookieBannerHtml;
+      new cookieConsent(document.querySelector('.govuk-cookie-banner'), true);
+      const cookieBanner = document.querySelector('.govuk-cookie-banner');
+
+      expect(setConsentCookie).not.toHaveBeenCalled();
       expect(cookieBanner.getAttribute('hidden')).not.toBe(null);
     });
   });


### PR DESCRIPTION
# Purpose

Stop cookies being set to essential only when navigating to cookie page 

Fixes UML-2286

## Approach

logic missing to only set cookies to essential only when navigating to cookie page AND cookies have not previously been set

This last step has now been added to the logic

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
