### PR TITLE
UML-2584 fix some metrics that weren't appearing

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,11 +169,11 @@ run the following command:
 ```
 then try again
 
-### I cannot add  LPA's locally, which are in the seeded data set.
+### I cannot add LPA's locally, which are in the seeded data set.
 
 This could be because the LPA Gateway (Sirius Gateway) has not been properly initialised.
-make sure all docker compose services are running andhave settled first, then try again.
-If still not working,run the following command:
+make sure all docker compose services are running and have settled first, then try again.
+If still not working, run the following command:
 ```shell
 <DOCKER_COMPOSE> run lpa-gateway-setup
 ```

--- a/terraform/environment/cloudwatch_metrics.tf
+++ b/terraform/environment/cloudwatch_metrics.tf
@@ -1,55 +1,56 @@
 locals {
   event_codes = [
-    "ACCOUNT_ACTIVATED",
-    "ACCOUNT_CREATED",
-    "ACCOUNT_DELETED",
-    "DOWNLOAD_SUMMARY",
-    "OLDER_LPA_DOES_NOT_MATCH",
-    "OLDER_LPA_HAS_ACTIVATION_KEY",
-    "OLDER_LPA_INVALID_STATUS",
-    "OLDER_LPA_NOT_ELIGIBLE",
-    "OLDER_LPA_NOT_FOUND",
-    "OLDER_LPA_SUCCESS",
-    "OLDER_LPA_CLEANSE_SUCCESS",
-    "OLDER_LPA_TOO_OLD",
-    "OLDER_LPA_ALREADY_ADDED",
-    "OLDER_LPA_FORCE_ACTIVATION_KEY",
-    "OLDER_LPA_PARTIAL_MATCH_HAS_BEEN_CLEANSED",
-    "OLDER_LPA_PARTIAL_MATCH_TOO_RECENT",
-    "SHARE_CODE_NOT_FOUND",
-    "VIEW_LPA_SHARE_CODE_NOT_FOUND",
-    "VIEW_LPA_SHARE_CODE_SUCCESS",
-    "VIEW_LPA_SHARE_CODE_EXPIRED",
-    "VIEW_LPA_SHARE_CODE_CANCELLED",
-    "ADD_LPA_FOUND",
-    "ADD_LPA_NOT_FOUND",
-    "ADD_LPA_NOT_ELIGIBLE",
-    "ADD_LPA_ALREADY_ADDED",
-    "ADD_LPA_SUCCESS",
-    "ADD_LPA_FAILURE",
-    "LPA_REMOVED",
-    "OLDER_LPA_FOUND",
-    "OOLPA_KEY_REQUESTED_FOR_DONOR",
-    "OOLPA_KEY_REQUESTED_FOR_ATTORNEY",
-    "OOLPA_PHONE_NUMBER_PROVIDED",
-    "OOLPA_PHONE_NUMBER_NOT_PROVIDED",
-    "OLDER_LPA_KEY_ALREADY_REQUESTED",
-    "OLDER_LPA_NEEDS_CLEANSING",
-    "UNEXPECTED_DATA_LPA_API_RESPONSE",
-    "ACTIVATION_KEY_EXISTS",
-    "ACTIVATION_KEY_NOT_EXISTS",
-    "ACTIVATION_KEY_EXPIRED"
+    "event_code.ACCOUNT_ACTIVATED",
+    "event_code.ACCOUNT_CREATED",
+    "event_code.ACCOUNT_DELETED",
+    "event_code.DOWNLOAD_SUMMARY",
+    "event_code.OLDER_LPA_DOES_NOT_MATCH",
+    "event_code.OLDER_LPA_HAS_ACTIVATION_KEY",
+    "event_code.OLDER_LPA_INVALID_STATUS",
+    "event_code.OLDER_LPA_NOT_ELIGIBLE",
+    "event_code.OLDER_LPA_NOT_FOUND",
+    "event_code.OLDER_LPA_SUCCESS",
+    "event_code.OLDER_LPA_CLEANSE_SUCCESS",
+    "event_code.OLDER_LPA_TOO_OLD",
+    "event_code.OLDER_LPA_ALREADY_ADDED",
+    "event_code.OLDER_LPA_FORCE_ACTIVATION_KEY",
+    "event_code.OLDER_LPA_PARTIAL_MATCH_HAS_BEEN_CLEANSED",
+    "event_code.OLDER_LPA_PARTIAL_MATCH_TOO_RECENT",
+    "event_code.SHARE_CODE_NOT_FOUND",
+    "event_code.VIEW_LPA_SHARE_CODE_NOT_FOUND",
+    "event_code.VIEW_LPA_SHARE_CODE_SUCCESS",
+    "event_code.VIEW_LPA_SHARE_CODE_EXPIRED",
+    "event_code.VIEW_LPA_SHARE_CODE_CANCELLED",
+    "event_code.ADD_LPA_FOUND",
+    "event_code.ADD_LPA_NOT_FOUND",
+    "event_code.ADD_LPA_NOT_ELIGIBLE",
+    "event_code.ADD_LPA_ALREADY_ADDED",
+    "event_code.ADD_LPA_SUCCESS",
+    "event_code.ADD_LPA_FAILURE",
+    "event_code.LPA_REMOVED",
+    "event_code.OLDER_LPA_FOUND",
+    "role.OOLPA_KEY_REQUESTED_FOR_DONOR",
+    "role.OOLPA_KEY_REQUESTED_FOR_ATTORNEY",
+    "phone.OOLPA_PHONE_NUMBER_PROVIDED",
+    "phone.OOLPA_PHONE_NUMBER_NOT_PROVIDED",
+    "event_code.OLDER_LPA_KEY_ALREADY_REQUESTED",
+    "event_code.OLDER_LPA_NEEDS_CLEANSING",
+    "event_code.UNEXPECTED_DATA_LPA_API_RESPONSE",
+    "key_status.ACTIVATION_KEY_EXISTS",
+    "key_status.ACTIVATION_KEY_NOT_EXISTS",
+    "key_status.ACTIVATION_KEY_EXPIRED",
+    "event_code.IDENTITY_HASH_CHANGE"
   ]
 }
 
 resource "aws_cloudwatch_log_metric_filter" "log_event_code_metrics" {
   for_each       = toset(local.event_codes)
-  name           = "${local.environment_name}_${lower(each.value)}"
-  pattern        = "{ $.context.event_code = \"${each.value}\" }"
+  name           = "${local.environment_name}_${lower(split(".", each.value)[1])}"
+  pattern        = "{ $.context.${split(".", each.value)[0]} = \"${split(".", each.value)[1]}\" }"
   log_group_name = aws_cloudwatch_log_group.application_logs.name
 
   metric_transformation {
-    name          = "${lower(each.value)}_event"
+    name          = "${lower(split(".", each.value)[1])}_event"
     namespace     = "${local.environment_name}_events"
     value         = "1"
     default_value = "0"


### PR DESCRIPTION
# Purpose

Some of the metrics weren't appearing in the logs

Fixes UML-2584

## Approach

I was actually looking at a different ticket but it turns out it was one for devs to look at but as part of that I noticed some of the metrics weren't appearing as the keys weren't always event_code. 

Not sure if it's a bit of an ugly fix.. I decided to keep DRY and split out the keys. I initially tried a map but because the keys will be the same it misses most of the metrics so this was nicest way I could think of doing it even if it does lead to some ugly keys.

## Learning

Wanted to put this query in place but not sure if putting it in code is best place as we only seem to have 2 of them in the code.

```
fields @timestamp, coalesce(context.event_code, context.key_status, context.phone, context.role) as event
| filter @message like /("event_code":|"key_status":|"role":|"phone":)/
| stats count(event) by event
| sort event
```

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
