### PR TITLE
Add coverage to dynamodb.go

### DIFF
--- a/service-admin/cmd/admin/main.go
+++ b/service-admin/cmd/admin/main.go
@@ -72,7 +72,7 @@ func main() {
 
 	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
 
-	app := server.NewAdminApp(dynamoDB, mux.NewRouter(), handlers.NewTemplateWriterService())
+	app := server.NewAdminApp(*dynamoDB, mux.NewRouter(), handlers.NewTemplateWriterService())
 
 	srv := &http.Server{
 		Handler:      app.InitialiseServer(*keyURL, u),

--- a/service-admin/internal/server/data/account.go
+++ b/service-admin/internal/server/data/account.go
@@ -43,7 +43,7 @@ func NewAccountService(db DynamoDBClient) *accountService {
 
 func (a *accountService) GetActorUserByEmail(ctx context.Context, email string) (aa *ActorUser, err error) {
 	result, err := a.db.Query(ctx, &dynamodb.QueryInput{
-		TableName:              aws.String(prefixedTableName(ActorTableName)),
+		TableName:              aws.String(PrefixedTableName(ActorTableName)),
 		IndexName:              aws.String(ActorTableEmailIndexName),
 		KeyConditionExpression: aws.String("Email = :e"),
 		ExpressionAttributeValues: map[string]types.AttributeValue{
@@ -71,7 +71,7 @@ func (a *accountService) GetActorUserByEmail(ctx context.Context, email string) 
 
 func (a *accountService) GetEmailByUserID(ctx context.Context, userID string) (email string, err error) {
 	result, err := a.db.GetItem(ctx, &dynamodb.GetItemInput{
-		TableName: aws.String(prefixedTableName(ActorTableName)),
+		TableName: aws.String(PrefixedTableName(ActorTableName)),
 		Key: map[string]types.AttributeValue{
 			"Id": &types.AttributeValueMemberS{Value: userID},
 		},

--- a/service-admin/internal/server/data/account.go
+++ b/service-admin/internal/server/data/account.go
@@ -38,7 +38,7 @@ func NewAccountService(db DynamoConnection) *accountService {
 
 func (a *accountService) GetActorUserByEmail(ctx context.Context, email string) (aa *ActorUser, err error) {
 	result, err := a.db.Client.Query(ctx, &dynamodb.QueryInput{
-		TableName:              aws.String(a.db.PrefixedTableName(ActorTableName)),
+		TableName:              aws.String(a.db.prefixedTableName(ActorTableName)),
 		IndexName:              aws.String(ActorTableEmailIndexName),
 		KeyConditionExpression: aws.String("Email = :e"),
 		ExpressionAttributeValues: map[string]types.AttributeValue{
@@ -66,7 +66,7 @@ func (a *accountService) GetActorUserByEmail(ctx context.Context, email string) 
 
 func (a *accountService) GetEmailByUserID(ctx context.Context, userID string) (email string, err error) {
 	result, err := a.db.Client.GetItem(ctx, &dynamodb.GetItemInput{
-		TableName: aws.String(a.db.PrefixedTableName(ActorTableName)),
+		TableName: aws.String(a.db.prefixedTableName(ActorTableName)),
 		Key: map[string]types.AttributeValue{
 			"Id": &types.AttributeValueMemberS{Value: userID},
 		},

--- a/service-admin/internal/server/data/dynamo.go
+++ b/service-admin/internal/server/data/dynamo.go
@@ -8,9 +8,18 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-var prefix string
+type DynamoDBClient interface {
+	Query(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
+	GetItem(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error)
+}
 
-func NewDynamoConnection(region string, endpoint string, tablePrefix string) *dynamodb.Client {
+type DynamoConnection struct {
+	Prefix string
+	Client DynamoDBClient
+}
+
+func NewDynamoConnection(region string, endpoint string, tablePrefix string) *DynamoConnection {
+	prefix := ""
 	if tablePrefix != "" {
 		prefix = tablePrefix + "-"
 	}
@@ -32,9 +41,9 @@ func NewDynamoConnection(region string, endpoint string, tablePrefix string) *dy
 		}
 	})
 
-	return svc
+	return &DynamoConnection{Prefix: prefix, Client: svc}
 }
 
-func PrefixedTableName(name string) string {
-	return prefix + name
+func (dc *DynamoConnection) PrefixedTableName(name string) string {
+	return dc.Prefix + name
 }

--- a/service-admin/internal/server/data/dynamo.go
+++ b/service-admin/internal/server/data/dynamo.go
@@ -44,6 +44,6 @@ func NewDynamoConnection(region string, endpoint string, tablePrefix string) *Dy
 	return &DynamoConnection{Prefix: prefix, Client: svc}
 }
 
-func (dc *DynamoConnection) PrefixedTableName(name string) string {
+func (dc *DynamoConnection) prefixedTableName(name string) string {
 	return dc.Prefix + name
 }

--- a/service-admin/internal/server/data/dynamo.go
+++ b/service-admin/internal/server/data/dynamo.go
@@ -35,6 +35,6 @@ func NewDynamoConnection(region string, endpoint string, tablePrefix string) *dy
 	return svc
 }
 
-func prefixedTableName(name string) string {
+func PrefixedTableName(name string) string {
 	return prefix + name
 }

--- a/service-admin/internal/server/data/dynamo_test.go
+++ b/service-admin/internal/server/data/dynamo_test.go
@@ -1,0 +1,77 @@
+package data_test
+
+import (
+	"github.com/ministryofjustice/opg-use-an-lpa/service-admin/internal/server/data"
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"testing"
+)
+
+func TestNewDynamoConnection(t *testing.T) {
+	type args struct {
+		region      string
+		endpoint    string
+		tablePrefix string
+	}
+
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "test dynamo db given",
+			args: args{
+				region:      "",
+				endpoint:    "ENDPOINT",
+				tablePrefix: "someprefix",
+			},
+		},
+		{
+			name: "test dynamo db given with region",
+			args: args{
+				region:      "some region",
+				endpoint:    "ENDPOINT",
+				tablePrefix: "someprefix",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := data.NewDynamoConnection(tt.args.region, tt.args.endpoint, tt.args.tablePrefix)
+			if got == nil {
+				t.Errorf("Error nil dynamodb recieved")
+			}
+			v := reflect.ValueOf(*got)
+			gotOptions := v.FieldByName("options")
+			if gotOptions.FieldByName("Region").String() != tt.args.region {
+				t.Errorf("expected options %v got %v", gotOptions.FieldByName("Region").String(), tt.args.region)
+			}
+
+		})
+	}
+}
+
+func TestPrefixedTableName(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name   string
+		args   args
+		prefix string
+		want   string
+	}{
+		{
+			name:   "test prefix added",
+			args:   args{name: "table-name"},
+			prefix: "prefixed",
+			want:   "prefixed-table-name",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data.NewDynamoConnection("", "", tt.prefix)
+			assert.Equalf(t, tt.want, data.PrefixedTableName(tt.args.name), "PrefixedTableName(%v)", tt.args.name)
+		})
+	}
+}

--- a/service-admin/internal/server/data/dynamo_test.go
+++ b/service-admin/internal/server/data/dynamo_test.go
@@ -3,7 +3,6 @@ package data_test
 import (
 	"github.com/ministryofjustice/opg-use-an-lpa/service-admin/internal/server/data"
 	"github.com/stretchr/testify/assert"
-	"reflect"
 	"testing"
 )
 
@@ -42,10 +41,8 @@ func TestNewDynamoConnection(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := data.NewDynamoConnection(tt.args.region, tt.args.endpoint, tt.args.tablePrefix)
-			v := reflect.ValueOf(*got)
-			gotOptions := v.FieldByName("options")
-			if gotOptions.FieldByName("Region").String() != tt.args.region {
-				t.Errorf("expected options %v got %v", gotOptions.FieldByName("Region").String(), tt.args.region)
+			if got.Prefix != tt.args.tablePrefix+"-" {
+				t.Errorf("expected prefix %v got %v", got.Prefix, tt.args.tablePrefix)
 			}
 
 		})
@@ -58,7 +55,7 @@ func TestPrefixedTableName(t *testing.T) {
 	type args struct {
 		name string
 	}
-	
+
 	tests := []struct {
 		name   string
 		args   args
@@ -76,8 +73,8 @@ func TestPrefixedTableName(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			data.NewDynamoConnection("", "", tt.prefix)
-			assert.Equalf(t, tt.want, data.PrefixedTableName(tt.args.name), "PrefixedTableName(%v)", tt.args.name)
+			dynamodbConnection := data.NewDynamoConnection("", "", tt.prefix)
+			assert.Equalf(t, tt.want, dynamodbConnection.PrefixedTableName(tt.args.name), "PrefixedTableName(%v)", tt.args.name)
 		})
 	}
 }

--- a/service-admin/internal/server/data/dynamo_test.go
+++ b/service-admin/internal/server/data/dynamo_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestNewDynamoConnection(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		region      string
 		endpoint    string
@@ -36,11 +38,10 @@ func TestNewDynamoConnection(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := data.NewDynamoConnection(tt.args.region, tt.args.endpoint, tt.args.tablePrefix)
-			if got == nil {
-				t.Errorf("Error nil dynamodb recieved")
-			}
 			v := reflect.ValueOf(*got)
 			gotOptions := v.FieldByName("options")
 			if gotOptions.FieldByName("Region").String() != tt.args.region {
@@ -52,9 +53,12 @@ func TestNewDynamoConnection(t *testing.T) {
 }
 
 func TestPrefixedTableName(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		name string
 	}
+	
 	tests := []struct {
 		name   string
 		args   args
@@ -69,7 +73,9 @@ func TestPrefixedTableName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			data.NewDynamoConnection("", "", tt.prefix)
 			assert.Equalf(t, tt.want, data.PrefixedTableName(tt.args.name), "PrefixedTableName(%v)", tt.args.name)
 		})

--- a/service-admin/internal/server/data/dynamo_test.go
+++ b/service-admin/internal/server/data/dynamo_test.go
@@ -2,7 +2,6 @@ package data_test
 
 import (
 	"github.com/ministryofjustice/opg-use-an-lpa/service-admin/internal/server/data"
-	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -45,36 +44,6 @@ func TestNewDynamoConnection(t *testing.T) {
 				t.Errorf("expected prefix %v got %v", got.Prefix, tt.args.tablePrefix)
 			}
 
-		})
-	}
-}
-
-func TestPrefixedTableName(t *testing.T) {
-	t.Parallel()
-
-	type args struct {
-		name string
-	}
-
-	tests := []struct {
-		name   string
-		args   args
-		prefix string
-		want   string
-	}{
-		{
-			name:   "test prefix added",
-			args:   args{name: "table-name"},
-			prefix: "prefixed",
-			want:   "prefixed-table-name",
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			dynamodbConnection := data.NewDynamoConnection("", "", tt.prefix)
-			assert.Equalf(t, tt.want, dynamodbConnection.PrefixedTableName(tt.args.name), "PrefixedTableName(%v)", tt.args.name)
 		})
 	}
 }

--- a/service-admin/internal/server/data/lpa.go
+++ b/service-admin/internal/server/data/lpa.go
@@ -36,7 +36,7 @@ func NewLPAService(db DynamoConnection) *lpaService {
 
 func (l *lpaService) GetLpasByUserID(ctx context.Context, uid string) (lpas []*LPA, err error) {
 	result, err := l.db.Client.Query(ctx, &dynamodb.QueryInput{
-		TableName:              aws.String(l.db.PrefixedTableName(UserLpaActorTableName)),
+		TableName:              aws.String(l.db.prefixedTableName(UserLpaActorTableName)),
 		IndexName:              aws.String(UserLpaActorUserIndexName),
 		KeyConditionExpression: aws.String("UserId = :u"),
 		ExpressionAttributeValues: map[string]types.AttributeValue{
@@ -61,7 +61,7 @@ func (l *lpaService) GetLpasByUserID(ctx context.Context, uid string) (lpas []*L
 
 func (l *lpaService) GetLPAByActivationCode(ctx context.Context, activationCode string) (lpa *LPA, err error) {
 	result, err := l.db.Client.Query(ctx, &dynamodb.QueryInput{
-		TableName:              aws.String(l.db.PrefixedTableName(UserLpaActorTableName)),
+		TableName:              aws.String(l.db.prefixedTableName(UserLpaActorTableName)),
 		IndexName:              aws.String(ActivationCodeIndexName),
 		KeyConditionExpression: aws.String("ActivationCode = :a"),
 		ExpressionAttributeValues: map[string]types.AttributeValue{

--- a/service-admin/internal/server/data/lpa.go
+++ b/service-admin/internal/server/data/lpa.go
@@ -12,7 +12,7 @@ import (
 )
 
 type lpaService struct {
-	db *dynamodb.Client
+	db DynamoConnection
 }
 
 type LPA struct {
@@ -30,13 +30,13 @@ const (
 
 var ErrUserLpaActorMapNotFound = errors.New("userlpaactormap not found")
 
-func NewLPAService(db *dynamodb.Client) *lpaService {
+func NewLPAService(db DynamoConnection) *lpaService {
 	return &lpaService{db: db}
 }
 
 func (l *lpaService) GetLpasByUserID(ctx context.Context, uid string) (lpas []*LPA, err error) {
-	result, err := l.db.Query(ctx, &dynamodb.QueryInput{
-		TableName:              aws.String(PrefixedTableName(UserLpaActorTableName)),
+	result, err := l.db.Client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String(l.db.PrefixedTableName(UserLpaActorTableName)),
 		IndexName:              aws.String(UserLpaActorUserIndexName),
 		KeyConditionExpression: aws.String("UserId = :u"),
 		ExpressionAttributeValues: map[string]types.AttributeValue{
@@ -60,8 +60,8 @@ func (l *lpaService) GetLpasByUserID(ctx context.Context, uid string) (lpas []*L
 }
 
 func (l *lpaService) GetLPAByActivationCode(ctx context.Context, activationCode string) (lpa *LPA, err error) {
-	result, err := l.db.Query(ctx, &dynamodb.QueryInput{
-		TableName:              aws.String(PrefixedTableName(UserLpaActorTableName)),
+	result, err := l.db.Client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String(l.db.PrefixedTableName(UserLpaActorTableName)),
 		IndexName:              aws.String(ActivationCodeIndexName),
 		KeyConditionExpression: aws.String("ActivationCode = :a"),
 		ExpressionAttributeValues: map[string]types.AttributeValue{

--- a/service-admin/internal/server/data/lpa.go
+++ b/service-admin/internal/server/data/lpa.go
@@ -36,7 +36,7 @@ func NewLPAService(db *dynamodb.Client) *lpaService {
 
 func (l *lpaService) GetLpasByUserID(ctx context.Context, uid string) (lpas []*LPA, err error) {
 	result, err := l.db.Query(ctx, &dynamodb.QueryInput{
-		TableName:              aws.String(prefixedTableName(UserLpaActorTableName)),
+		TableName:              aws.String(PrefixedTableName(UserLpaActorTableName)),
 		IndexName:              aws.String(UserLpaActorUserIndexName),
 		KeyConditionExpression: aws.String("UserId = :u"),
 		ExpressionAttributeValues: map[string]types.AttributeValue{
@@ -61,7 +61,7 @@ func (l *lpaService) GetLpasByUserID(ctx context.Context, uid string) (lpas []*L
 
 func (l *lpaService) GetLPAByActivationCode(ctx context.Context, activationCode string) (lpa *LPA, err error) {
 	result, err := l.db.Query(ctx, &dynamodb.QueryInput{
-		TableName:              aws.String(prefixedTableName(UserLpaActorTableName)),
+		TableName:              aws.String(PrefixedTableName(UserLpaActorTableName)),
 		IndexName:              aws.String(ActivationCodeIndexName),
 		KeyConditionExpression: aws.String("ActivationCode = :a"),
 		ExpressionAttributeValues: map[string]types.AttributeValue{

--- a/service-admin/internal/server/server.go
+++ b/service-admin/internal/server/server.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/gorilla/mux"
 	"github.com/ministryofjustice/opg-use-an-lpa/service-admin/internal/server/auth"
 	"github.com/ministryofjustice/opg-use-an-lpa/service-admin/internal/server/data"
@@ -24,7 +23,7 @@ type errorInterceptResponseWriter struct {
 }
 
 type app struct {
-	db *dynamodb.Client
+	db data.DynamoConnection
 	r  *mux.Router
 	tw handlers.TemplateWriterService
 }
@@ -48,7 +47,7 @@ func (w *errorInterceptResponseWriter) Write(p []byte) (int, error) {
 	return w.ResponseWriter.Write(p)
 }
 
-func NewAdminApp(db *dynamodb.Client, r *mux.Router, tw handlers.TemplateWriterService) *app {
+func NewAdminApp(db data.DynamoConnection, r *mux.Router, tw handlers.TemplateWriterService) *app {
 	return &app{db, r, tw}
 }
 


### PR DESCRIPTION
# Purpose

add coverage 

Fixes UML-2269

## Approach

prefix is now added to the DynamoConnection struct. This way it is not global and can be accessed in parallel by multiple tests. 

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added tests to prove my work
