### PR TITLE
UML-2559c handle longer path names

### DIFF
--- a/.github/workflows/pull-request-path.yml
+++ b/.github/workflows/pull-request-path.yml
@@ -53,7 +53,7 @@ jobs:
       - name: extract variables for workflow
         id: variables
         run: |
-          echo "branch_formatted=$(echo ${GITHUB_HEAD_REF:-${GITHUB_REF##*/}} | tr -cd '[:alnum:]' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+          echo "branch_formatted=$(echo ${GITHUB_HEAD_REF:-${GITHUB_REF##*/}} | tr -cd '[:alnum:]' | tr '[:upper:]' '[:lower:]' | cut -c1-8)" >> $GITHUB_OUTPUT
           echo "short_sha=$(echo ${GITHUB_SHA:0:7})" >> $GITHUB_OUTPUT
           if [[ ${{ steps.changed-files-terraform.outputs.only_changed }} = "true" ]]
           then


### PR DESCRIPTION
# Purpose

the team often use longer branch names in the format branch_description.

## Approach

whilst I thought about trying to just extract the branch name using combination of awk and some regex logic, there are quite a few variants that get used and I feel like I will miss some without a bit of thought so for now i'm just cutting the branch to be first 8 chars.

## Learning

NA

## Checklist

* [x] I have performed a self-review of my own code

