### PR TITLE
UML-2016 - Don't let underscores be part of an env name

### DIFF
--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -101,7 +101,7 @@ variable "environments" {
 }
 
 locals {
-  environment_name  = lower(terraform.workspace)
+  environment_name  = lower(replace(terraform.workspace, "_", "-"))
   environment       = contains(keys(var.environments), local.environment_name) ? var.environments[local.environment_name] : var.environments["default"]
   dns_namespace_acc = local.environment_name == "production" ? "" : "${local.environment.account_name}."
   dns_namespace_env = local.environment.account_name == "production" ? "" : "${local.environment_name}."


### PR DESCRIPTION
# Purpose

Enviornment names are used in load balancer resource names and underscores are not permited there

Fixes UML-2016

## Approach

- use the terraform replace function

## Learning

- https://www.terraform.io/language/functions/replace

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* ~The product team have tested these changes~
