### PR TITLE
UML-2565 add stats weekly run back into circle for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,18 @@
 version: 2.1
 
 workflows:
+  post_statistics:
+    triggers:
+      - schedule:
+          cron: "0 9 * * 1" # 9am every Monday
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - slack_notify_stats:
+          name: slack_notify_stats
+
   path_to_live:
       jobs:
         # Common tasks
@@ -981,6 +993,29 @@ jobs:
             export IMAGE_TAG=$(bash ~/project/scripts/pipeline/set_environment_variables/set_image_tag.sh $CIRCLE_BRANCH $CIRCLE_SHA1) >> $BASH_ENV
             echo $IMAGE_TAG
             python scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py --search use_an_lpa --tag $IMAGE_TAG
+
+  slack_notify_stats:
+    docker:
+      - image: cimg/python:3.7
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_ACCESS_TOKEN
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp
+      - run:
+          name: Get Stats
+          command: |
+            pip install -r scripts/pipeline/requirements.txt
+            python ~/project/scripts/get_statistics/get_statistics.py --text > ./output.txt
+      - slack/notify:
+          title: "Service Statistics - Use a Lasting Power of Attorney Production"
+          color: "#9933ff"
+          message: $(cat ./output.txt)
+          webhook: ${PROD_RELEASE_SLACK_WEBHOOK}
+          footer: ""
 
   cancel_redundant_builds:
     docker:


### PR DESCRIPTION
# Purpose

Had removed this as part of the GH work as we now post directly to dynamo. However, having this back in for now as that piece of work isn't fully active yet

Fixes UML-2565

## Approach

Adding back to circle rather than GH as would have to find a slack action that formatted results similarly and not worth doing now as we likely won't need this in future. 

## Learning

NA

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
