### PR TITLE
Uml 2467 improve password hashing

### DIFF
--- a/service-api/app/features/context/Acceptance/AccountContext.php
+++ b/service-api/app/features/context/Acceptance/AccountContext.php
@@ -54,7 +54,7 @@ class AccountContext implements Context
                 $this->marshalAwsResultData([
                     'Id'        => $this->base->userAccountId,
                     'Email'     => $this->base->userAccountEmail,
-                    'Password'  => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT),
+                    'Password'  => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
                     'LastLogin' => null,
                 ]),
             ],
@@ -124,7 +124,7 @@ class AccountContext implements Context
                 $this->marshalAwsResultData([
                     'Id'        => $this->base->userAccountId,
                     'Email'     => $this->base->userAccountEmail,
-                    'Password'  => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT),
+                    'Password'  => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
                     'LastLogin' => null,
                 ]),
             ],
@@ -157,7 +157,7 @@ class AccountContext implements Context
                 $this->marshalAwsResultData([
                     'Id'              => $this->base->userAccountId,
                     'Email'           => $this->base->userAccountEmail,
-                    'Password'        => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT),
+                    'Password'        => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
                     'LastLogin'       => null,
                     'ActivationToken' => 'a12b3c4d5e',
                 ]),
@@ -690,7 +690,7 @@ class AccountContext implements Context
         $this->awsFixtures->append(new Result([
             'Item' => $this->marshalAwsResultData([
                 'Id'       => $this->base->userAccountId,
-                'Password' => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT),
+                'Password' => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
             ]),
         ]));
 
@@ -729,7 +729,7 @@ class AccountContext implements Context
         $this->awsFixtures->append(new Result([
             'Item' => $this->marshalAwsResultData([
                 'Id'       => $this->base->userAccountId,
-                'Password' => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT),
+                'Password' => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
             ]),
         ]));
 
@@ -797,7 +797,7 @@ class AccountContext implements Context
             'Item' => $this->marshalAwsResultData([
                 'Id'       => $this->base->userAccountId,
                 'Email'    => $this->base->userAccountEmail,
-                'Password' => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT),
+                'Password' => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
             ]),
         ]));
 
@@ -836,7 +836,7 @@ class AccountContext implements Context
             'Item' => $this->marshalAwsResultData([
                 'Id'       => $this->base->userAccountId,
                 'Email'    => $this->base->userAccountEmail,
-                'Password' => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT),
+                'Password' => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
             ]),
         ]));
 
@@ -865,7 +865,7 @@ class AccountContext implements Context
             'Item' => $this->marshalAwsResultData([
                 'Id'       => $this->base->userAccountId,
                 'Email'    => $this->base->userAccountEmail,
-                'Password' => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT),
+                'Password' => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
             ]),
         ]));
 
@@ -993,7 +993,7 @@ class AccountContext implements Context
             'Item' => $this->marshalAwsResultData([
                 'Id'       => $this->base->userAccountId,
                 'Email'    => $this->base->userAccountEmail,
-                'Password' => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT),
+                'Password' => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
             ]),
         ]));
 
