### PR TITLE
UML-2559b fix out of date circleci file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,8 @@ orbs:
                 sudo ln -sf /usr/bin/python3-config python-config
       dockerhub_login:
         steps:
-          - docker/install-docker-credential-helper
+          - docker/install-docker-credential-helper:
+              release-tag: v0.6.4
           - docker/check:
               docker-password: DOCKER_ACCESS_TOKEN
               docker-username: DOCKER_USER
@@ -377,7 +378,6 @@ orbs:
           - checkout
           - install_aws_cli
           - setup_remote_docker:
-              version: 20.10.11
               docker_layer_caching: false
           - attach_workspace:
               at: ~/project
@@ -455,7 +455,6 @@ orbs:
           - checkout
           - install_aws_cli
           - setup_remote_docker:
-              version: 20.10.11
               docker_layer_caching: false
           - attach_workspace:
               at: ~/project
@@ -499,7 +498,6 @@ orbs:
           - checkout
           - install_aws_cli
           - setup_remote_docker:
-              version: 20.10.11
               docker_layer_caching: false
           - dockerhub_login
           - run:
@@ -583,7 +581,6 @@ orbs:
           - checkout
           - install_aws_cli
           - setup_remote_docker:
-              version: 20.10.11
               docker_layer_caching: false
           - dockerhub_login
           - run:
@@ -639,7 +636,6 @@ orbs:
           - checkout
           - install_aws_cli
           - setup_remote_docker:
-              version: 20.10.11
               docker_layer_caching: false
           - dockerhub_login
           - run:


### PR DESCRIPTION
circleci file became out of date on UML-2559 and some changes were missed so we are seeing some reoccurring issues. This should bring it back to how it was (minus the workflows that have been moved to actions)
