### PR TITLE
DDPB-4509 use latest remote docker version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -931,7 +931,6 @@ orbs:
           - checkout
           - install_aws_cli
           - setup_remote_docker:
-              version: 20.10.11
               docker_layer_caching: false
           - attach_workspace:
               at: ~/project
@@ -1009,7 +1008,6 @@ orbs:
           - checkout
           - install_aws_cli
           - setup_remote_docker:
-              version: 20.10.11
               docker_layer_caching: false
           - attach_workspace:
               at: ~/project
@@ -1053,7 +1051,6 @@ orbs:
           - checkout
           - install_aws_cli
           - setup_remote_docker:
-              version: 20.10.11
               docker_layer_caching: false
           - dockerhub_login
           - run:
@@ -1137,7 +1134,6 @@ orbs:
           - checkout
           - install_aws_cli
           - setup_remote_docker:
-              version: 20.10.11
               docker_layer_caching: false
           - dockerhub_login
           - run:
@@ -1193,7 +1189,6 @@ orbs:
           - checkout
           - install_aws_cli
           - setup_remote_docker:
-              version: 20.10.11
               docker_layer_caching: false
           - dockerhub_login
           - run:


### PR DESCRIPTION
# Purpose

As per this instruction:

`use the default version of Docker in setup_remote_docker jobs. This can be achieved by eliminating the version flag specified in each job that uses setup_remote_docker.`

Fixes DDPB-4509

## Approach

NA

## Learning

NA

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
