### PR TITLE
add lock timeout to plan command. 

### DIFF
--- a/.github/workflows/_run-terraform.yml
+++ b/.github/workflows/_run-terraform.yml
@@ -118,7 +118,7 @@ jobs:
           TF_VAR_admin_container_version: ${{ steps.version-output.outputs.admin-tag }}
         run: |
           terraform workspace show
-          terraform plan -input=false -parallelism=30
+          terraform plan -input=false -parallelism=30 -lock-timeout=5m
         working-directory: terraform/${{ inputs.terraform_path }}
 
       - name: add TTL to dynamodb for environment


### PR DESCRIPTION
# Purpose

If TF lock is in conflict currently this fails the PR straight away. Adding a timeout will allow the PR to wait up to 5 minutes before failing. If the lock becomes available again in this time the TF plan should go ahead.

## Learning

https://developer.hashicorp.com/terraform/cli/commands/plan#lock-timeout-duration:~:text=%2Dlock%2Dtimeout%3DDURATION)

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
