### PR TITLE
UML-2347 - Create DDOS alarms for each loadbalancer

### DIFF
--- a/terraform/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/cloudwatch_alarms.tf
@@ -58,3 +58,55 @@ resource "aws_cloudwatch_metric_alarm" "unexpected_data_lpa_api_resposnes" {
   threshold           = 5
   treat_missing_data  = "notBreaching"
 }
+
+resource "aws_cloudwatch_metric_alarm" "actor_ddos_attack_external" {
+  alarm_name          = "ActorDDoSDetected"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "3"
+  metric_name         = "DDoSDetected"
+  namespace           = "AWS/DDoSProtection"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "0"
+  alarm_description   = "Triggers when AWS Shield Advanced detects a DDoS attack"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
+  dimensions = {
+    ResourceArn = aws_lb.actor.arn
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "viewer_ddos_attack_external" {
+  alarm_name          = "ViewerDDoSDetected"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "3"
+  metric_name         = "DDoSDetected"
+  namespace           = "AWS/DDoSProtection"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "0"
+  alarm_description   = "Triggers when AWS Shield Advanced detects a DDoS attack"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
+  dimensions = {
+    ResourceArn = aws_lb.viewer.arn
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "admin_ddos_attack_external" {
+  count               = local.environment.build_admin ? 1 : 0
+  alarm_name          = "AdminDDoSDetected"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "3"
+  metric_name         = "DDoSDetected"
+  namespace           = "AWS/DDoSProtection"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "0"
+  alarm_description   = "Triggers when AWS Shield Advanced detects a DDoS attack"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
+  dimensions = {
+    ResourceArn = aws_lb.admin[0].arn
+  }
+}


### PR DESCRIPTION
# Purpose

Enrol UaL in Shield Advanced

Fixes UML-2347

## Approach

- Create a cloudwatch alarm for each aws_lb monitoring the DDOSDetected events

## Learning

- https://user-guide.modernisation-platform.service.justice.gov.uk/runbooks/enabling-shield-advanced.html#create-alarms

## Checklist

* [ ] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* ~The product team have tested these changes~
