### PR TITLE
UML-2700 NO ACTIVE CODES badge

### DIFF
--- a/service-front/app/features/actor-dashboard.feature
+++ b/service-front/app/features/actor-dashboard.feature
@@ -19,7 +19,7 @@ Feature: The user is able to see correct information on their dashboard
       | noActiveCodes                | code1Expiry | code2Expiry |
       | 2 active codes               |  +3weeks    | +3weeks     |
       | 1 active code                |  -1week     | +3weeks     |
-      | No organisations have access |  -1day      | -1week      |
+      | No active codes              |  -1day      | -1week      |
 
   @integration @ui
   Scenario: As a user I can see the number of active access codes an LPA has

--- a/service-front/app/features/context/UI/LpaContext.php
+++ b/service-front/app/features/context/UI/LpaContext.php
@@ -794,7 +794,7 @@ class LpaContext implements Context
         $this->ui->visit('/lpa/dashboard');
 
         $this->ui->assertPageAddress('/lpa/dashboard');
-        $this->ui->assertPageContainsText('No organisations have access');
+        $this->ui->assertPageNotContainsText('active codes');
     }
 
     /**

--- a/service-front/app/src/Actor/templates/actor/lpa-dashboard.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-dashboard.html.twig
@@ -68,6 +68,7 @@
                             {% set actorToken = lpaData['user-lpa-actor-token'] %}
                             {% set actorActive = lpaData['actorActive'] %}
                             {% set activeCodeCount = lpaData['activeCodeCount'] %}
+                            {% set shareCodes = lpaData['shareCodes'] %}
                             {% set caseSubtype = lpa.caseSubtype == 'pfa' ? 'Property and finance'| trans : 'Health and welfare'| trans %}
                             {% set applicationHasRestrictions = lpa.applicationHasRestrictions %}
                             {% set applicationHasGuidance = lpa.applicationHasGuidance %}

--- a/service-front/app/src/Actor/templates/actor/partials/lpa-details.html.twig
+++ b/service-front/app/src/Actor/templates/actor/partials/lpa-details.html.twig
@@ -28,8 +28,10 @@
             <span class="moj-badge moj-badge--large moj-badge--blue govuk-!-margin-bottom-2">
                 {% trans count activeCodeCount %}%count% active code|%count% active codes{% endtrans %}
             </span>
-        {% elseif actorActive %}
-            <span class="govuk-hint govuk-!-margin-bottom-2 govuk-!-font-size-16 govuk-!-font-weight-bold">{% trans %}No organisations have access{% endtrans %}</span>
+        {% elseif actorActive and shareCodes|length > 1 %}
+            <span class="moj-badge moj-badge--large moj-badge--grey govuk-!-margin-bottom-2">
+                {% trans  %}No active codes{% endtrans %}
+            </span>
         {% endif %}
     </div>
 </div>

--- a/service-front/app/src/Actor/templates/actor/partials/lpa-details.html.twig
+++ b/service-front/app/src/Actor/templates/actor/partials/lpa-details.html.twig
@@ -28,6 +28,7 @@
             <span class="moj-badge moj-badge--large moj-badge--blue govuk-!-margin-bottom-2">
                 {% trans count activeCodeCount %}%count% active code|%count% active codes{% endtrans %}
             </span>
+        {# shareCodes array contains activecodecount as an item so we need to factor in this when checking if empty #}
         {% elseif actorActive and shareCodes|length > 1 %}
             <span class="moj-badge moj-badge--large moj-badge--grey govuk-!-margin-bottom-2">
                 {% trans  %}No active codes{% endtrans %}

--- a/service-front/app/src/Common/src/Service/Lpa/PopulateLpaMetadata.php
+++ b/service-front/app/src/Common/src/Service/Lpa/PopulateLpaMetadata.php
@@ -40,6 +40,7 @@ class PopulateLpaMetadata
             );
 
             $lpas->$lpaKey->activeCodeCount = $shareCodes->activeCodeCount;
+            $lpas->$lpaKey->shareCodes = $shareCodes;
             $lpas->$lpaKey->actorActive     =
                 $lpaData['actor']['type'] === 'donor' || $lpaData['actor']['details']->getSystemStatus();
         }


### PR DESCRIPTION
# Purpose

Replace "No organisations have access" with badge that says no active codes. When no codes have been made at all this area is blank

Fixes UML-2700

## Approach

add access to share codes in PopulateLPAMetadata access length of this array in twig template 

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [x] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [] The product team have tested these changes


[UML-2700]: https://opgtransform.atlassian.net/browse/UML-2700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