### PR TITLE
Add hidden string to authenticate method

### DIFF
--- a/.idea/runConfigurations/API_Integration.xml
+++ b/.idea/runConfigurations/API_Integration.xml
@@ -6,8 +6,6 @@
         <option name="interpreterName" value="test-api-app" />
       </PhpTestInterpreterSettings>
     </CommandLine>
-    <method v="2">
-      <option name="ToolBeforeRunTask" enabled="true" actionId="Tool_External Tools_Cleanup PACT containers" />
-    </method>
+    <method v="2" />
   </configuration>
 </component>

--- a/service-api/app/features/context/Integration/AccountContext.php
+++ b/service-api/app/features/context/Integration/AccountContext.php
@@ -104,7 +104,7 @@ class AccountContext extends BaseIntegrationContext
 
         $us = $this->container->get(UserService::class);
 
-        $user = $us->authenticate($this->userAccountEmail, $this->password);
+        $user = $us->authenticate($this->userAccountEmail, new HiddenString($this->password));
 
         Assert::assertEquals($this->userAccountId, $user['Id']);
         Assert::assertEquals($this->userAccountEmail, $user['Email']);
@@ -206,7 +206,7 @@ class AccountContext extends BaseIntegrationContext
         $us = $this->container->get(UserService::class);
 
         try {
-            $us->authenticate($this->userAccountEmail, $this->userAccountPassword);
+            $us->authenticate($this->userAccountEmail, new HiddenString($this->userAccountPassword));
         } catch (UnauthorizedException $ex) {
             Assert::assertEquals(
                 'Authentication attempted against inactive account with Id ' . $this->userAccountId,
@@ -245,7 +245,7 @@ class AccountContext extends BaseIntegrationContext
         $us = $this->container->get(UserService::class);
 
         try {
-            $us->authenticate($this->userAccountEmail, '1nc0rr3ctPa33w0rd');
+            $us->authenticate($this->userAccountEmail, new HiddenString('1nc0rr3ctPa33w0rd'));
         } catch (ForbiddenException $fe) {
             Assert::assertEquals('Authentication failed for email ' . $this->userAccountEmail, $fe->getMessage());
             Assert::assertEquals(403, $fe->getCode());
@@ -1465,7 +1465,7 @@ class AccountContext extends BaseIntegrationContext
         $us = $this->container->get(UserService::class);
 
         try {
-            $us->authenticate('incorrect@email.com', $this->userAccountPassword);
+            $us->authenticate('incorrect@email.com', new HiddenString($this->userAccountPassword));
         } catch (NotFoundException $ex) {
             Assert::assertEquals('User not found for email', $ex->getMessage());
             Assert::assertEquals(404, $ex->getCode());

--- a/service-api/app/src/App/src/Handler/AuthHandler.php
+++ b/service-api/app/src/App/src/Handler/AuthHandler.php
@@ -15,6 +15,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 /**
  * Class AuthHandler
+ *
  * @package App\Handler
  * @codeCoverageIgnore
  */
@@ -44,10 +45,9 @@ class AuthHandler implements RequestHandlerInterface
         }
 
         $password = new HiddenString($params['password']);
-        
+
         $user = $this->userService->authenticate($params['email'], $password);
 
         return new JsonResponse($user);
     }
 }
-

--- a/service-api/app/src/App/src/Handler/AuthHandler.php
+++ b/service-api/app/src/App/src/Handler/AuthHandler.php
@@ -8,6 +8,7 @@ use App\Exception\BadRequestException;
 use App\Service\User\UserService;
 use Exception;
 use Laminas\Diactoros\Response\JsonResponse;
+use ParagonIE\HiddenString\HiddenString;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -42,7 +43,9 @@ class AuthHandler implements RequestHandlerInterface
             throw new BadRequestException('Email address and password must be provided');
         }
 
-        $user = $this->userService->authenticate($params['email'], $params['password']);
+        $password = new HiddenString($params['password']);
+        
+        $user = $this->userService->authenticate($params['email'], $password);
 
         return new JsonResponse($user);
     }

--- a/service-api/app/src/App/src/Service/User/UserService.php
+++ b/service-api/app/src/App/src/Service/User/UserService.php
@@ -151,16 +151,16 @@ class UserService
      * Attempts authentication of a user
      *
      * @param string $email
-     * @param string $password
+     * @param HiddenString $password
      *
      * @return array
      * @throws NotFoundException|ForbiddenException|UnauthorizedException|Exception
      */
-    public function authenticate(string $email, string $password): array
+    public function authenticate(string $email, HiddenString $password): array
     {
         $user = $this->usersRepository->getByEmail($email);
 
-        if (!password_verify($password, $user['Password'])) {
+        if (!password_verify($password->getString(), $user['Password'])) {
             throw new ForbiddenException('Authentication failed for email ' . $email, ['email' => $email]);
         }
 

--- a/service-api/app/test/AppTest/Service/User/UserServiceTest.php
+++ b/service-api/app/test/AppTest/Service/User/UserServiceTest.php
@@ -197,7 +197,7 @@ class UserServiceTest extends TestCase
 
         $us = new UserService($repoProphecy->reveal(), $loggerProphecy->reveal());
 
-        $return = $us->authenticate('a@b.com', self::PASS);
+        $return = $us->authenticate('a@b.com', new HiddenString(self::PASS));
 
         $this->assertEquals(['Id' => '1234-1234-1234', 'Email' => 'a@b.com', 'Password' => self::PASS_HASH, 'LastLogin' => '2020-01-01'], $return);
     }
@@ -214,7 +214,7 @@ class UserServiceTest extends TestCase
         $us = new UserService($repoProphecy->reveal(), $loggerProphecy->reveal());
 
         $this->expectException(ForbiddenException::class);
-        $return = $us->authenticate('a@b.com', 'badpassword');
+        $return = $us->authenticate('a@b.com', new HiddenString('badpassword'));
     }
 
     /** @test */
@@ -229,7 +229,7 @@ class UserServiceTest extends TestCase
         $us = new UserService($repoProphecy->reveal(), $loggerProphecy->reveal());
 
         $this->expectException(NotFoundException::class);
-        $return = $us->authenticate('baduser@b.com', self::PASS);
+        $return = $us->authenticate('baduser@b.com', new HiddenString(self::PASS));
     }
 
     /** @test */
@@ -244,7 +244,7 @@ class UserServiceTest extends TestCase
         $us = new UserService($repoProphecy->reveal(), $loggerProphecy->reveal());
 
         $this->expectException(UnauthorizedException::class);
-        $return = $us->authenticate('a@b.com', self::PASS);
+        $return = $us->authenticate('a@b.com', new HiddenString(self::PASS));
     }
 
     /** @test */

--- a/service-api/app/test/AppTest/Service/User/UserServiceTest.php
+++ b/service-api/app/test/AppTest/Service/User/UserServiceTest.php
@@ -687,4 +687,3 @@ class UserServiceTest extends TestCase
         $this->assertNull($response);
     }
 }
-


### PR DESCRIPTION
# Purpose

Use hidden string to avoid accidental printing of plaintext credentials

Fixes UML-2655 

## Checklist

* [x] I have performed a self-review of my own code
