### PR TITLE
Uml 2540 dependabot to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,8 @@ updates:
     directory: "/service-front/web"
     schedule:
       # Check for updates on the first of each month at 10am UTC
-      interval: "monthly"
-      time: "10:00"
+      interval: "daily"
+      time: "09:00"
       timezone: "Europe/London"
     versioning-strategy: lockfile-only
 
@@ -16,8 +16,8 @@ updates:
     directory: "/service-pdf/app"
     schedule:
       # Check for updates on the first of each month at 10am UTC
-      interval: "monthly"
-      time: "10:00"
+      interval: "daily"
+      time: "09:00"
       timezone: "Europe/London"
     versioning-strategy: lockfile-only
 
@@ -26,8 +26,8 @@ updates:
     directory: "/service-front/app"
     schedule:
       # Check for updates on the first of each month at 10am UTC
-      interval: "monthly"
-      time: "10:00"
+      interval: "daily"
+      time: "09:00"
       timezone: "Europe/London"
     versioning-strategy: lockfile-only
 
@@ -36,8 +36,8 @@ updates:
     directory: "/service-api/app"
     schedule:
       # Check for updates on the first of each month at 10am UTC
-      interval: "monthly"
-      time: "10:00"
+      interval: "daily"
+      time: "09:00"
       timezone: "Europe/London"
     versioning-strategy: lockfile-only
 
@@ -46,8 +46,8 @@ updates:
     directory: "/tests/smoke"
     schedule:
       # Check for updates on the first of each month at 10am UTC
-      interval: "monthly"
-      time: "10:00"
+      interval: "daily"
+      time: "09:00"
       timezone: "Europe/London"
     versioning-strategy: lockfile-only
 
@@ -56,8 +56,8 @@ updates:
     directory: "/terraform/account"
     schedule:
       # Check for updates on the first of each month at 10am UTC
-      interval: "monthly"
-      time: "10:00"
+      interval: "daily"
+      time: "09:00"
       timezone: "Europe/London"
 
     # Enable version updates for environment terraform
@@ -65,22 +65,22 @@ updates:
     directory: "/terraform/environment"
     schedule:
       # Check for updates on the first of each month at 10am UTC
-      interval: "monthly"
-      time: "10:00"
+      interval: "daily"
+      time: "09:00"
       timezone: "Europe/London"
 
     # Enable version updates for service-admin gomod
   - package-ecosystem: "gomod"
     directory: "/service-admin"
     schedule:
-      interval: "monthly"
-      time: "10:00"
+      interval: "daily"
+      time: "09:00"
       timezone: "Europe/London"
 
     # Enable version updates for service-admin docker
   - package-ecosystem: "docker"
     directory: "/service-admin"
     schedule:
-      interval: "monthly"
-      time: "10:00"
+      interval: "daily"
+      time: "09:00"
       timezone: "Europe/London"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
   - package-ecosystem: "npm"
     directory: "/service-front/web"
     schedule:
-      # Check for updates on the first of each month at 10am UTC
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
@@ -15,7 +14,6 @@ updates:
   - package-ecosystem: "npm"
     directory: "/service-pdf/app"
     schedule:
-      # Check for updates on the first of each month at 10am UTC
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
@@ -25,7 +23,6 @@ updates:
   - package-ecosystem: "composer"
     directory: "/service-front/app"
     schedule:
-      # Check for updates on the first of each month at 10am UTC
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
@@ -35,7 +32,6 @@ updates:
   - package-ecosystem: "composer"
     directory: "/service-api/app"
     schedule:
-      # Check for updates on the first of each month at 10am UTC
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
@@ -45,7 +41,6 @@ updates:
   - package-ecosystem: "composer"
     directory: "/tests/smoke"
     schedule:
-      # Check for updates on the first of each month at 10am UTC
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
@@ -55,7 +50,6 @@ updates:
   - package-ecosystem: "terraform"
     directory: "/terraform/account"
     schedule:
-      # Check for updates on the first of each month at 10am UTC
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
@@ -64,7 +58,6 @@ updates:
   - package-ecosystem: "terraform"
     directory: "/terraform/environment"
     schedule:
-      # Check for updates on the first of each month at 10am UTC
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"


### PR DESCRIPTION
# Purpose

Currently we get swamped by dependabot updates every month, this PR will change the dependencies to be reported daily to potentially make them more manageable

Fixes UML-2540

## Checklist

* [x] I have performed a self-review of my own code