@@ -1064,7 +1064,7 @@ class AccountContext implements Context
             'Item' => $this->marshalAwsResultData([
                 'Id'               => $this->base->userAccountId,
                 'Email'            => $this->base->userAccountEmail,
-                'Password'         => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT),
+                'Password'         => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
                 'EmailResetExpiry' => time() + (60 * 60),
                 'LastLogin'        => null,
                 'NewEmail'         => $this->newEmail,
@@ -1099,7 +1099,7 @@ class AccountContext implements Context
             'Item' => $this->marshalAwsResultData([
                 'Id'               => $this->base->userAccountId,
                 'Email'            => $this->base->userAccountEmail,
-                'Password'         => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT),
+                'Password'         => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
                 'EmailResetExpiry' => time() + (60 * 60),
                 'LastLogin'        => null,
                 'NewEmail'         => $this->newEmail,
@@ -1159,7 +1159,7 @@ class AccountContext implements Context
             'Item' => $this->marshalAwsResultData([
                 'Id'               => $this->base->userAccountId,
                 'Email'            => $this->base->userAccountEmail,
-                'Password'         => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT),
+                'Password'         => password_hash($this->base->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
                 'EmailResetExpiry' => time() - (60 * 60),
                 'LastLogin'        => null,
                 'NewEmail'         => $this->newEmail,
@@ -1218,7 +1218,7 @@ class AccountContext implements Context
                 $this->marshalAwsResultData([
                     'Id'               => $this->base->userAccountId,
                     'Email'            => 'other@user.co.uk',
-                    'Password'         => password_hash('passW0rd', PASSWORD_DEFAULT),
+                    'Password'         => password_hash('passW0rd', PASSWORD_DEFAULT, ['cost' => 13]),
                     'EmailResetExpiry' => time() + (60 * 60),
                     'LastLogin'        => null,
                     'NewEmail'         => 'test@test.com',

--- a/service-api/app/features/context/Integration/AccountContext.php
+++ b/service-api/app/features/context/Integration/AccountContext.php
@@ -78,7 +78,7 @@ class AccountContext extends BaseIntegrationContext
                             [
                                 'Id' => $this->userAccountId,
                                 'Email' => $this->userAccountEmail,
-                                'Password' => password_hash($this->password, PASSWORD_DEFAULT),
+                                'Password' => password_hash($this->password, PASSWORD_DEFAULT, ['cost' => 13]),
                                 'LastLogin' => null,
                             ]
                         ),
@@ -194,7 +194,7 @@ class AccountContext extends BaseIntegrationContext
                             [
                                 'Id' => $this->userAccountId,
                                 'Email' => $this->userAccountEmail,
-                                'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT),
+                                'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
                                 'LastLogin' => null,
                                 'ActivationToken' => 'a12b3c4d5e',
                             ]
@@ -234,7 +234,7 @@ class AccountContext extends BaseIntegrationContext
                             [
                                 'Id' => $this->userAccountId,
                                 'Email' => $this->userAccountEmail,
-                                'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT),
+                                'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
                                 'LastLogin' => null,
                             ]
                         ),
@@ -362,7 +362,7 @@ class AccountContext extends BaseIntegrationContext
                     'Item' => $this->marshalAwsResultData(
                         [
                             'Id' => $this->userAccountId,
-                            'Password' => password_hash($failedPassword, PASSWORD_DEFAULT),
+                            'Password' => password_hash($failedPassword, PASSWORD_DEFAULT, ['cost' => 13]),
                         ]
                     ),
                 ]
@@ -488,7 +488,7 @@ class AccountContext extends BaseIntegrationContext
                         [
                             'Id' => $this->userAccountId,
                             'Email' => $this->userAccountEmail,
-                            'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT),
+                            'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
                             'EmailResetExpiry' => time() + (60 * 60),
                             'LastLogin' => null,
                             'NewEmail' => $this->newEmail,
@@ -535,7 +535,7 @@ class AccountContext extends BaseIntegrationContext
                         [
                             'Id' => $this->userAccountId,
                             'Email' => $this->userAccountEmail,
-                            'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT),
+                            'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
                             'EmailResetExpiry' => (time() + (60 * 60)),
                             'LastLogin' => null,
                             'NewEmail' => $this->newEmail,
@@ -587,7 +587,7 @@ class AccountContext extends BaseIntegrationContext
                         [
                             'Id' => $this->userAccountId,
                             'Email' => $this->userAccountEmail,
-                            'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT),
+                            'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
                             'EmailResetExpiry' => (time() - (60 * 60)),
                             'LastLogin' => null,
                             'NewEmail' => $this->newEmail,
@@ -831,7 +831,7 @@ class AccountContext extends BaseIntegrationContext
                             [
                                 'Id' => '123456789',
                                 'Email' => 'other@user.co.uk',
-                                'Password' => password_hash('passW0rd', PASSWORD_DEFAULT),
+                                'Password' => password_hash('passW0rd', PASSWORD_DEFAULT, ['cost' => 13]),
                                 'EmailResetExpiry' => (time() + (60 * 60)),
                                 'LastLogin' => null,
                                 'NewEmail' => 'test@test.com',
@@ -1131,7 +1131,7 @@ class AccountContext extends BaseIntegrationContext
                     'Item' => $this->marshalAwsResultData(
                         [
                             'Id' => $this->userAccountId,
-                            'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT),
+                            'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
                         ]
                     ),
                 ]
@@ -1188,7 +1188,7 @@ class AccountContext extends BaseIntegrationContext
                         [
                             'Id' => $this->userAccountId,
                             'Email' => $this->userAccountEmail,
-                            'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT),
+                            'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
                         ]
                     ),
                 ]
@@ -1234,7 +1234,7 @@ class AccountContext extends BaseIntegrationContext
                         [
                             'Id' => $this->userAccountId,
                             'Email' => $this->userAccountEmail,
-                            'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT),
+                            'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
                         ]
                     ),
                 ]
@@ -1359,7 +1359,7 @@ class AccountContext extends BaseIntegrationContext
                         [
                             'Id' => $this->userAccountId,
                             'Email' => $this->userAccountEmail,
-                            'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT),
+                            'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
                         ]
                     ),
                 ]
@@ -1508,7 +1508,7 @@ class AccountContext extends BaseIntegrationContext
                         [
                             'Id' => $this->userAccountId,
                             'Email' => $this->userAccountEmail,
-                            'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT),
+                            'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
                         ]
                     ),
                 ]
