### PR TITLE
UML-2778: show not applicable in email row when added lpa is deleted

### DIFF
--- a/service-admin/web/templates/result_code.partial.gohtml
+++ b/service-admin/web/templates/result_code.partial.gohtml
@@ -18,16 +18,21 @@
       </dd>
     </div>
 
-    {{ if .Email }}
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
         Email
       </dt>
-      <dd class="govuk-summary-list__value">
+      {{ if .Email }}
+        <dd class="govuk-summary-list__value">
           {{ .Email }}
-      </dd>
+        </dd>
+      {{ else }}
+        <dd class="govuk-summary-list__value">
+          Not applicable
+        </dd>    
+      {{ end }}
     </div>
-    {{ end }}
+    
 
     {{ if .ActivationKey }}
 


### PR DESCRIPTION

# Purpose

https://opgtransform.atlassian.net/browse/UML-2778

Fixes UML-2778

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [X] I have performed a self-review of my own code
~* [ ] I have added relevant logging with appropriate levels to my code~
~* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
~* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
~* [ ] I have added tests to prove my work~
~* [ ] I have added welsh translation tags and updated translation files~
~* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
~* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* [ ] The product team have tested these changes
