### PR TITLE
Move JS script tag to bottom of document

### DIFF
--- a/service-front/app/src/Common/templates/layout/default.html.twig
+++ b/service-front/app/src/Common/templates/layout/default.html.twig
@@ -25,7 +25,6 @@
         window.gaConfig = {};
         window.gaConfig.uaId = "{{ uaId }}";
     </script>
-    <script async src="{{ asset('index.js') }}"></script>
 
 
     {% if application == 'actor' %}
@@ -172,6 +171,7 @@
     </div>
 </footer>
 
+<script async src="{{ asset('index.js') }}"></script>
 {% block javascript %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
# Purpose

We do not use onload events and JS loads quicker than the DOM being rendered. Moving the script tag to the bottom of the document ensures the JS is preloaded but not executed until the DOM is parsed and rendered.

Fixes UML-2788

## Approach

Move JS script tag to bottom of document

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
