### PR TITLE
UML-2429: Verify that the Cross-Origin Resource Sharing (CORS) Access-Control-Allow-Origin header uses a strict allow list of trusted domains

### DIFF
--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -44,6 +44,7 @@ server {
     add_header X-Content-Type-Options "nosniff";
     add_header Strict-Transport-Security "max-age=3600; includeSubDomains";
     add_header Referrer-Policy "same-origin";
+    #add_header 'Access-Control-Allow-Origin' '*';
 
     location / {
         root    /web;
@@ -55,6 +56,18 @@ server {
             access_log off;
         }
         try_files $uri /index.php$is_args$args;
+
+        set $cors '';
+        if ($http_origin ~ '^https?://(localhost|www\.gov\.uk|www\.use-lasting-power-of-attorney.service.gov.uk|www\.view-lasting-power-of-attorney.service.gov.uk\)') {
+                set $cors 'true';
+        }
+    }
+
+
+    if ($cors = 'true') {
+        add_header 'Access-Control-Allow-Origin' "$http_origin" always;
+        add_header 'Access-Control-Allow-Credentials' 'true' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
     }
 
     # serve noindex, nofollow meta tag on each page so that search engines do not index this domain

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -14,7 +14,9 @@ log_format json_combined escape=json
         '"request_time":"$request_time",'
         '"http_referrer":"$http_referer",'
         '"http_user_agent":"$http_user_agent",'
-        '"request_id":"$trace_id"'
+        '"request_id":"$trace_id",'
+        '"http_host":"$http_host",'
+        '"http_origin": "$http_origin"'
     '}';
 
 # ensures that the trace id always has a value, used mostly for
@@ -22,6 +24,16 @@ log_format json_combined escape=json
 map $http_x_amzn_trace_id $trace_id {
     "~*Root=" $http_x_amzn_trace_id;
     default "Root=1-$msec-$connection$connection_requests";
+}
+
+map $http_host $cors_origin_header {
+    default "";
+    "~localhost:9002" "$http_host";
+    "~^https://use-lasting-power-of-attorney.service.gov.uk" "$http_origin";
+    "~^https://view-lasting-power-of-attorney.service.gov.uk" "$http_origin";
+   #not getting regex to work
+   # "~(^http:\/\/)(localhost:[0-9]{1,4})|(localhost:[0-9]{1,4})" "$http_host";
+   # "~^https://"{{ getv "/app/port" }} "$http_origin";
 }
 
 server {
@@ -45,6 +57,11 @@ server {
     add_header Strict-Transport-Security "max-age=3600; includeSubDomains";
     add_header Referrer-Policy "same-origin";
 
+    add_header Access-Control-Allow-Origin $cors_origin_header always;
+    add_header Access-Control-Allow-Credentials 'true' always;
+    add_header Access-Control-Allow-Methods "GET, POST, OPTIONS, HEAD";
+    add_header Access-Control-Allow-Headers "Authorization, Origin, X-Requested-With, Content-Type, Accept";
+
     location / {
         root    /web;
 
@@ -58,15 +75,8 @@ server {
 
         #set $cors '';
         #if ($http_origin ~ '^https?://(localhost|www\.gov\.uk|www\.use-lasting-power-of-attorney.service.gov.uk|www\.view-lasting-power-of-attorney.service.gov.uk\)') {
-                set $cors 'true';
+        #       set $cors 'true';
         #}
-    }
-
-
-    if ($cors = 'true') {
-        add_header 'Access-Control-Allow-Origin' "$http_origin" always;
-        add_header 'Access-Control-Allow-Credentials' 'true' always;
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, HEAD, OPTIONS' always;
     }
 
     # serve noindex, nofollow meta tag on each page so that search engines do not index this domain

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -44,7 +44,6 @@ server {
     add_header X-Content-Type-Options "nosniff";
     add_header Strict-Transport-Security "max-age=3600; includeSubDomains";
     add_header Referrer-Policy "same-origin";
-    #add_header 'Access-Control-Allow-Origin' '*';
 
     location / {
         root    /web;
@@ -57,17 +56,17 @@ server {
         }
         try_files $uri /index.php$is_args$args;
 
-        set $cors '';
-        if ($http_origin ~ '^https?://(localhost|www\.gov\.uk|www\.use-lasting-power-of-attorney.service.gov.uk|www\.view-lasting-power-of-attorney.service.gov.uk\)') {
+        #set $cors '';
+        #if ($http_origin ~ '^https?://(localhost|www\.gov\.uk|www\.use-lasting-power-of-attorney.service.gov.uk|www\.view-lasting-power-of-attorney.service.gov.uk\)') {
                 set $cors 'true';
-        }
+        #}
     }
 
 
     if ($cors = 'true') {
         add_header 'Access-Control-Allow-Origin' "$http_origin" always;
         add_header 'Access-Control-Allow-Credentials' 'true' always;
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, HEAD, OPTIONS' always;
     }
 
     # serve noindex, nofollow meta tag on each page so that search engines do not index this domain

--- a/terraform/environment/actor_ecs.tf
+++ b/terraform/environment/actor_ecs.tf
@@ -195,6 +195,10 @@ locals {
           value = "60"
         },
         {
+          name  = "APP_DOMAIN",
+          value = aws_route53_record.public_facing_use_lasting_power_of_attorney.fqdn
+        },
+        {
           name  = "CONTAINER_VERSION",
           value = var.container_version
       }]

--- a/terraform/environment/viewer_ecs.tf
+++ b/terraform/environment/viewer_ecs.tf
@@ -192,6 +192,10 @@ locals {
           value = "9000"
         },
         {
+          name  = "APP_DOMAIN",
+          value = aws_route53_record.public_facing_view_lasting_power_of_attorney.fqdn
+        },
+        {
           name  = "TIMEOUT",
           value = "60"
         },

--- a/tests/features/security-headers.feature
+++ b/tests/features/security-headers.feature
@@ -18,3 +18,9 @@ Feature: Headers to increase service security
     When I access the service homepage
     Then I receive headers that cause the browser to not inform the destination site any URL information
 
+  @smoke
+  Scenario: Verify that a suitable CORS header is included
+    When I access the service homepage from localhost:9002
+    Then I see headers that ensures avoiding everyone freely accessing any resources of that domain
+
+

--- a/tests/smoke/context/CommonContext.php
+++ b/tests/smoke/context/CommonContext.php
@@ -32,6 +32,14 @@ class CommonContext implements Context
     }
 
     /**
+     * @When I access the service homepage from (.*)
+     */
+    public function iAccessTheServiceHomepageFromLocalhost($local): void
+    {
+        $this->ui->visit('http://localhost:9002/');
+    }
+
+    /**
      * @Given I access the service homepage insecurely
      * @Given I access the viewer service insecurely
      * @Given I access the actor service insecurely
@@ -230,6 +238,19 @@ class CommonContext implements Context
 
         Assert::assertNotNull($referrerPolicyTag);
         Assert::assertStringContainsString('same-origin', $referrerPolicyTag);
+    }
+
+    /**
+     * @Then /^I see headers that ensures avoiding everyone freely accessing any resources of that domain$/
+     */
+    public function iReceiveHeadersThatEnsuresAvoidingEveryoneFreelyAccessingAnyResourcesOfThatDomain()
+    {
+        $session = $this->ui->getSession();
+
+        $referrerPolicyTag = $session->getResponseHeader("Access-Control-Allow-Origin");
+
+        Assert::assertNotNull($referrerPolicyTag);
+        Assert::assertStringContainsString('localhost:9002', $referrerPolicyTag);
     }
 
     /**


### PR DESCRIPTION
# Purpose

https://opgtransform.atlassian.net/browse/UML-2429

Fixes UML-2429

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
