### PR TITLE
UML-1960 - create a metric for each failed login status

### DIFF
--- a/terraform/environment/cloudwatch_metrics.tf
+++ b/terraform/environment/cloudwatch_metrics.tf
@@ -84,7 +84,7 @@ locals {
 resource "aws_cloudwatch_log_metric_filter" "login_attempt_failures" {
   for_each       = toset(local.login_attempt_status)
   name           = "${local.environment_name}_${lower(each.value)}"
-  pattern        = "{ $.request = \"*/v1/auth*\" && $.status = each.vaule }"
+  pattern        = "{ $.request = \"*/v1/auth*\" && $.status = \"${each.value}\" }"
   log_group_name = aws_cloudwatch_log_group.application_logs.name
 
   metric_transformation {

--- a/terraform/environment/cloudwatch_metrics.tf
+++ b/terraform/environment/cloudwatch_metrics.tf
@@ -72,3 +72,25 @@ resource "aws_cloudwatch_log_metric_filter" "rate_limiting_metrics" {
     default_value = "0"
   }
 }
+
+locals {
+  login_attempt_status = [
+    "403",
+    "404",
+    "401",
+  ]
+}
+
+resource "aws_cloudwatch_log_metric_filter" "login_attempt_failures" {
+  for_each       = toset(local.login_attempt_status)
+  name           = "${local.environment_name}_${lower(each.value)}"
+  pattern        = "{ $.status = \"each.vaule\" && $.request = \"PATCH /v1/auth HTTP/1.1\" }"
+  log_group_name = aws_cloudwatch_log_group.application_logs.name
+
+  metric_transformation {
+    name          = "${lower(each.value)}_login_attempt_failures"
+    namespace     = "${local.environment_name}_events"
+    value         = "1"
+    default_value = "0"
+  }
+}

--- a/terraform/environment/cloudwatch_metrics.tf
+++ b/terraform/environment/cloudwatch_metrics.tf
@@ -84,7 +84,7 @@ locals {
 resource "aws_cloudwatch_log_metric_filter" "login_attempt_failures" {
   for_each       = toset(local.login_attempt_status)
   name           = "${local.environment_name}_${lower(each.value)}"
-  pattern        = "{ $.request = \"*/v1/auth*\" && $.status = \"each.vaule\" }"
+  pattern        = "{ $.request = \"*/v1/auth*\" && $.status = each.vaule }"
   log_group_name = aws_cloudwatch_log_group.application_logs.name
 
   metric_transformation {

--- a/terraform/environment/cloudwatch_metrics.tf
+++ b/terraform/environment/cloudwatch_metrics.tf
@@ -73,33 +73,6 @@ resource "aws_cloudwatch_log_metric_filter" "rate_limiting_metrics" {
   }
 }
 
-
-resource "aws_cloudwatch_log_metric_filter" "login_attempt_user_not_found" {
-  name           = "${local.environment_name}_login_attempt_user_not_found"
-  pattern        = "{ $.message = \"User not found for email\" }"
-  log_group_name = aws_cloudwatch_log_group.application_logs.name
-
-  metric_transformation {
-    name          = "login_attempt_user_not_found"
-    namespace     = "${local.environment_name}_events"
-    value         = "1"
-    default_value = "0"
-  }
-}
-
-resource "aws_cloudwatch_log_metric_filter" "login_attempt_authentication_failure" {
-  name           = "${local.environment_name}_login_attempt_authentication_failure"
-  pattern        = "{ $.message = \"Authentication failed for*\" }"
-  log_group_name = aws_cloudwatch_log_group.application_logs.name
-
-  metric_transformation {
-    name          = "login_attempt_authentication_failure"
-    namespace     = "${local.environment_name}_events"
-    value         = "1"
-    default_value = "0"
-  }
-}
-
 locals {
   login_attempt_status = [
     "403",
@@ -111,7 +84,7 @@ locals {
 resource "aws_cloudwatch_log_metric_filter" "login_attempt_failures" {
   for_each       = toset(local.login_attempt_status)
   name           = "${local.environment_name}_${lower(each.value)}"
-  pattern        = "{  $.message = \"Authentication failed for*\" && $.message = \"* with code ${each.value}\" }"
+  pattern        = "{  $.message = \"Authentication failed for*\" && $.message = \"*with code ${each.value}\" }"
   log_group_name = aws_cloudwatch_log_group.application_logs.name
 
   metric_transformation {

--- a/terraform/environment/cloudwatch_metrics.tf
+++ b/terraform/environment/cloudwatch_metrics.tf
@@ -84,7 +84,7 @@ locals {
 resource "aws_cloudwatch_log_metric_filter" "login_attempt_failures" {
   for_each       = toset(local.login_attempt_status)
   name           = "${local.environment_name}_${lower(each.value)}"
-  pattern        = "{ $.request = \"*/v1/auth*\" && $.status = \"${each.value}\" }"
+  pattern        = "{ $.logStream = \"*api-app*\" && $.request = \"*/v1/auth*\" && $.status = \"${each.value}\" }"
   log_group_name = aws_cloudwatch_log_group.application_logs.name
 
   metric_transformation {

--- a/terraform/environment/cloudwatch_metrics.tf
+++ b/terraform/environment/cloudwatch_metrics.tf
@@ -84,7 +84,7 @@ locals {
 resource "aws_cloudwatch_log_metric_filter" "login_attempt_failures" {
   for_each       = toset(local.login_attempt_status)
   name           = "${local.environment_name}_${lower(each.value)}"
-  pattern        = "{ $.status = \"each.vaule\" && $.request = \"PATCH /v1/auth HTTP/1.1\" }"
+  pattern        = "{ $.request = \"*/v1/auth*\" && $.status = \"each.vaule\" }"
   log_group_name = aws_cloudwatch_log_group.application_logs.name
 
   metric_transformation {

--- a/terraform/environment/cloudwatch_metrics.tf
+++ b/terraform/environment/cloudwatch_metrics.tf
@@ -94,3 +94,5 @@ resource "aws_cloudwatch_log_metric_filter" "login_attempt_failures" {
     default_value = "0"
   }
 }
+
+# no change

--- a/terraform/environment/cloudwatch_metrics.tf
+++ b/terraform/environment/cloudwatch_metrics.tf
@@ -94,5 +94,3 @@ resource "aws_cloudwatch_log_metric_filter" "login_attempt_failures" {
     default_value = "0"
   }
 }
-
-# no change


### PR DESCRIPTION
# Purpose

Measure the reasons for log in failures

Fixes UML-1960

## Approach

- Create a metric filter for each failed login status

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter

## Checklist

* [ ] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* ~The product team have tested these changes~
