### PR TITLE
make 500 errors on api connection failure a 502 (Bad Gateway)

### DIFF
--- a/service-front/app/src/Common/src/Exception/ApiException.php
+++ b/service-front/app/src/Common/src/Exception/ApiException.php
@@ -57,6 +57,7 @@ class ApiException extends AbstractApiException
         ?string $message = null,
         ?ResponseInterface $response = null,
         ?Throwable $previous = null,
+        ?int $statusCode = null,
     ): ApiException {
         $code           = self::DEFAULT_ERROR;
         $additionalData = null;
@@ -84,6 +85,10 @@ class ApiException extends AbstractApiException
                     );
                 }
             }
+        }
+
+        if ($statusCode != null) {
+            $code = $statusCode;
         }
 
         return new self($message, $code, $response, $additionalData, $previous);

--- a/service-front/app/src/Common/src/Service/ApiClient/Client.php
+++ b/service-front/app/src/Common/src/Service/ApiClient/Client.php
@@ -71,7 +71,7 @@ class Client
         } catch (ClientExceptionInterface $ex) {
             $response = $ex instanceof HttpException ? $ex->getResponse() : null;
 
-            throw ApiException::create('Error whilst making http GET request', $response, $ex);
+            throw ApiException::create('Error whilst making http GET request', $response, $ex, 502);
         }
     }
 
@@ -104,7 +104,7 @@ class Client
         } catch (ClientExceptionInterface $ex) {
             $response        = $ex instanceof HttpException ? $ex->getResponse() : null;
             $responseMessage = $this->getResponseMessage($response, 'Error whilst making http POST request');
-            throw ApiException::create($responseMessage, $response, $ex);
+            throw ApiException::create($responseMessage, $response, $ex, 502);
         }
     }
 
@@ -137,7 +137,7 @@ class Client
         } catch (ClientExceptionInterface $ex) {
             $response = $ex instanceof HttpException ? $ex->getResponse() : null;
 
-            throw ApiException::create('Error whilst making http PUT request', $response, $ex);
+            throw ApiException::create('Error whilst making http PUT request', $response, $ex, 502);
         }
     }
 
@@ -170,7 +170,7 @@ class Client
         } catch (ClientExceptionInterface $ex) {
             $response = $ex instanceof HttpException ? $ex->getResponse() : null;
 
-            throw ApiException::create('Error whilst making http PATCH request', $response, $ex);
+            throw ApiException::create('Error whilst making http PATCH request', $response, $ex, 502);
         }
     }
 
@@ -202,7 +202,7 @@ class Client
         } catch (ClientExceptionInterface $ex) {
             $response = $ex instanceof HttpException ? $ex->getResponse() : null;
 
-            throw ApiException::create('Error whilst making http DELETE request', $response, $ex);
+            throw ApiException::create('Error whilst making http DELETE request', $response, $ex, 502);
         }
     }
 

--- a/service-front/app/test/CommonTest/Service/ApiClient/ClientTest.php
+++ b/service-front/app/test/CommonTest/Service/ApiClient/ClientTest.php
@@ -108,7 +108,7 @@ class ClientTest extends TestCase
                         'details' => '',
                         'data'    => [],
                     ]),
-                    StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR
+                    StatusCodeInterface::STATUS_BAD_GATEWAY
                 )->reveal()
             );
 
@@ -118,7 +118,7 @@ class ClientTest extends TestCase
         $client = new Client($this->apiClient->reveal(), 'https://localhost', '');
 
         $this->expectException(ApiException::class);
-        $this->expectExceptionCode(StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR);
+        $this->expectExceptionCode(StatusCodeInterface::STATUS_BAD_GATEWAY);
         $data = $client->httpGet('/simple_get', ['simple_query' => 'query_value']);
     }
 
@@ -176,7 +176,7 @@ class ClientTest extends TestCase
                         'details' => '',
                         'data'    => [],
                     ]),
-                    StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR
+                    StatusCodeInterface::STATUS_BAD_GATEWAY
                 )->reveal()
             );
 
@@ -186,7 +186,7 @@ class ClientTest extends TestCase
         $client = new Client($this->apiClient->reveal(), 'https://localhost', '');
 
         $this->expectException(ApiException::class);
-        $this->expectExceptionCode(StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR);
+        $this->expectExceptionCode(StatusCodeInterface::STATUS_BAD_GATEWAY);
         $data = $client->httpPost('/simple_post', ['simple_query' => 'query_value']);
     }
 
@@ -244,7 +244,7 @@ class ClientTest extends TestCase
                         'details' => '',
                         'data'    => [],
                     ]),
-                    StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR
+                    StatusCodeInterface::STATUS_BAD_GATEWAY
                 )->reveal()
             );
 
@@ -254,7 +254,7 @@ class ClientTest extends TestCase
         $client = new Client($this->apiClient->reveal(), 'https://localhost', '');
 
         $this->expectException(ApiException::class);
-        $this->expectExceptionCode(StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR);
+        $this->expectExceptionCode(StatusCodeInterface::STATUS_BAD_GATEWAY);
         $data = $client->httpPut('/simple_put', ['simple_query' => 'query_value']);
     }
 
@@ -312,7 +312,7 @@ class ClientTest extends TestCase
                         'details' => '',
                         'data'    => [],
                     ]),
-                    StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR
+                    StatusCodeInterface::STATUS_BAD_GATEWAY
                 )->reveal()
             );
 
@@ -322,7 +322,7 @@ class ClientTest extends TestCase
         $client = new Client($this->apiClient->reveal(), 'https://localhost', '');
 
         $this->expectException(ApiException::class);
-        $this->expectExceptionCode(StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR);
+        $this->expectExceptionCode(StatusCodeInterface::STATUS_BAD_GATEWAY);
         $data = $client->httpPatch('/simple_patch', ['simple_query' => 'query_value']);
     }
 
@@ -380,7 +380,7 @@ class ClientTest extends TestCase
                         'details' => '',
                         'data'    => [],
                     ]),
-                    StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR
+                    StatusCodeInterface::STATUS_BAD_GATEWAY
                 )->reveal()
             );
 
@@ -390,7 +390,7 @@ class ClientTest extends TestCase
         $client = new Client($this->apiClient->reveal(), 'https://localhost', '');
 
         $this->expectException(ApiException::class);
-        $this->expectExceptionCode(StatusCodeInterface::STATUS_INTERNAL_SERVER_ERROR);
+        $this->expectExceptionCode(StatusCodeInterface::STATUS_BAD_GATEWAY);
         $data = $client->httpDelete('/simple_delete', ['simple_query' => 'query_value']);
     }
 


### PR DESCRIPTION
# Purpose

When the connection between our Frontend and API 

Fixes UML-2740

## Approach

When connections fail it raises an implementation of the ClientExceptionInterface. If one of these exceptions have been raised we can tell that the connection has failed. In this case we need to force the resulting exception to be a 502 error instead of a 500 

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
