### PR TITLE
UML-2652: Updated end page designs so that banner width and headings is same as text  on some pages

### DIFF
--- a/service-front/app/src/Actor/templates/actor/activation-key-request-received.html.twig
+++ b/service-front/app/src/Actor/templates/actor/activation-key-request-received.html.twig
@@ -10,7 +10,7 @@
 
         <main class="govuk-main-wrapper" id="main-content" role="main">
             <div class="govuk-grid-row">
-                <div class="govuk-grid-column-full">
+                <div class="govuk-grid-column-two-thirds">
                     <div class="govuk-panel govuk-panel--confirmation">
                         <h1 class="govuk-panel__title">
                             {% trans %}We've got your activation key request{% endtrans %}

--- a/service-front/app/src/Actor/templates/actor/change-email.html.twig
+++ b/service-front/app/src/Actor/templates/actor/change-email.html.twig
@@ -13,7 +13,7 @@
 
         <main class="govuk-main-wrapper" id="main-content" role="main">
             <div class="govuk-grid-row">
-                <div class="govuk-grid-column-full">
+                <div class="govuk-grid-column-two-thirds">
 
                     {{ govuk_error_summary(form) }}
                     {{ govuk_form_open(form) }}

--- a/service-front/app/src/Actor/templates/actor/create-account-success.html.twig
+++ b/service-front/app/src/Actor/templates/actor/create-account-success.html.twig
@@ -14,7 +14,7 @@
 
         <div class="govuk-grid-row">
 
-            <div class="govuk-grid-column-three-quarters">
+            <div class="govuk-grid-column-two-thirds">
 
                 <h1 class="govuk-heading-l">{% trans %}Check your email{% endtrans %}</h1>
 

--- a/service-front/app/src/Actor/templates/actor/instructions-preferences.html.twig
+++ b/service-front/app/src/Actor/templates/actor/instructions-preferences.html.twig
@@ -14,7 +14,7 @@
         <main class="govuk-main-wrapper" id="main-content" role="main">
             <div class="govuk-grid-row">
 
-                <div class="govuk-grid-column-full">
+                <div class="govuk-grid-column-two-thirds">
                     <h1 class="govuk-heading-xl">
                         {% trans %}Instructions and preferences{% endtrans %}
                     </h1>

--- a/service-front/app/src/Actor/templates/actor/lpa-blank-dashboard.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-blank-dashboard.html.twig
@@ -15,7 +15,7 @@
             {{ include('@actor/partials/flash-message.html.twig', {flash_obj: flash, flash_key:'Actor\\Handler\\RemoveLpaHandler::REMOVE_LPA_FLASH_MSG'}) }}
 
             <div class="govuk-grid-row">
-                <div class="govuk-grid-column-full">
+                <div class="govuk-grid-column-two-thirds">
                     <h1 class="govuk-heading-xl">{% trans %}Your lasting powers of attorney{% endtrans %}</h1>
                 </div>
             </div>

--- a/service-front/app/src/Actor/templates/actor/lpa-dashboard.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-dashboard.html.twig
@@ -15,7 +15,7 @@
             {{ include('@actor/partials/flash-message.html.twig', {flash_obj: flash, flash_key:'Actor\\Handler\\RemoveLpaHandler::REMOVE_LPA_FLASH_MSG'}) }}
 
             <div class="govuk-grid-row">
-                <div class="govuk-grid-column-full">
+                <div class="govuk-grid-column-two-thirds">
                     <h1 class="govuk-heading-xl">{% trans %}Your lasting powers of attorney{% endtrans %}</h1>
                 </div>
             </div>
@@ -51,7 +51,7 @@
             </div>
 
             <div class="govuk-grid-row">
-                <div class="govuk-grid-column-full">
+                <div class="govuk-grid-column-two-thirds">
 
                     {% set totalLpas = total_lpas %}
 

--- a/service-front/app/src/Actor/templates/actor/lpa-removed.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-removed.html.twig
@@ -15,7 +15,7 @@
         <main class="govuk-main-wrapper" id="main-content" role="main">
 
             <div class="govuk-grid-row">
-                <div class="govuk-grid-column-full">
+                <div class="govuk-grid-column-two-thirds">
 
                     <h1 class="govuk-heading-xl">{% trans %}We've removed an LPA from your account{% endtrans %}</h1>
 

--- a/service-front/app/src/Actor/templates/actor/request-activation-key/donor-details.html.twig
+++ b/service-front/app/src/Actor/templates/actor/request-activation-key/donor-details.html.twig
@@ -16,7 +16,7 @@
             {{ govuk_error_summary(form) }}
 
             <div class="govuk-grid-row">
-                <div class="govuk-grid-column-one-half">
+                <div class="govuk-grid-column-two-thirds">
 
                     <h1 class="govuk-heading-xl">{% trans %}The donor's details{% endtrans %}</h1>
 

--- a/service-front/app/src/Actor/templates/actor/send-activation-key-confirmation.html.twig
+++ b/service-front/app/src/Actor/templates/actor/send-activation-key-confirmation.html.twig
@@ -10,7 +10,7 @@
 
         <main class="govuk-main-wrapper" id="main-content" role="main">
             <div class="govuk-grid-row">
-                <div class="govuk-grid-column-full">
+                <div class="govuk-grid-column-two-thirds">
                     <div class="govuk-panel govuk-panel--confirmation">
                         <h1 class="govuk-panel__title">
                             {% trans %}We're posting you an activation key{% endtrans %}

--- a/service-front/app/src/Actor/templates/actor/stats-page.html.twig
+++ b/service-front/app/src/Actor/templates/actor/stats-page.html.twig
@@ -6,7 +6,7 @@
 
     <main class="govuk-main-wrapper">
         <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
+            <div class="govuk-grid-column-two-thirds">
 
                 <h1 class="govuk-heading-xl">LPA Statistics</h1>
 

--- a/service-front/app/src/Actor/templates/actor/your-details.html.twig
+++ b/service-front/app/src/Actor/templates/actor/your-details.html.twig
@@ -11,7 +11,7 @@
         <main class="govuk-main-wrapper" id="main-content" role="main">
 
             <div class="govuk-grid-row">
-                <div class="govuk-grid-column-three-quarters">
+                <div class="govuk-grid-column-two-thirds">
                     <h1 class="govuk-heading-xl">{% trans %}Your details{% endtrans %}</h1>
 
                             <dl class="govuk-summary-list">

--- a/service-front/app/src/Common/templates/common/instructions-preferences-signed-before-2016.html.twig
+++ b/service-front/app/src/Common/templates/common/instructions-preferences-signed-before-2016.html.twig
@@ -13,7 +13,7 @@
         <main class="govuk-main-wrapper" id="main-content" role="main">
             <div class="govuk-grid-row">
 
-                <div class="govuk-grid-column-full">
+                <div class="govuk-grid-column-two-thirds">
                     <h1 class="govuk-heading-xl">
                         {% trans %}Preferences and instructions cannot be shown for this LPA{% endtrans %}
                     </h1>

--- a/service-front/app/src/Viewer/templates/viewer/stats-page.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/stats-page.html.twig
@@ -6,7 +6,7 @@
 
     <main class="govuk-main-wrapper">
         <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
+            <div class="govuk-grid-column-two-thirds">
 
                 <h1 class="govuk-heading-xl">LPA Statistics</h1>
 


### PR DESCRIPTION

# Purpose

https://opgtransform.atlassian.net/browse/UML-2652

Fixes UML-2652

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
