### PR TITLE
UML-2793: Number of access code views should look at event viewer codes viewed

### DIFF
--- a/service-admin/web/templates/stats.page.gohtml
+++ b/service-admin/web/templates/stats.page.gohtml
@@ -89,7 +89,7 @@
   <tr>
     <th scope="col" class="govuk-table__header">Number of access code Views</th>
     {{ range .Result }}
-      <th scope="col" class="govuk-table__header">{{ .view_lpa_share_code_success_event }}</th>
+      <th scope="col" class="govuk-table__header">{{ .viewer_codes_viewed }}</th>
     {{ end }}
   </tr>
   </thead>

--- a/service-api/seeding/dynamodb.py
+++ b/service-api/seeding/dynamodb.py
@@ -217,7 +217,8 @@ stats = [
         'account_created_event': 30,
         'account_deleted_event': 30,
         'account_activated_event': 20,
-        'viewer_codes_created': 10
+        'viewer_codes_created': 10,
+        'viewer_codes_viewed' : 5
     },
     {
         'TimePeriod': (datetime.date.today() - relativedelta(months=4)).strftime('%Y-%m'),
@@ -226,7 +227,8 @@ stats = [
         'account_created_event': 3,
         'account_deleted_event': 2,
         'account_activated_event': 2,
-        'viewer_codes_created': 2
+        'viewer_codes_created': 2,
+        'viewer_codes_viewed' : 1
     },
     {
         'TimePeriod': (datetime.date.today() - relativedelta(months=3)).strftime('%Y-%m'),
@@ -235,7 +237,8 @@ stats = [
         'account_created_event': 5,
         'account_deleted_event': 1,
         'account_activated_event': 15,
-        'viewer_codes_created': 4
+        'viewer_codes_created': 4,
+        'viewer_codes_viewed' : 3
     },
     {
         'TimePeriod': (datetime.date.today() - relativedelta(months=2)).strftime('%Y-%m'),
@@ -244,7 +247,8 @@ stats = [
         'account_created_event': 12,
         'account_deleted_event': 3,
         'account_activated_event': 12,
-        'viewer_codes_created': 2
+        'viewer_codes_created': 2,
+        'viewer_codes_viewed' : 0
 
     },
     {
@@ -254,7 +258,8 @@ stats = [
         'account_created_event': 15,
         'account_deleted_event': 1,
         'account_activated_event': 9,
-        'viewer_codes_created': 1
+        'viewer_codes_created': 1,
+        'viewer_codes_viewed' : 0
     },
     {
         'TimePeriod': datetime.date.today().strftime('%Y-%m'),
@@ -263,7 +268,8 @@ stats = [
         'account_created_event': 6,
         'account_deleted_event': 4,
         'account_activated_event': 12,
-        'viewer_codes_created': 1
+        'viewer_codes_created': 1,
+        'viewer_codes_viewed' : 1
     }
 ]
 


### PR DESCRIPTION
# Purpose

https://opgtransform.atlassian.net/browse/UML-2793

Fixes UML-2793

## Approach

Number of access code views was looking at wrong event, code changed to now look at event viewer codes viewed event

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [X] I have performed a self-review of my own code
~* [ ] I have added relevant logging with appropriate levels to my code~
~* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
~* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
~* [ ] I have added tests to prove my work~
~* [ ] I have added welsh translation tags and updated translation files~
~* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
~* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* [ ] The product team have tested these changes
