### PR TITLE
Ensure we use correct GDS markup for input prefixes

### DIFF
--- a/service-front/app/src/Common/templates/partials/govuk_form.html.twig
+++ b/service-front/app/src/Common/templates/partials/govuk_form.html.twig
@@ -25,18 +25,19 @@
 
         {% endif %}
 
-        {% if input_prefix is defined %}
-
-            <span class="govuk-body-l govuk-!-font-weight-bold">
-                {{ input_prefix }}
-            </span>
-
-        {% endif %}
-
         {%- if attr is defined and attr['class'] is defined and 'moj-password-reveal' in attr['class'] -%}
             {{- block('input_show_hide_password') -}}
         {% else %}
+            {% if input_prefix is defined %}
+                <div class="govuk-input__wrapper">
+                    <div class="govuk-input__prefix" aria-hidden="true">{{ input_prefix }}</div>
+            {% endif %}
+
             {{- block('form_input') -}}
+
+            {% if input_prefix is defined %}
+                </div>
+            {% endif %}
         {% endif %}
 
     </div>


### PR DESCRIPTION
# Purpose

Switch to GDS markup for input field prefixes. 

Fixes UML-2289

## Approach

Change made to our GDS component template and will affect all fields that use a prefix. This is currently only the activation key entry and viewer code entry fields on the actor and viewer side respectively.

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* [x] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* [x] The product team have tested these changes