@@ -1523,7 +1523,7 @@ class AccountContext extends BaseIntegrationContext
                         [
                             'Id' => $this->userAccountId,
                             'Email' => $this->userAccountEmail,
-                            'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT),
+                            'Password' => password_hash($this->userAccountPassword, PASSWORD_DEFAULT, ['cost' => 13]),
                             'LastLogin' => null,
                         ]
                     ),

--- a/service-api/app/src/App/src/DataAccess/Repository/ActorUsersInterface.php
+++ b/service-api/app/src/App/src/DataAccess/Repository/ActorUsersInterface.php
@@ -161,4 +161,16 @@ interface ActorUsersInterface
      * @return mixed
      */
     public function resetActivationDetails(string $id, HiddenString $password, int $activationTtl): array;
+
+    /**
+     * updates the password field of a user with the supplied password. This is intended
+     * to be used as a part of the password rehashing that occurs to keep us up to date with
+     * standards
+     *
+     * @param string       $id
+     * @param HiddenString $password
+     *
+     * @return bool
+     */
+    public function rehashPassword(string $id, HiddenString $password): bool;
 }

--- a/service-api/app/src/App/src/Service/User/UserService.php
+++ b/service-api/app/src/App/src/Service/User/UserService.php
@@ -423,7 +423,7 @@ class UserService
 
     public function completeChangeEmail(string $resetToken): void
     {
-        $userId = $this->usersRepository->  getIdByEmailResetToken($resetToken);
+        $userId = $this->usersRepository->getIdByEmailResetToken($resetToken);
 
         $user = $this->usersRepository->get($userId);
 

--- a/service-api/app/src/App/src/Service/User/UserService.php
+++ b/service-api/app/src/App/src/Service/User/UserService.php
@@ -62,14 +62,14 @@ class UserService
         if (!empty($emailResetExists) && !$this->checkIfEmailResetViable($emailResetExists, true)) {
             //checks if the new email chosen has already been requested for reset
             $this->logger->notice(
-                'Could not create account with email {email} as another user has already requested to
-                change their email that email address',
+                'Could not create account with email {email} as another user has already requested to ' .
+                    'change their email that email address',
                 ['email' => $data['email']]
             );
 
             throw new ConflictException(
-                'Account creation email conflict - another user has requested to change their
-                email to ' . $data['email'],
+                'Account creation email conflict - another user has requested to change their ' .
+                    'email to ' . $data['email'],
                 ['email' => $data['email']]
             );
         }

--- a/service-api/app/src/App/src/Service/User/UserService.php
+++ b/service-api/app/src/App/src/Service/User/UserService.php
@@ -158,6 +158,9 @@ class UserService
             (new DateTime('now'))->format(DateTimeInterface::ATOM)
         );
 
+        // Ensure we don't return our Password over the wire.
+        unset($user['Password']);
+
         $this->logger->info(
             'Authentication successful for account with Id {id}',
             [

--- a/service-api/app/test/AppTest/Service/User/UserServiceTest.php
+++ b/service-api/app/test/AppTest/Service/User/UserServiceTest.php
@@ -221,13 +221,13 @@ class UserServiceTest extends TestCase
             [
                 'Id'        => '1234-1234-1234',
                 'Email'     => 'a@b.com',
-                'Password'  => self::PASS_HASH,
                 'LastLogin' => '2020-01-01',
             ],
             $return
         );
     }
 
+    /** @test */
     public function will_update_the_password_hash_on_successful_authentication(): void
     {
         $repoProphecy   = $this->prophesize(ActorUsersInterface::class);
@@ -245,6 +245,8 @@ class UserServiceTest extends TestCase
         $repoProphecy->rehashPassword('1234-1234-1234', Argument::any())
             ->shouldBeCalled()
             ->willReturn(true);
+        $repoProphecy->recordSuccessfulLogin('1234-1234-1234', Argument::any())
+            ->shouldBeCalled();
 
         $us = new UserService($repoProphecy->reveal(), $loggerProphecy->reveal());
 
@@ -254,7 +256,6 @@ class UserServiceTest extends TestCase
             [
                 'Id'        => '1234-1234-1234',
                 'Email'     => 'a@b.com',
-                'Password'  => self::PASS_HASH,
                 'LastLogin' => '2020-01-01',
             ],
             $return


### PR DESCRIPTION
# Purpose

Verify that if bcrypt is used, the work factor SHOULD be as large as verification server performance will allow, typically at least 13

Fixes UML-2467

## Approach

Increase the work factor for the PHP password hashing and implement a technique for updating users stored passwords to the new hashing scheme when they successfully login.

## Learning

Turns out that PHPs standard hashing option is for a work factor of 10. 

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* The product team have tested these changes
