### PR TITLE
Uml 2680 fix password reset page issue

### DIFF
--- a/service-api/app/src/App/src/Service/Email/EmailClient.php
+++ b/service-api/app/src/App/src/Service/Email/EmailClient.php
@@ -71,11 +71,8 @@ class EmailClient
         self::CY_LOCALE => 'c1e2994e-2346-48b4-ac18-ef9eb26b114d',
     ];
 
-    private Client $notifyClient;
-
-    public function __construct(Client $notifyClient)
+    public function __construct(private Client $notifyClient)
     {
-        $this->notifyClient = $notifyClient;
     }
 
     /**
@@ -92,7 +89,7 @@ class EmailClient
             self::TEMPLATE_ID_ACCOUNT_ACTIVATION[$locale],
             [
                 'activate-account-url' => $activateAccountUrl,
-            ]
+            ],
         );
     }
 
@@ -110,7 +107,7 @@ class EmailClient
             self::TEMPLATE_ID_ACCOUNT_ACTIVATED_CONFIRMATION[$locale],
             [
                 'sign-in-url' => $signInLink,
-            ]
+            ],
         );
     }
 
@@ -124,7 +121,7 @@ class EmailClient
     {
         $this->notifyClient->sendEmail(
             $recipient,
-            self::TEMPLATE_ID_EMAIL_ADDRESS_ALREADY_REGISTERED[$locale]
+            self::TEMPLATE_ID_EMAIL_ADDRESS_ALREADY_REGISTERED[$locale],
         );
     }
 
@@ -142,7 +139,7 @@ class EmailClient
             self::TEMPLATE_ID_PASSWORD_RESET[$locale],
             [
                 'password-reset-url' => $passwordResetUrl,
-            ]
+            ],
         );
     }
 
@@ -156,7 +153,7 @@ class EmailClient
     {
         $this->notifyClient->sendEmail(
             $recipient,
-            self::TEMPLATE_ID_PASSWORD_CHANGE[$locale]
+            self::TEMPLATE_ID_PASSWORD_CHANGE[$locale],
         );
     }
 
@@ -177,7 +174,7 @@ class EmailClient
             self::TEMPLATE_ID_EMAIL_CHANGE_SENT_TO_CURRENT_EMAIL[$locale],
             [
                 'new-email-address' => $newEmailAddress,
-            ]
+            ],
         );
     }
 
@@ -198,7 +195,7 @@ class EmailClient
             self::TEMPLATE_ID_EMAIL_CHANGE_SENT_TO_NEW_EMAIL[$locale],
             [
                 'verify-new-email-url' => $completeEmailChangeUrl,
-            ]
+            ],
         );
     }
 
@@ -212,7 +209,7 @@ class EmailClient
     {
         $this->notifyClient->sendEmail(
             $recipient,
-            self::TEMPLATE_ID_RESET_CONFLICT_EMAIL_CHANGE_INCOMPLETE[$locale]
+            self::TEMPLATE_ID_RESET_CONFLICT_EMAIL_CHANGE_INCOMPLETE[$locale],
         );
     }
 
@@ -239,7 +236,7 @@ class EmailClient
                 'reference_number' => $referenceNumber,
                 'postcode' => $postCode,
                 'date' => $letterExpectedDate,
-            ]
+            ],
         );
     }
 
@@ -263,7 +260,7 @@ class EmailClient
             [
                 'reference_number' => $referenceNumber,
                 'date' => $letterExpectedDate,
-            ]
+            ],
         );
     }
 
@@ -277,7 +274,7 @@ class EmailClient
     {
         $this->notifyClient->sendEmail(
             $recipient,
-            self::TEMPLATE_ID_NO_EXISTING_ACCOUNT[$locale]
+            self::TEMPLATE_ID_NO_EXISTING_ACCOUNT[$locale],
         );
     }
 
@@ -285,17 +282,17 @@ class EmailClient
      * Email a user to ask them to reset their password for security reasons
      *
      * @param string $recipient
-     * @param string $resetUrl
+     * @param string $passwordResetUrl
      *
      */
-    public function sendForcePasswordResetEmail(string $recipient, string $locale, string $resetUrl): void
+    public function sendForcePasswordResetEmail(string $recipient, string $locale, string $passwordResetUrl): void
     {
         $this->notifyClient->sendEmail(
             $recipient,
             self::TEMPLATE_ID_FORCE_PASSWORD_RESET[$locale],
             [
-                'password-reset-url' => $resetUrl,
-            ]
+                'password-reset-url' => $passwordResetUrl,
+            ],
         );
     }
 }

--- a/service-front/app/src/Actor/src/Form/PasswordResetRequest.php
+++ b/service-front/app/src/Actor/src/Form/PasswordResetRequest.php
@@ -7,18 +7,17 @@ namespace Actor\Form;
 use Common\Form\AbstractForm;
 use Common\Form\Element\Email;
 use Common\Validator\EmailAddressValidator;
-use Laminas\Form\Element\Hidden;
-use Mezzio\Csrf\CsrfGuardInterface;
 use Laminas\Filter\StringToLower;
