### PR TITLE
UML-2371 - add cookie_flag setup for gtag

### DIFF
--- a/service-front/web/src/javascript/googleAnalytics.js
+++ b/service-front/web/src/javascript/googleAnalytics.js
@@ -14,6 +14,9 @@ export default class GoogleAnalytics {
             window.dataLayer.push(arguments);
         }
         window.gtag('js', new Date());
+        window.gtag('set', {
+          'cookie_flags': 'SameSite=None;Secure'
+        });
         window.gtag('config', this.analyticsId, {
             'linker': {
                 'domains': ['www.gov.uk']


### PR DESCRIPTION
# Purpose

Cookie “session” will be soon rejected because it has the “SameSite” attribute 
set to “None” or an invalid value, without the “secure” attribute.

Fixes UML-2371

## Approach

- Add gtag setup for cookie flag

## Learning

- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
- https://developers.google.com/analytics/devguides/collection/gtagjs/cookies-user-id?hl=en#cookie_flags

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
