### PR TITLE
UML-2575 - remove planned path from maintenance redirect

### DIFF
--- a/terraform/environment/actor_load_balancer.tf
+++ b/terraform/environment/actor_load_balancer.tf
@@ -135,7 +135,7 @@ resource "aws_lb_listener_rule" "actor_maintenance" {
 
     redirect {
       host        = "maintenance.opg.service.justice.gov.uk"
-      path        = "/en-gb/use-a-lasting-power-of-attorney/planned"
+      path        = "/en-gb/use-a-lasting-power-of-attorney"
       port        = "443"
       protocol    = "HTTPS"
       status_code = "HTTP_302"
@@ -163,7 +163,7 @@ resource "aws_lb_listener_rule" "actor_maintenance_welsh" {
 
     redirect {
       host        = "maintenance.opg.service.justice.gov.uk"
-      path        = "/cy/defnyddio-atwrneiaeth-arhosol/planned"
+      path        = "/cy/defnyddio-atwrneiaeth-arhosol"
       port        = "443"
       protocol    = "HTTPS"
       status_code = "HTTP_302"

--- a/terraform/environment/viewer_load_balancer.tf
+++ b/terraform/environment/viewer_load_balancer.tf
@@ -134,7 +134,7 @@ resource "aws_lb_listener_rule" "viewer_maintenance" {
 
     redirect {
       host        = "maintenance.opg.service.justice.gov.uk"
-      path        = "/en-gb/view-a-lasting-power-of-attorney/planned"
+      path        = "/en-gb/view-a-lasting-power-of-attorney"
       port        = "443"
       protocol    = "HTTPS"
       status_code = "HTTP_302"
@@ -163,7 +163,7 @@ resource "aws_lb_listener_rule" "viewer_maintenance_welsh" {
 
     redirect {
       host        = "maintenance.opg.service.justice.gov.uk"
-      path        = "/cy/gweld-atwrneiaeth-arhosol/planned"
+      path        = "/cy/gweld-atwrneiaeth-arhosol"
       port        = "443"
       protocol    = "HTTPS"
       status_code = "HTTP_302"


### PR DESCRIPTION
# Purpose

Point at regular maintnenance pages

Fixes UML-2575

## Approach

- remove /planned from redirect paths

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule#path

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* ~The product team have tested these changes~
