### PR TITLE
UML-2555 - Add permission for /code endpoint to admin app

### DIFF
--- a/terraform/environment/admin_ecs.tf
+++ b/terraform/environment/admin_ecs.tf
@@ -163,6 +163,7 @@ data "aws_iam_policy_document" "admin_permissions_role" {
     resources = [
       "arn:aws:execute-api:eu-west-1:${local.environment.sirius_account_id}:*/*/GET/healthcheck",
       "arn:aws:execute-api:eu-west-1:${local.environment.sirius_account_id}:*/*/POST/exists",
+      "arn:aws:execute-api:eu-west-1:${local.environment.sirius_account_id}:*/*/POST/code",
     ]
   }
 }


### PR DESCRIPTION
# Purpose

Allow the admin app to make requests to /code

Fixes UML-2555

## Approach

- add resource to lpacodesaccess statement

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event~+logs)
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~I have added tests to prove my work~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* ~The product team have tested these changes~
