### PR TITLE
Pin docker credential helper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -769,7 +769,8 @@ orbs:
                 sudo ln -sf /usr/bin/python3-config python-config
       dockerhub_login:
         steps:
-          - docker/install-docker-credential-helper
+          - docker/install-docker-credential-helper:
+              release-tag: v0.6.4
           - docker/check:
               docker-password: DOCKER_ACCESS_TOKEN
               docker-username: DOCKER_USER


### PR DESCRIPTION
Fixes UML-2686

## Approach

Pin install docker credentials orb to v0.6.4 so it stops breaking 

## Checklist

* [x] I have performed a self-review of my own code