+use Laminas\Filter\StringTrim;
+use Laminas\Form\Element\Hidden;
 use Laminas\InputFilter\InputFilterProviderInterface;
 use Laminas\Validator\Identical;
 use Laminas\Validator\NotEmpty;
-use Laminas\Filter\StringTrim;
-
+use Mezzio\Csrf\CsrfGuardInterface;
 
 class PasswordResetRequest extends AbstractForm implements InputFilterProviderInterface
 {
-    const FORM_NAME = 'password-reset-request';
+    public const FORM_NAME = 'password-reset-request';
 
     /**
      * PasswordReset constructor.
@@ -53,7 +52,6 @@ class PasswordResetRequest extends AbstractForm implements InputFilterProviderIn
                     ],
                     [
                         'name' => StringTrim::class,
-
                     ],
                 ],
                 'validators' => [
@@ -62,14 +60,15 @@ class PasswordResetRequest extends AbstractForm implements InputFilterProviderIn
                         'break_chain_on_failure' => true,
                         'options'                => [
                             'messages'           => [
-                                NotEmpty::IS_EMPTY => 'Enter an email address in the correct format, like name@example.com',
+                                NotEmpty::IS_EMPTY =>
+                                    'Enter an email address in the correct format, like name@example.com',
                             ],
                         ],
                     ],
                     [
                         'name'                   => EmailAddressValidator::class,
                         'break_chain_on_failure' => true,
-                    ]
+                    ],
                 ],
             ],
             'email_confirm'    => [
@@ -103,7 +102,7 @@ class PasswordResetRequest extends AbstractForm implements InputFilterProviderIn
             ],
             'forced'           => [
                 'required' => false,
-            ]
+            ],
         ];
     }
 }

--- a/service-front/app/src/Actor/src/Handler/PasswordResetRequestPageHandler.php
+++ b/service-front/app/src/Actor/src/Handler/PasswordResetRequestPageHandler.php
@@ -9,15 +9,14 @@ use Common\Exception\ApiException;
 use Common\Handler\AbstractHandler;
 use Common\Handler\CsrfGuardAware;
 use Common\Handler\Traits\CsrfGuard;
+use Common\Service\Notify\NotifyService;
 use Common\Service\User\UserService;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use Laminas\Diactoros\Response\HtmlResponse;
-use Mezzio\Csrf\CsrfMiddleware;
 use Mezzio\Helper\ServerUrlHelper;
 use Mezzio\Helper\UrlHelper;
 use Mezzio\Template\TemplateRendererInterface;
-use Common\Service\Notify\NotifyService;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Class PasswordResetRequestPageHandler
@@ -28,15 +27,6 @@ use Common\Service\Notify\NotifyService;
 class PasswordResetRequestPageHandler extends AbstractHandler implements CsrfGuardAware
 {
     use CsrfGuard;
-
-    /** @var UserService */
-    private $userService;
-
-    /** @var ServerUrlHelper */
-    private $serverUrlHelper;
-
-    /** @var NotifyService */
-    private $notifyService;
 
     /**
      * PasswordResetRequestPageHandler constructor.
@@ -52,15 +42,11 @@ class PasswordResetRequestPageHandler extends AbstractHandler implements CsrfGua
     public function __construct(
         TemplateRendererInterface $renderer,
         UrlHelper $urlHelper,
-        UserService $userService,
-        ServerUrlHelper $serverUrlHelper,
-        NotifyService $notifyService
+        private UserService $userService,
+        private ServerUrlHelper $serverUrlHelper,
+        private NotifyService $notifyService,
     ) {
         parent::__construct($renderer, $urlHelper);
-
-        $this->userService = $userService;
-        $this->serverUrlHelper = $serverUrlHelper;
-        $this->notifyService = $notifyService;
     }
 
     /**
@@ -90,15 +76,14 @@ class PasswordResetRequestPageHandler extends AbstractHandler implements CsrfGua
 
                     if (!empty($data['forced'])) {
                         $this->notifyService->sendEmailToUser(
-                                              NotifyService::FORCE_PASSWORD_RESET_EMAIL_TEMPLATE,
-                                              $data['email'],
+                            NotifyService::FORCE_PASSWORD_RESET_EMAIL_TEMPLATE,
+                            $data['email'],
                             passwordResetUrl: $passwordResetUrl
                         );
-                        //$this->emailClient->sendForcePasswordResetEmail($data['email'], $passwordResetUrl);
                     } else {
                         $this->notifyService->sendEmailToUser(
-                                              NotifyService::PASSWORD_RESET_EMAIL_TEMPLATE,
-                                              $data['email'],
+                            NotifyService::PASSWORD_RESET_EMAIL_TEMPLATE,
+                            $data['email'],
                             passwordResetUrl: $passwordResetUrl
                         );
                     }


### PR DESCRIPTION
# Purpose

We were not using the correct parameter name for the force password reset email.

Fixes UML-2680

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* The product team have tested these changes
