### PR TITLE
Turns out in the UK level1 is the more appropriate type for address-town

### DIFF
--- a/service-front/app/src/Actor/templates/actor/request-activation-key/actor-address.html.twig
+++ b/service-front/app/src/Actor/templates/actor/request-activation-key/actor-address.html.twig
@@ -36,7 +36,7 @@
 
                     {{ govuk_form_element(form.get('actor_address_town'), {
                         'label': 'Town or city' | trans,
-                        'autocomplete': 'address-level2'
+                        'autocomplete': 'address-level1'
                     }) }}
 
                     <div class="govuk-form-group">


### PR DESCRIPTION
# Purpose

Chose the wrong address level for town/city entry as it's slightly different in the UK vs. the world.

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* ~The product team have tested these changes~
