### PR TITLE
UML-1512 - Use Fargate SPOT as a capacity provider for PR environments

### DIFF
--- a/terraform/environment/actor_ecs.tf
+++ b/terraform/environment/actor_ecs.tf
@@ -2,11 +2,11 @@
 // Actor ECS Service level config
 
 resource "aws_ecs_service" "actor" {
-  name             = "actor-service"
-  cluster          = aws_ecs_cluster.use-an-lpa.id
-  task_definition  = aws_ecs_task_definition.actor.arn
-  desired_count    = local.environment.autoscaling.use.minimum
-  launch_type      = "FARGATE"
+  name            = "actor-service"
+  cluster         = aws_ecs_cluster.use-an-lpa.id
+  task_definition = aws_ecs_task_definition.actor.arn
+  desired_count   = local.environment.autoscaling.use.minimum
+  # launch_type      = "FARGATE"
   platform_version = "1.4.0"
 
   network_configuration {

--- a/terraform/environment/actor_ecs.tf
+++ b/terraform/environment/actor_ecs.tf
@@ -2,11 +2,10 @@
 // Actor ECS Service level config
 
 resource "aws_ecs_service" "actor" {
-  name            = "actor-service"
-  cluster         = aws_ecs_cluster.use-an-lpa.id
-  task_definition = aws_ecs_task_definition.actor.arn
-  desired_count   = local.environment.autoscaling.use.minimum
-  # launch_type      = "FARGATE"
+  name             = "actor-service"
+  cluster          = aws_ecs_cluster.use-an-lpa.id
+  task_definition  = aws_ecs_task_definition.actor.arn
+  desired_count    = local.environment.autoscaling.use.minimum
   platform_version = "1.4.0"
 
   network_configuration {

--- a/terraform/environment/actor_ecs.tf
+++ b/terraform/environment/actor_ecs.tf
@@ -21,6 +21,11 @@ resource "aws_ecs_service" "actor" {
     container_port   = 80
   }
 
+  capacity_provider_strategy {
+    capacity_provider = local.capacity_provider
+    weight            = 100
+  }
+
   wait_for_steady_state = true
 
   lifecycle {

--- a/terraform/environment/admin_ecs.tf
+++ b/terraform/environment/admin_ecs.tf
@@ -7,7 +7,6 @@ resource "aws_ecs_service" "admin" {
   cluster          = aws_ecs_cluster.use-an-lpa.id
   task_definition  = aws_ecs_task_definition.admin[0].arn
   desired_count    = 1
-  launch_type      = "FARGATE"
   platform_version = "1.4.0"
 
   network_configuration {
@@ -22,10 +21,15 @@ resource "aws_ecs_service" "admin" {
     container_port   = 80
   }
 
+  capacity_provider_strategy {
+    capacity_provider = local.capacity_provider
+    weight            = 100
+  }
+
   wait_for_steady_state = true
 
   lifecycle {
-    create_before_destroy = true
+    create_before_destroy = false
   }
 
   depends_on = [aws_lb.admin]

--- a/terraform/environment/admin_ecs.tf
+++ b/terraform/environment/admin_ecs.tf
@@ -29,7 +29,7 @@ resource "aws_ecs_service" "admin" {
   wait_for_steady_state = true
 
   lifecycle {
-    create_before_destroy = false
+    create_before_destroy = true
   }
 
   depends_on = [aws_lb.admin]

--- a/terraform/environment/api_ecs.tf
+++ b/terraform/environment/api_ecs.tf
@@ -27,7 +27,7 @@ resource "aws_ecs_service" "api" {
   wait_for_steady_state = true
 
   lifecycle {
-    create_before_destroy = false
+    create_before_destroy = true
   }
 }
 

--- a/terraform/environment/api_ecs.tf
+++ b/terraform/environment/api_ecs.tf
@@ -6,7 +6,6 @@ resource "aws_ecs_service" "api" {
   cluster                           = aws_ecs_cluster.use-an-lpa.id
   task_definition                   = aws_ecs_task_definition.api.arn
   desired_count                     = local.environment.autoscaling.api.minimum
-  launch_type                       = "FARGATE"
   platform_version                  = "1.4.0"
   health_check_grace_period_seconds = 0
 
@@ -20,10 +19,15 @@ resource "aws_ecs_service" "api" {
     registry_arn = aws_service_discovery_service.api_ecs.arn
   }
 
+  capacity_provider_strategy {
+    capacity_provider = local.capacity_provider
+    weight            = 100
+  }
+
   wait_for_steady_state = true
 
   lifecycle {
-    create_before_destroy = true
+    create_before_destroy = false
   }
 }
 

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -70,6 +70,7 @@ variable "environments" {
       associate_alb_with_waf_web_acl_enabled    = bool
       pdf_container_version                     = string
       deploy_opentelemetry_sidecar              = bool
+      fargate_spot                              = bool
       application_flags = object({
         use_legacy_codes_service                                   = bool
         use_older_lpa_journey                                      = bool

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -107,6 +107,7 @@ locals {
   dns_namespace_acc = local.environment_name == "production" ? "" : "${local.environment.account_name}."
   dns_namespace_env = local.environment.account_name == "production" ? "" : "${local.environment_name}."
   dev_wildcard      = local.environment.account_name == "production" ? "" : "*."
+  capacity_provider = local.environment.fargate_spot ? "FARGATE_SPOT" : "FARGATE"
 
   mandatory_moj_tags = {
     business-unit    = "OPG"

--- a/terraform/environment/pdf_ecs.tf
+++ b/terraform/environment/pdf_ecs.tf
@@ -6,7 +6,6 @@ resource "aws_ecs_service" "pdf" {
   cluster          = aws_ecs_cluster.use-an-lpa.id
   task_definition  = aws_ecs_task_definition.pdf.arn
   desired_count    = local.environment.autoscaling.pdf.minimum
-  launch_type      = "FARGATE"
   platform_version = "1.4.0"
 
   network_configuration {
@@ -19,10 +18,15 @@ resource "aws_ecs_service" "pdf" {
     registry_arn = aws_service_discovery_service.pdf_ecs.arn
   }
 
+  capacity_provider_strategy {
+    capacity_provider = local.capacity_provider
+    weight            = 100
+  }
+
   wait_for_steady_state = true
 
   lifecycle {
-    create_before_destroy = true
+    create_before_destroy = false
   }
 }
 

--- a/terraform/environment/pdf_ecs.tf
+++ b/terraform/environment/pdf_ecs.tf
@@ -26,7 +26,7 @@ resource "aws_ecs_service" "pdf" {
   wait_for_steady_state = true
 
   lifecycle {
-    create_before_destroy = false
+    create_before_destroy = true
   }
 }
 

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -43,7 +43,8 @@
       "notify_key_secret_name": "notify-api-key",
       "associate_alb_with_waf_web_acl_enabled": false,
       "pdf_container_version": "latest",
-      "deploy_opentelemetry_sidecar":false,
+      "deploy_opentelemetry_sidecar": false,
+      "fargate_spot": true,
       "application_flags": {
         "use_legacy_codes_service": false,
         "use_older_lpa_journey": true,
@@ -114,7 +115,8 @@
       "notify_key_secret_name": "notify-api-key-demo",
       "associate_alb_with_waf_web_acl_enabled": true,
       "pdf_container_version": "latest",
-      "deploy_opentelemetry_sidecar":false,
+      "deploy_opentelemetry_sidecar": false,
+      "fargate_spot": false,
       "application_flags": {
         "use_legacy_codes_service": false,
         "use_older_lpa_journey": true,
@@ -185,7 +187,8 @@
       "notify_key_secret_name": "notify-api-key",
       "associate_alb_with_waf_web_acl_enabled": true,
       "pdf_container_version": "latest",
-      "deploy_opentelemetry_sidecar":false,
+      "deploy_opentelemetry_sidecar": false,
+      "fargate_spot": false,
       "application_flags": {
         "use_legacy_codes_service": false,
         "use_older_lpa_journey": true,
@@ -256,7 +259,8 @@
       "notify_key_secret_name": "notify-api-key",
       "associate_alb_with_waf_web_acl_enabled": true,
       "pdf_container_version": "latest",
-      "deploy_opentelemetry_sidecar":false,
+      "deploy_opentelemetry_sidecar": false,
+      "fargate_spot": false,
       "application_flags": {
         "use_legacy_codes_service": false,
         "use_older_lpa_journey": true,

--- a/terraform/environment/viewer_ecs.tf
+++ b/terraform/environment/viewer_ecs.tf
@@ -28,7 +28,7 @@ resource "aws_ecs_service" "viewer" {
   wait_for_steady_state = true
 
   lifecycle {
-    create_before_destroy = false
+    create_before_destroy = true
   }
 
   depends_on = [aws_lb.viewer]

--- a/terraform/environment/viewer_ecs.tf
+++ b/terraform/environment/viewer_ecs.tf
@@ -25,11 +25,10 @@ resource "aws_ecs_service" "viewer" {
     weight            = 100
   }
 
-
   wait_for_steady_state = true
 
   lifecycle {
-    create_before_destroy = true
+    create_before_destroy = false
   }
 
   depends_on = [aws_lb.viewer]

--- a/terraform/environment/viewer_ecs.tf
+++ b/terraform/environment/viewer_ecs.tf
@@ -6,7 +6,6 @@ resource "aws_ecs_service" "viewer" {
   cluster          = aws_ecs_cluster.use-an-lpa.id
   task_definition  = aws_ecs_task_definition.viewer.arn
   desired_count    = local.environment.autoscaling.view.minimum
-  launch_type      = "FARGATE"
   platform_version = "1.4.0"
 
   network_configuration {
@@ -20,6 +19,12 @@ resource "aws_ecs_service" "viewer" {
     container_name   = "web"
     container_port   = 80
   }
+
+  capacity_provider_strategy {
+    capacity_provider = local.capacity_provider
+    weight            = 100
+  }
+
 
   wait_for_steady_state = true
 


### PR DESCRIPTION
# Purpose

Reduce cost of development by running PR environment ECS services on Fargate Spot capacity providers

Fixes UML-1512

## Approach

### Note: This PR requires downtime

**Release instructions**
The create_before_destroy lifecycle will be temporarily set to false so that the replacement can take place, the apply run from local, then the path to live will deploy update task definitions

- Create a new variable to determine whether fargate spot should be used
- Configure capacity providers for all ecs services
- Use fargate spot on PR environments only

## Learning

- https://aws.amazon.com/blogs/aws/aws-fargate-spot-now-generally-available/
- https://docs.aws.amazon.com/AmazonECS/latest/userguide/fargate-capacity-providers.html

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* ~The product team have tested these changes~
