### PR TITLE
Reduce logged output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,6 @@ rebuild:
 
 down:
 	$(COMPOSE) down $(filter-out $@,$(MAKECMDGOALS))
-.PHONY: exec
 .PHONY: down
 
 down_all:
@@ -133,12 +132,20 @@ development_mode: | enable_development_mode clear_config_cache
 .PHONY: development_mode
 
 run_front_composer:
-	$(COMPOSE) run front-composer install --prefer-dist --no-suggest --no-interaction --no-scripts --optimize-autoloader
+	$(COMPOSE) run front-composer $(filter-out $@,$(MAKECMDGOALS))
 .PHONY: run_front_composer
 
 run_api_composer:
-	$(COMPOSE) run api-composer install --prefer-dist --no-suggest --no-interaction --no-scripts --optimize-autoloader
+	$(COMPOSE) run api-composer $(filter-out $@,$(MAKECMDGOALS))
 .PHONY: run_api_composer
+
+run_front_composer_install:
+	$(COMPOSE) run front-composer install --prefer-dist --no-suggest --no-interaction --no-scripts --optimize-autoloader
+.PHONY: run_front_composer_install
+
+run_api_composer_install:
+	$(COMPOSE) run api-composer install --prefer-dist --no-suggest --no-interaction --no-scripts --optimize-autoloader
+.PHONY: run_api_composer_install
 
 run_front_composer_update:
 	$(COMPOSE) run front-composer update

--- a/service-front/app/src/Common/src/Service/Security/UserIdentificationService.php
+++ b/service-front/app/src/Common/src/Service/Security/UserIdentificationService.php
@@ -40,7 +40,7 @@ class UserIdentificationService
 
         // if the identity in the session does not match the identity we just calculated something about this
         // request is probably nefarious, log it.
-        if ($sessionIdentity !== $id->hash()) {
+        if ($sessionIdentity !== null && $sessionIdentity !== $id->hash()) {
             $this->logger->notice(
                 'Identity of incoming request is different to session stored identity',
                 [


### PR DESCRIPTION
# Purpose

Stop logging when an identity is "new" which is for us nearly all load balancer healthchecks.

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* The product team have tested these changes
