### PR TITLE
UML-2342 - Disable DNS caching for libcurl

### DIFF
--- a/terraform/environment/actor_ecs.tf
+++ b/terraform/environment/actor_ecs.tf
@@ -314,6 +314,10 @@ locals {
           name  = "DONT_SEND_LPAS_REGISTERED_AFTER_SEP_2019_TO_CLEANSING_TEAM",
           value = tostring(local.environment.application_flags.dont_send_lpas_registered_after_sep_2019_to_cleansing_team)
         },
+        # {
+        #   name  = "CURLOPT_DNS_CACHE_TIMEOUT",
+        #   value = "0"
+        # },
       ]
   })
 

--- a/terraform/environment/actor_ecs.tf
+++ b/terraform/environment/actor_ecs.tf
@@ -314,10 +314,10 @@ locals {
           name  = "DONT_SEND_LPAS_REGISTERED_AFTER_SEP_2019_TO_CLEANSING_TEAM",
           value = tostring(local.environment.application_flags.dont_send_lpas_registered_after_sep_2019_to_cleansing_team)
         },
-        # {
-        #   name  = "CURLOPT_DNS_CACHE_TIMEOUT",
-        #   value = "0"
-        # },
+        {
+          name  = "CURLOPT_DNS_CACHE_TIMEOUT",
+          value = "0"
+        },
       ]
   })
 


### PR DESCRIPTION
# Purpose

In order to make dns requests predictable for egress management, we will test disabling libcurl's DNS caching.

Fixes UML-2342

## Approach

- disable libcurl dns cache with CURLOPT_DNS_CACHE_TIMEOUT set to 0

## Learning

- https://curl.se/libcurl/c/CURLOPT_DNS_CACHE_TIMEOUT.html

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
