### PR TITLE
Admin/uml 1409 search by lpa number

### DIFF
--- a/.idea/php-test-framework.xml
+++ b/.idea/php-test-framework.xml
@@ -9,6 +9,7 @@
             <configuration_by_sdk interpreter_id="f727a88f-8a28-4df0-87a2-12a139ed8d31" executable_path="/app/vendor/behat/behat/bin/behat" />
             <configuration_by_sdk interpreter_id="629f1e4d-0e9c-4595-aa54-e8d28c3ac0df" executable_path="/home/circleci/project/vendor/behat/behat/bin/behat" />
             <configuration_by_sdk interpreter_id="a252f9af-85e6-4a7b-b4d0-a73204db31c6" executable_path="/app/vendor/behat/behat/bin/behat" />
+            <local_configuration executable_path="$PROJECT_DIR$/service-front/app/vendor/behat/behat/bin/behat" />
           </configurations>
         </settings>
       </tool>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -170,6 +170,12 @@
       <path value="$PROJECT_DIR$/service-front/app/vendor/gettext/gettext" />
       <path value="$PROJECT_DIR$/service-front/app/vendor/gettext/languages" />
       <path value="$PROJECT_DIR$/service-front/app/vendor/aws/aws-crt-php" />
+      <path value="$PROJECT_DIR$/service-front/app/vendor/blazon/psr11-monolog" />
+      <path value="$PROJECT_DIR$/service-front/app/vendor/sebastian/type" />
+      <path value="$PROJECT_DIR$/service-front/app/vendor/laminas/laminas-cache-storage-adapter-redis" />
+      <path value="$PROJECT_DIR$/service-front/app/vendor/laminas/laminas-cache-storage-adapter-apcu" />
+      <path value="$PROJECT_DIR$/service-front/app/vendor/laminas/laminas-cache-storage-adapter-memory" />
+      <path value="$PROJECT_DIR$/service-front/app/vendor/laravel/serializable-closure" />
     </include_path>
   </component>
   <component name="PhpInterpreters">

