### PR TITLE
ddos alarm names were not unique and were overwritting each other

### DIFF
--- a/terraform/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/cloudwatch_alarms.tf
@@ -60,7 +60,7 @@ resource "aws_cloudwatch_metric_alarm" "unexpected_data_lpa_api_resposnes" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "actor_ddos_attack_external" {
-  alarm_name          = "ActorDDoSDetected"
+  alarm_name          = "${local.environment_name}_ActorDDoSDetected"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "3"
   metric_name         = "DDoSDetected"
@@ -77,7 +77,7 @@ resource "aws_cloudwatch_metric_alarm" "actor_ddos_attack_external" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "viewer_ddos_attack_external" {
-  alarm_name          = "ViewerDDoSDetected"
+  alarm_name          = "${local.environment_name}_ViewerDDoSDetected"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "3"
   metric_name         = "DDoSDetected"
@@ -95,7 +95,7 @@ resource "aws_cloudwatch_metric_alarm" "viewer_ddos_attack_external" {
 
 resource "aws_cloudwatch_metric_alarm" "admin_ddos_attack_external" {
   count               = local.environment.build_admin ? 1 : 0
-  alarm_name          = "AdminDDoSDetected"
+  alarm_name          = "${local.environment_name}_AdminDDoSDetected"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "3"
   metric_name         = "DDoSDetected"


### PR DESCRIPTION
# Purpose

Cloudwatch alarms for DDOS attacks were not unique per environment

Fixes UML-2512

## Approach

- add environment namesapce to each alarm

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* ~The product team have tested these changes~
