### PR TITLE
UML-2594 - Install stable release of xdebug in development docker layer

### DIFF
--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -45,7 +45,7 @@ COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr
 COPY --from=composer /usr/bin/composer /usr/bin/
 
 RUN set -xe \
-  && install-php-extensions xdebug \
+  && install-php-extensions xdebug-stable \
   && rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 # Development images are only ever run using compose so will have this mounted in as a volume


### PR DESCRIPTION
# Purpose

Path to live is broken due to alpha release of xdebug not installing successfully. We do not want alpha releases of php extensions unless for a specific reason.

Fixes UML-2594

## Approach

- specify `stable` for version constraint

## Learning

- https://github.com/mlocati/docker-php-extension-installer#installing-specific-versions-of-an-extension

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* ~The product team have tested these changes~