--- a/service-admin/internal/server/data/lpa_test.go
+++ b/service-admin/internal/server/data/lpa_test.go
@@ -14,14 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type mockDynamoDBClient struct {
-	QueryFunc func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
-}
-
-func (m *mockDynamoDBClient) Query(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
-	return m.QueryFunc(ctx, params, optFns...)
-}
-
 func TestGetLpasByUserID(t *testing.T) {
 	t.Parallel()
 
@@ -151,10 +143,13 @@ func TestGetLPAByActivationCode(t *testing.T) {
 }
 
 func Test_lpaService_GetLPARecordBySiriusID(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		ctx       context.Context
 		lpaNumber string
 	}
+
 	tests := []struct {
 		name      string
 		args      args
@@ -213,6 +208,7 @@ func Test_lpaService_GetLPARecordBySiriusID(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 
 		dynamodbConnection := DynamoConnection{
 			Client: &mockDynamoDBClent{
@@ -222,6 +218,8 @@ func Test_lpaService_GetLPARecordBySiriusID(t *testing.T) {
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			l := NewLPAService(dynamodbConnection)
 			gotLpas, err := l.GetLpaRecordBySiriusID(tt.args.ctx, tt.args.lpaNumber)
 			if (err != nil) != tt.wantErr {

--- a/service-admin/internal/server/data/lpa_test.go
+++ b/service-admin/internal/server/data/lpa_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -12,6 +13,14 @@ import (
 	. "github.com/ministryofjustice/opg-use-an-lpa/service-admin/internal/server/data"
 	"github.com/stretchr/testify/assert"
 )
+
+type mockDynamoDBClient struct {
+	QueryFunc func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
+}
+
+func (m *mockDynamoDBClient) Query(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	return m.QueryFunc(ctx, params, optFns...)
+}
 
 func TestGetLpasByUserID(t *testing.T) {
 	t.Parallel()
@@ -137,6 +146,91 @@ func TestGetLPAByActivationCode(t *testing.T) {
 				return
 			}
 			assert.EqualValues(t, tt.want, lpas)
+		})
+	}
+}
+
+func Test_lpaService_GetLPARecordBySiriusID(t *testing.T) {
+	type args struct {
+		ctx       context.Context
+		lpaNumber string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		queryFunc func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
+		wantLpas  []*LPA
+		wantErr   bool
+	}{
+		{
+			name: "Get Records by Sirius ID",
+			args: args{
+				ctx:       context.Background(),
+				lpaNumber: "700000000138",
+			},
+			queryFunc: func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+				return &dynamodb.QueryOutput{
+					Count: 1,
+					Items: []map[string]types.AttributeValue{
+						{
+							"SiriusUid": &types.AttributeValueMemberS{Value: "700000000138"},
+							"Added":     &types.AttributeValueMemberS{Value: "2020-08-20T14:37:49.522828Z"},
+							"UserId":    &types.AttributeValueMemberS{Value: "bf9e7e77-f283-49c6-a79c-65d5d309ef77"},
+						},
+						{
+							"SiriusUid": &types.AttributeValueMemberS{Value: "700000000138"},
+							"Added":     &types.AttributeValueMemberS{Value: "2020-08-20T14:37:49.522828Z"},
+							"UserId":    &types.AttributeValueMemberS{Value: "9123b6f9-0cbe-4a2e-a204-d723c80de6dc"},
+						},
+					},
+				}, nil
+			},
+			wantLpas: []*LPA{
+				{
+					SiriusUID: "700000000138",
+					Added:     "2020-08-20T14:37:49.522828Z",
+					UserID:    "bf9e7e77-f283-49c6-a79c-65d5d309ef77",
+				},
+				{
+					SiriusUID: "700000000138",
+					Added:     "2020-08-20T14:37:49.522828Z",
+					UserID:    "9123b6f9-0cbe-4a2e-a204-d723c80de6dc",
+				},
+			},
+		},
+		{
+			name: "Error getting lpa records",
+			args: args{
+				ctx:       context.Background(),
+				lpaNumber: "700000000138",
+			},
+			queryFunc: func(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+				return &dynamodb.QueryOutput{Count: 0}, errors.New("Some Error")
+			},
+			wantLpas: nil,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+
+		dynamodbConnection := DynamoConnection{
+			Client: &mockDynamoDBClent{
+				QueryFunc: tt.queryFunc,
+			},
+			Prefix: "",
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			l := NewLPAService(dynamodbConnection)
+			gotLpas, err := l.GetLpaRecordBySiriusID(tt.args.ctx, tt.args.lpaNumber)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("lpaService.GetUsersByLPAID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotLpas, tt.wantLpas) {
+				t.Errorf("lpaService.GetUsersByLPAID() = %v, want %v", gotLpas, tt.wantLpas)
+			}
 		})
 	}
 }

--- a/service-admin/internal/server/handlers/search.go
+++ b/service-admin/internal/server/handlers/search.go
@@ -175,11 +175,9 @@ func (s *SearchServer) SearchByLPANumber(ctx context.Context, q string) interfac
 		"LPANumber": q,
 		"AddedBy":   emails,
 	}
-
 }
 
 func (s *SearchServer) SearchByEmail(ctx context.Context, q string) interface{} {
-
 	r, err := s.accountService.GetActorUserByEmail(ctx, q)
 	if err != nil {
 		return nil
@@ -194,7 +192,6 @@ func (s *SearchServer) SearchByEmail(ctx context.Context, q string) interface{} 
 }
 
 func (s *SearchServer) SearchByActivationCode(ctx context.Context, q string) interface{} {
-
 	r, err := s.lpaService.GetLPAByActivationCode(ctx, q)
 
 	if err == nil {
@@ -248,7 +245,6 @@ func (s *SearchServer) SearchByActivationCode(ctx context.Context, q string) int
 	}
 
 	return nil
-
 }
 
 func isUsed(active bool, status string) string {

--- a/service-admin/internal/server/handlers/search.go
+++ b/service-admin/internal/server/handlers/search.go
@@ -54,7 +54,7 @@ var (
 	ErrNotEmailOrCode error = errors.New("Enter an email address or activation code")
 
 	activationCodeRegexp *regexp.Regexp = regexp.MustCompile(`(?i)^c(-|)[a-z0-9]{4}(-|)[a-z0-9]{4}(-|)[a-z0-9]{4}$`)
-	lpaNumberRegex       *regexp.Regexp = regexp.MustCompile(`(?i)[0-9]{12}$`)
+	lpaNumberRegex       *regexp.Regexp = regexp.MustCompile(`(?i)(\d[ -]*?){12}$`)
 )
 
 type QueryType int

--- a/service-admin/internal/server/handlers/search_test.go
+++ b/service-admin/internal/server/handlers/search_test.go
@@ -73,6 +73,7 @@ func (m *mockLPAService) GetLpaRecordBySiriusID(ctx context.Context, lpaID strin
 	if m.GetUsersByLPAIDFunc != nil {
 		return m.GetUsersByLPAIDFunc(ctx, lpaID)
 	}
+
 	return []*data.LPA{}, nil
 }
 
@@ -475,7 +476,7 @@ func Test_SearchByActivationCode(t *testing.T) {
 
 			s := NewSearchServer(tt.accountService, tt.lpaService, tt.templateService, tt.activationKeyService)
 
-			if got := s.DoSearch(tt.args.ctx, tt.args.queryType, tt.args.q); !reflect.DeepEqual(got, tt.want) {
+			if got := s.SearchByActivationCode(tt.args.ctx, tt.args.q); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("doSearch() = %v, want %v", got, tt.want)
 			}
 		})

--- a/service-admin/internal/server/handlers/search_test.go
+++ b/service-admin/internal/server/handlers/search_test.go
@@ -50,6 +50,7 @@ func (m *mockAccountService) GetEmailByUserID(ctx context.Context, userID string
 type mockLPAService struct {
 	GetLPAsByUserIDFunc        func(context.Context, string) ([]*data.LPA, error)
 	GetLPAByActivationCodeFunc func(context.Context, string) (*data.LPA, error)
+	GetUsersByLPAIDFunc        func(context.Context, string) ([]*data.LPA, error)
 }
 
 func (m *mockLPAService) GetLpasByUserID(ctx context.Context, userID string) ([]*data.LPA, error) {
@@ -66,6 +67,13 @@ func (m *mockLPAService) GetLPAByActivationCode(ctx context.Context, code string
 	}
 
 	return nil, nil
+}
+
+func (m *mockLPAService) GetLpaRecordBySiriusID(ctx context.Context, lpaID string) (userIDs []*data.LPA, err error) {
+	if m.GetUsersByLPAIDFunc != nil {
+		return m.GetUsersByLPAIDFunc(ctx, lpaID)
+	}
+	return []*data.LPA{}, nil
 }
 
 func Test_doSearch(t *testing.T) {

--- a/service-admin/internal/server/handlers/search_test.go
+++ b/service-admin/internal/server/handlers/search_test.go
@@ -76,7 +76,7 @@ func (m *mockLPAService) GetLpaRecordBySiriusID(ctx context.Context, lpaID strin
 	return []*data.LPA{}, nil
 }
 
-func Test_doSearch(t *testing.T) {
+func Test_SearchByEmail(t *testing.T) {
 	t.Parallel()
 
 	testLPA := &data.LPA{
@@ -189,6 +189,46 @@ func Test_doSearch(t *testing.T) {
 			activationKeyService: &mockActivationKeyService{},
 			want:                 &data.ActorUser{ID: "TestID", Email: "test@email.com", LastLogin: "TestTime", LPAs: nil},
 		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := NewSearchServer(tt.accountService, tt.lpaService, tt.templateService, tt.activationKeyService)
+
+			if got := s.SearchByEmail(tt.args.ctx, tt.args.q); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SearchByEmail() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_SearchByActivationCode(t *testing.T) {
+	t.Parallel()
+
+	testLPA := &data.LPA{
+		SiriusUID: "700000000123",
+		Added:     "Date Added",
+		UserID:    "TestID",
+	}
+
+	type args struct {
+		ctx       context.Context
+		queryType QueryType
+		q         string
+	}
+
+	tests := []struct {
+		name                 string
+		args                 args
+		templateService      TemplateWriterService
+		accountService       AccountService
+		lpaService           LPAService
+		activationKeyService data.ActivationKeyService
+		want                 interface{}
+	}{
 		{
 			name: "Test standard activation key query",
 			args: args{

--- a/service-admin/internal/server/handlers/search_test.go
+++ b/service-admin/internal/server/handlers/search_test.go
@@ -274,66 +274,6 @@ func Test_SearchByLPANumber(t *testing.T) {
 			activationKeyService: &mockActivationKeyService{},
 			want:                 nil,
 		},
-		// {
-		// 	name: "Test email query with error on account lookup",
-		// 	args: args{
-		// 		ctx:       context.TODO(),
-		// 		queryType: 0, //Email query
-		// 		q:         "test@email.com",
-		// 	},
-		// 	accountService: &mockAccountService{
-		// 		GetActorByUserEmailFunc: func(ctx context.Context, s string) (*data.ActorUser, error) {
-		// 			return nil, errors.New("this is an error")
-		// 		},
-		// 	},
-		// 	lpaService:           &mockLPAService{},
-		// 	activationKeyService: &mockActivationKeyService{},
-		// 	want:                 nil,
-		// },
-		// {
-		// 	name: "Test email query with error on LPA lookup",
-		// 	args: args{
-		// 		ctx:       context.TODO(),
-		// 		queryType: 0, //Email query
-		// 		q:         "test@email.com",
-		// 	},
-		// 	accountService: &mockAccountService{},
-		// 	lpaService: &mockLPAService{
-		// 		GetLPAsByUserIDFunc: func(ctx context.Context, s string) ([]*data.LPA, error) {
-		// 			return nil, errors.New("this is an error")
-		// 		},
-		// 	},
-		// 	activationKeyService: &mockActivationKeyService{},
-		// 	want:                 nil,
-		// },
-		// {
-		// 	name: "Test email query with not found error on LPA lookup returns empty result not nil",
-		// 	args: args{
-		// 		ctx:       context.TODO(),
-		// 		queryType: 0, //Email query
-		// 		q:         "test@email.com",
-		// 	},
-		// 	accountService: &mockAccountService{
-		// 		GetActorByUserEmailFunc: func(ctx context.Context, s string) (*data.ActorUser, error) {
-		// 			if s == "test@email.com" {
-		// 				return &data.ActorUser{
-		// 					ID:        "TestID",
-		// 					LastLogin: "TestTime",
-		// 					Email:     "test@email.com",
-		// 				}, nil
-		// 			}
-		// 			t.Errorf("expected test@email.com got %v", s)
-		// 			return nil, nil
-		// 		},
-		// 	},
-		// 	lpaService: &mockLPAService{
-		// 		GetLPAsByUserIDFunc: func(ctx context.Context, s string) ([]*data.LPA, error) {
-		// 			return nil, data.ErrUserLpaActorMapNotFound
-		// 		},
-		// 	},
-		// 	activationKeyService: &mockActivationKeyService{},
-		// 	want:                 &data.ActorUser{ID: "TestID", Email: "test@email.com", LastLogin: "TestTime", LPAs: nil},
-		// },
 	}
 
 	for _, tt := range tests {

--- a/service-admin/internal/server/templates.go
+++ b/service-admin/internal/server/templates.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/ministryofjustice/opg-use-an-lpa/service-admin/internal/server/handlers"
@@ -77,6 +78,8 @@ func LoadTemplates(folder fs.FS) *Templates {
 }
 
 func readableDateTime(date string) string {
+	date = strings.TrimSpace(date)
+
 	l, err := time.LoadLocation("Europe/London")
 	if err != nil {
 		return date
@@ -84,7 +87,10 @@ func readableDateTime(date string) string {
 
 	t, err := time.Parse(time.RFC3339, date)
 	if err != nil {
-		return date
+		t, err = time.Parse("2006-01-02T15:04:05", date)
+		if err != nil {
+			return date
+		}
 	}
 
 	return t.In(l).Format("2 January 2006 at 3:04PM")

--- a/service-admin/web/templates/result_lpa.partial.gohtml
+++ b/service-admin/web/templates/result_lpa.partial.gohtml
@@ -12,7 +12,7 @@
     {{ if .AddedBy }}
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
-        LPAs
+        Added by
       </dt>
       <dd class="govuk-summary-list__value">
         <ul class="govuk-list">

--- a/service-admin/web/templates/result_lpa.partial.gohtml
+++ b/service-admin/web/templates/result_lpa.partial.gohtml
@@ -1,0 +1,29 @@
+{{ define "result_lpa" }}
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        LPA number
+      </dt>
+      <dd class="govuk-summary-list__value">
+        {{ .LPANumber }}
+      </dd>
+    </div>
+
+    {{ if .AddedBy }}
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        LPAs
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <ul class="govuk-list">
+        {{ range .AddedBy }}
+          <li>{{ .Email }}</li>
+          <li class="govuk-hint govuk-!-margin-bottom-2">{{ .DateAdded | readableDateTime }}</li>
+        {{ end }}
+        </ul>
+      </dd>
+    </div>
+    {{ end }}
+  </dl>
+{{ end }}
+

--- a/service-admin/web/templates/search.page.gohtml
+++ b/service-admin/web/templates/search.page.gohtml
@@ -52,5 +52,12 @@
       {{ template "result_code" .Result }}
     </div>
   </div>
+  {{ else if and .Query .Result (eq .Type 2) (not .Errors) }}
+  <div class="govuk-grid-row govuk-!-margin-top-6">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-hint">Showing results for "<strong>{{ .Query }}</strong>"</p>
+      {{ template "result_lpa" .Result }}
+    </div>
+  </div>
   {{ end }}
 {{ end }}

--- a/service-admin/web/templates/search.page.gohtml
+++ b/service-admin/web/templates/search.page.gohtml
@@ -14,7 +14,7 @@
           </h1>
 
           <div id="search-hint" class="govuk-hint moj-search__hint">
-            You can search by email address or activation key
+            You can search by email address, activation key or LPA number
           </div>
 
           {{ if .Errors.Query }}

--- a/service-api/docker/seeding/start.sh
+++ b/service-api/docker/seeding/start.sh
@@ -58,13 +58,16 @@ if ! [[ -z "${AWS_ENDPOINT_DYNAMODB}" ]]; then
 
     aws dynamodb create-table \
     --attribute-definitions AttributeName=Id,AttributeType=S AttributeName=UserId,AttributeType=S AttributeName=ActivationCode,AttributeType=S \
+     AttributeName=SiriusUid,AttributeType=S \
     --table-name UserLpaActorMap \
     --key-schema AttributeName=Id,KeyType=HASH \
     --provisioned-throughput ReadCapacityUnits=10,WriteCapacityUnits=10 \
     --region eu-west-1 \
     --endpoint $DYNAMODN_ENDPOINT \
     --global-secondary-indexes IndexName=UserIndex,KeySchema=["{AttributeName=UserId,KeyType=HASH}"],Projection="{ProjectionType=ALL}",ProvisionedThroughput="{ReadCapacityUnits=10,WriteCapacityUnits=10}"\
-      IndexName=ActivationCodeIndex,KeySchema=["{AttributeName=ActivationCode,KeyType=HASH}"],Projection="{ProjectionType=ALL}",ProvisionedThroughput="{ReadCapacityUnits=10,WriteCapacityUnits=10}"
+      IndexName=ActivationCodeIndex,KeySchema=["{AttributeName=ActivationCode,KeyType=HASH}"],Projection="{ProjectionType=ALL}",ProvisionedThroughput="{ReadCapacityUnits=10,WriteCapacityUnits=10}"\
+      IndexName=SiriusUidIndex,KeySchema=["{AttributeName=SiriusUid,KeyType=HASH}"],Projection="{ProjectionType=ALL}",ProvisionedThroughput="{ReadCapacityUnits=10,WriteCapacityUnits=10}"
+
 
      aws dynamodb update-time-to-live \
     --table-name UserLpaActorMap \


### PR DESCRIPTION
# Purpose

Enable searching by LPA number

Fixes UML-1409

## Approach

Query UserLPAActorMap for records with lpa number, get list of account IDs then query ActorUsers for email addresses. Consolidate all information into a list of email addresses with the date that they added and display

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have added tests to prove my work
* [x] The product team have tested these changes
