### PR TITLE
fix missing trivy sarif file when step fails due to unit tests

### DIFF
--- a/.github/workflows/_build-and-push.yml
+++ b/.github/workflows/_build-and-push.yml
@@ -241,7 +241,8 @@ jobs:
         id: trivy_upload_sarif
         uses: github/codeql-action/upload-sarif@v2
         if: |
-          always() && (inputs.specific_path == 'all' || inputs.specific_path == matrix.svc_prefix)
+          (steps.trivy_scan.outcome == 'success' || steps.trivy_scan.outcome == 'failure') &&
+          (inputs.specific_path == 'all' || inputs.specific_path == matrix.svc_prefix)
         with:
           sarif_file: 'trivy-results.sarif'
 


### PR DESCRIPTION
# Purpose

fix missing trivy file scans when unit tests fail

## Approach

try the newish outcome syntax.

## Learning

NA

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
