### PR TITLE
UML-2641: Display postcode on what is your current address page

### DIFF
--- a/service-front/app/src/Actor/src/Handler/RequestActivationKey/ActorAddressHandler.php
+++ b/service-front/app/src/Actor/src/Handler/RequestActivationKey/ActorAddressHandler.php
@@ -53,7 +53,8 @@ class ActorAddressHandler extends AbstractCleansingDetailsHandler
             [
                 'user'     => $this->user,
                 'form'     => $this->form->prepare(),
-                'back'     => $this->lastPage($this->state($request))
+                'back'     => $this->lastPage($this->state($request)),
+                'postCode' => $this->state($request)->postcode
             ]
         ));
     }

--- a/service-front/app/src/Actor/src/Handler/RequestActivationKey/CheckYourAnswersHandler.php
+++ b/service-front/app/src/Actor/src/Handler/RequestActivationKey/CheckYourAnswersHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Actor\Handler\RequestActivationKey;
 
+use Actor\Form\RequestActivationKey\ActorAddress;
 use Actor\Form\RequestActivationKey\CheckYourAnswers;
 use Actor\Form\RequestActivationKey\CreateNewActivationKey;
 use Actor\Workflow\RequestActivationKey;
@@ -218,7 +219,17 @@ class CheckYourAnswersHandler extends AbstractHandler implements UserAware, Csrf
 
                 case OlderLpaApiResponse::DOES_NOT_MATCH:
                     if (($this->featureEnabled)('allow_older_lpas')) {
-                        return $this->redirectToRoute('lpa.add.actor-address');
+                        $form = new ActorAddress($this->getCsrfGuard($request));
+                        return new HtmlResponse(
+                            $this->renderer->render(
+                                'actor::request-activation-key/actor-address',
+                                [
+                                    'user'     => $this->user,
+                                    'form'      => $form,
+                                    'postCode' => $state->postcode
+                                ]
+                            )
+                        );
                     } else {
                         return new HtmlResponse($this->renderer->render(
                             'actor::cannot-find-lpa',

--- a/service-front/app/src/Actor/src/Handler/RequestActivationKey/CheckYourAnswersHandler.php
+++ b/service-front/app/src/Actor/src/Handler/RequestActivationKey/CheckYourAnswersHandler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Actor\Handler\RequestActivationKey;
 
-use Actor\Form\RequestActivationKey\ActorAddress;
 use Actor\Form\RequestActivationKey\CheckYourAnswers;
 use Actor\Form\RequestActivationKey\CreateNewActivationKey;
 use Actor\Workflow\RequestActivationKey;
@@ -219,17 +218,7 @@ class CheckYourAnswersHandler extends AbstractHandler implements UserAware, Csrf
 
                 case OlderLpaApiResponse::DOES_NOT_MATCH:
                     if (($this->featureEnabled)('allow_older_lpas')) {
-                        $form = new ActorAddress($this->getCsrfGuard($request));
-                        return new HtmlResponse(
-                            $this->renderer->render(
-                                'actor::request-activation-key/actor-address',
-                                [
-                                    'user'     => $this->user,
-                                    'form'      => $form,
-                                    'postCode' => $state->postcode
-                                ]
-                            )
-                        );
+                        return $this->redirectToRoute('lpa.add.actor-address');
                     } else {
                         return new HtmlResponse($this->renderer->render(
                             'actor::cannot-find-lpa',

--- a/service-front/app/src/Actor/templates/actor/request-activation-key/actor-address.html.twig
+++ b/service-front/app/src/Actor/templates/actor/request-activation-key/actor-address.html.twig
@@ -8,7 +8,7 @@
         {{ include('@partials/welsh-switch.html.twig') }}
 
         <div role="navigation" aria-labelledby="back-link-navigation">
-            <a href="{{ path(back) }}" class="govuk-back-link"
+            <a href="{{ path('lpa.check-answers') }}" class="govuk-back-link"
                id="back-link-navigation">{% trans %}Back{% endtrans %}</a>
         </div>
 
@@ -22,6 +22,7 @@
                     <h1 class="govuk-heading-xl">{% trans %}We need some more details{% endtrans %}</h1>
                     <p class="govuk-body">{% trans %}We need a few extra details to make sure we have the right LPA for your activation key request.{% endtrans %}</p>
                     <h2 class="govuk-heading-l">{% trans %}What is your current address?{% endtrans %}</h2>
+                    <p class="govuk-body">{% trans %}You've already given your post code as:{% endtrans %} {{ postCode }}</p>
                     <p class="govuk-body">{% trans %}Your activation key will be posted to this address.{% endtrans %}</p>
 
                     {{ govuk_form_element(form.get('__csrf')) }}

--- a/service-front/app/src/Actor/templates/actor/request-activation-key/actor-address.html.twig
+++ b/service-front/app/src/Actor/templates/actor/request-activation-key/actor-address.html.twig
@@ -8,8 +8,7 @@
         {{ include('@partials/welsh-switch.html.twig') }}
 
         <div role="navigation" aria-labelledby="back-link-navigation">
-            <a href="{{ path('lpa.check-answers') }}" class="govuk-back-link"
-               id="back-link-navigation">{% trans %}Back{% endtrans %}</a>
+            <a href="{{ path(back) }}" class="govuk-back-link" id="back-link-navigation">{% trans %}Back{% endtrans %}</a>
         </div>
 
         <main class="govuk-main-wrapper" id="main-content" role="main">


### PR DESCRIPTION
# Purpose

https://opgtransform.atlassian.net/browse/UML-2641

Fixes UML-2641

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
