### PR TITLE
UML-2238/UML-2293 - Move API and PDF services to new service discovery DNS

### DIFF
--- a/terraform/environment/api_ecs.tf
+++ b/terraform/environment/api_ecs.tf
@@ -70,7 +70,7 @@ resource "aws_service_discovery_service" "api_ecs" {
 
 //
 locals {
-  api_service_fqdn = "${aws_service_discovery_service.api.name}.${aws_service_discovery_private_dns_namespace.internal_ecs.name}"
+  api_service_fqdn = "${aws_service_discovery_service.api_ecs.name}.${aws_service_discovery_private_dns_namespace.internal_ecs.name}"
 }
 
 //----------------------------------

--- a/terraform/environment/api_ecs.tf
+++ b/terraform/environment/api_ecs.tf
@@ -17,13 +17,13 @@ resource "aws_ecs_service" "api" {
   }
 
   service_registries {
-    registry_arn = aws_service_discovery_service.api.arn
+    registry_arn = aws_service_discovery_service.api_ecs.arn
   }
 
   wait_for_steady_state = true
 
   lifecycle {
-    create_before_destroy = true
+    create_before_destroy = false
   }
 }
 
@@ -70,7 +70,7 @@ resource "aws_service_discovery_service" "api_ecs" {
 
 //
 locals {
-  api_service_fqdn = "${aws_service_discovery_service.api.name}.${aws_service_discovery_private_dns_namespace.internal.name}"
+  api_service_fqdn = "${aws_service_discovery_service.api.name}.${aws_service_discovery_private_dns_namespace.internal_ecs.name}"
 }
 
 //----------------------------------

--- a/terraform/environment/dns.tf
+++ b/terraform/environment/dns.tf
@@ -13,6 +13,7 @@ data "aws_route53_zone" "live_service_view_lasting_power_of_attorney" {
   name     = "view-lasting-power-of-attorney.service.gov.uk"
 }
 
+# remove this after UML-2293 is merged
 resource "aws_service_discovery_private_dns_namespace" "internal" {
   name = "${local.environment_name}-internal"
   vpc  = data.aws_vpc.default.id

--- a/terraform/environment/pdf_ecs.tf
+++ b/terraform/environment/pdf_ecs.tf
@@ -16,13 +16,13 @@ resource "aws_ecs_service" "pdf" {
   }
 
   service_registries {
-    registry_arn = aws_service_discovery_service.pdf.arn
+    registry_arn = aws_service_discovery_service.pdf_ecs.arn
   }
 
   wait_for_steady_state = true
 
   lifecycle {
-    create_before_destroy = true
+    create_before_destroy = false
   }
 }
 
@@ -69,7 +69,7 @@ resource "aws_service_discovery_service" "pdf_ecs" {
 
 //
 locals {
-  pdf_service_fqdn = "${aws_service_discovery_service.pdf.name}.${aws_service_discovery_private_dns_namespace.internal.name}"
+  pdf_service_fqdn = "${aws_service_discovery_service.pdf.name}.${aws_service_discovery_private_dns_namespace.internal_ecs.name}"
 }
 
 //----------------------------------

--- a/terraform/environment/pdf_ecs.tf
+++ b/terraform/environment/pdf_ecs.tf
@@ -69,7 +69,7 @@ resource "aws_service_discovery_service" "pdf_ecs" {
 
 //
 locals {
-  pdf_service_fqdn = "${aws_service_discovery_service.pdf.name}.${aws_service_discovery_private_dns_namespace.internal_ecs.name}"
+  pdf_service_fqdn = "${aws_service_discovery_service.pdf_ecs.name}.${aws_service_discovery_private_dns_namespace.internal_ecs.name}"
 }
 
 //----------------------------------


### PR DESCRIPTION
# Purpose

Part 2 of 3 of Service Discovery DNS changes

Fixes UML-2293

## Approach

- build env
- move api and pdf to new service discovery

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* ~The product team have tested these changes~
