### PR TITLE
UML-2378 prism mock rejecting requestCode

### DIFF
--- a/service-api/app/src/App/src/DataAccess/ApiGateway/Lpas.php
+++ b/service-api/app/src/App/src/DataAccess/ApiGateway/Lpas.php
@@ -197,7 +197,6 @@ class Lpas implements LpasInterface
     private function buildHeaders(): array
     {
         $headerLines = [
-            'Accept'        => 'application/json',
             'Content-Type'  => 'application/json',
         ];
 


### PR DESCRIPTION
# Purpose

Prism mock is rejecting request code because the Accept header is stating applicationJson however we are being responded to with an empty response. Prism then gives the service a 406 error

Fixes UML-2378

## Approach

Drop the accept header for the "requestCode" request

## Checklist

* [x] I have performed a self-review of my own code
* [ ] The product team have tested these changes
