### PR TITLE
UML-2658-b fix of last PR due to naming issue in preprod

### DIFF
--- a/terraform/account/modules/s3_bucket/data_sources.tf
+++ b/terraform/account/modules/s3_bucket/data_sources.tf
@@ -1,5 +1,9 @@
+locals {
+  access_account_name = var.account_name == "preproduction" ? "preprod" : var.account_name
+}
+
 data "aws_region" "current" {}
 
 data "aws_s3_bucket" "access_logging" {
-  bucket = "s3-access-logs-opg-opg-use-an-lpa-${var.account_name}-${data.aws_region.current.name}"
+  bucket = "s3-access-logs-opg-opg-use-an-lpa-${local.access_account_name}-${data.aws_region.current.name}"
 }


### PR DESCRIPTION
# Purpose

Last PR for UML-2658 broke main pipe as the naming is different in preprod for the s3 access bucket. 

Fixes UML-2658

## Approach

Make the exception for the pre access naming

## Learning

NA

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
