### PR TITLE
UML-2825: Names in Iphone with ' need to be accepted when requesting activation key

### DIFF
--- a/mock-integrations/mock-openapi.yaml
+++ b/mock-integrations/mock-openapi.yaml
@@ -162,7 +162,7 @@ paths:
                         id: 25
                         middlenames: ""
                         salutation: Mr
-                        surname: M'atthews
+                        surname: M’atthews
                         systemStatus: true
                         uId: 7000-0000-0997
                       - addresses:
@@ -352,7 +352,7 @@ paths:
                           uId: 7000-0000-0971
                       middlenames: Suzanne
                       salutation: Mrs
-                      surname: Gilson
+                      surname: O’Gilson
                       uId: 7000-0000-0971
                     id: 5
                     invalidDate: null

--- a/mock-integrations/mock-openapi.yaml
+++ b/mock-integrations/mock-openapi.yaml
@@ -162,7 +162,7 @@ paths:
                         id: 25
                         middlenames: ""
                         salutation: Mr
-                        surname: Matthews
+                        surname: M'atthews
                         systemStatus: true
                         uId: 7000-0000-0997
                       - addresses:

--- a/service-api/app/features/context/Acceptance/LpaContext.php
+++ b/service-api/app/features/context/Acceptance/LpaContext.php
@@ -102,7 +102,7 @@ class LpaContext implements Context
 
         $this->userPostCode          = 'string';
         $this->userFirstnames        = 'Ian Deputy';
-        $this->userSurname           = 'Deputy';
+        $this->userSurname           = 'D"eputy';
         $this->lpa->registrationDate = '2019-09-01';
         $this->userDob               = '1975-10-05';
     }

--- a/service-api/app/features/context/Acceptance/LpaContext.php
+++ b/service-api/app/features/context/Acceptance/LpaContext.php
@@ -102,7 +102,7 @@ class LpaContext implements Context
 
         $this->userPostCode          = 'string';
         $this->userFirstnames        = 'Ian Deputy';
-        $this->userSurname           = 'D"eputy';
+        $this->userSurname           = 'D’eputy';
         $this->lpa->registrationDate = '2019-09-01';
         $this->userDob               = '1975-10-05';
     }

--- a/service-api/app/features/context/Integration/LpaContext.php
+++ b/service-api/app/features/context/Integration/LpaContext.php
@@ -1863,12 +1863,14 @@ class LpaContext extends BaseIntegrationContext
      */
     public function iProvideTheDetailsFromAValidPaperDocumentThatAlreadyHasAnActivationKey(): void
     {
+        $userSurname = 'D’eputy';
+
         $data = [
             'reference_number'     => $this->lpaUid,
             'dob'                  => $this->userDob,
             'postcode'             => $this->userPostCode,
             'first_names'          => $this->userFirstname,
-            'last_name'            => $this->userSurname,
+            'last_name'            => $userSurname,
             'force_activation_key' => false,
         ];
 
@@ -2670,6 +2672,7 @@ class LpaContext extends BaseIntegrationContext
      */
     public function iProvideTheDetailsFromAValidPaperLPAWhichIHaveAlreadyAddedToMyAccount(): void
     {
+        //$userSurname  = 'D’eputy';
         $differentLpa = json_decode(file_get_contents(__DIR__ . '../../../../test/fixtures/test_lpa.json'));
 
         $data = [
@@ -2790,6 +2793,7 @@ class LpaContext extends BaseIntegrationContext
      */
     public function iProvideTheDetailsFromAValidPaperLPAWhichIHaveAlreadyRequestedAnActivationKeyFor(): void
     {
+        $userSurname = 'D’eputy';
         $createdDate = (new DateTime())->modify('-14 days');
 
         $data = [
@@ -2797,7 +2801,7 @@ class LpaContext extends BaseIntegrationContext
             'dob'                  => $this->userDob,
             'postcode'             => $this->userPostCode,
             'first_names'          => $this->userFirstname,
-            'last_name'            => $this->userSurname,
+            'last_name'            => $userSurname,
             'force_activation_key' => false,
         ];
 

--- a/service-api/app/src/App/src/Service/Lpa/AddOlderLpa.php
+++ b/service-api/app/src/App/src/Service/Lpa/AddOlderLpa.php
@@ -77,7 +77,7 @@ class AddOlderLpa
                 $this->logger->notice(
                     'User {id} attempted to request a key for the LPA {uId} which already exists in their account',
                     [
-                        'id' => $userId,
+                        'id'  => $userId,
                         'uId' => $matchData['reference_number'],
                     ]
                 );

--- a/service-api/app/src/App/src/Service/Lpa/FindActorInLpa.php
+++ b/service-api/app/src/App/src/Service/Lpa/FindActorInLpa.php
@@ -152,24 +152,24 @@ class FindActorInLpa
      */
     private function normaliseComparisonData(array $data): ?array
     {
-        $data['first_names'] = $this->removeSpecialCharacters(
+        $data['first_names'] = $this->turnUnicodeCharToAscii(
             strtolower(explode(' ', $data['first_names'])[0])
         );
-        $data['last_name']   = $this->removeSpecialCharacters(strtolower($data['last_name']));
-        $data['postcode']    = $this->removeSpecialCharacters(strtolower($data['postcode']));
+        $data['last_name']   = $this->turnUnicodeCharToAscii(strtolower($data['last_name']));
+        $data['postcode']    = strtolower(str_replace(' ', '', $data['postcode']));
 
         return $data;
     }
 
     /**
-     * Removes special characters in given string
+     * Replace any unicode apostrophe's in string to an ascii [introduced to resolve iphone entry issue]
      *
      * @param string $string
      * @return string
      */
-    private function removeSpecialCharacters(string $string): string
+    private function turnUnicodeCharToAscii(string $string): string
     {
-        $charsToRemove = ['\'', '"', ',', ';', '-', '.', ' '];
-        return str_ireplace($charsToRemove, '', $string);
+        $charsToReplace = ['’'];
+        return str_ireplace($charsToReplace, '\'', $string);
     }
 }

--- a/service-api/app/test/AppTest/Service/Lpa/FindActorInLpaTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/FindActorInLpaTest.php
@@ -31,7 +31,7 @@ class FindActorInLpaTest extends TestCase
     public function returns_actor_and_lpa_details_if_match_found(?array $expectedResponse, array $userData): void
     {
         $lpa = [
-            'uId' => '700000012345',
+            'uId' => '700000012346',
             'donor' => [
                 'uId'       => '700000001111',
                 'dob'       => '1975-10-05',
@@ -87,7 +87,7 @@ class FindActorInLpaTest extends TestCase
                     'uId'       => '700000001234',
                     'dob'       => '1980-03-01',
                     'firstname' => 'Test',
-                    'surname'   => 'Testing',
+                    'surname'   => 'T\'esting',
                     'addresses' => [
                         [
                             'postcode' => 'Ab1 2Cd'
@@ -155,7 +155,7 @@ class FindActorInLpaTest extends TestCase
                     'uId'       => '700000001234',
                     'dob'       => '1980-03-01',
                     'firstname' => 'Test',
-                    'surname'   => 'Testing',
+                    'surname'   => 'T\'esting',
                     'addresses' => [
                         [
                             'postcode' => 'Ab1 2Cd'
@@ -171,6 +171,7 @@ class FindActorInLpaTest extends TestCase
         );
 
         $matchData = $sut($lpa, $userData);
+
         $this->assertEquals($expectedResponse, $matchData);
     }
 
@@ -183,7 +184,7 @@ class FindActorInLpaTest extends TestCase
                         'uId'       => '700000001234',
                         'dob'       => '1980-03-01',
                         'firstname' => 'Test',
-                        'surname'   => 'Testing',
+                        'surname'   => 'T\'esting',
                         'addresses' => [
                             [
                                 'postcode' => 'Ab1 2Cd'
@@ -192,13 +193,13 @@ class FindActorInLpaTest extends TestCase
                         'systemStatus' => true,
                     ],
                     'role' => 'attorney', // successful match for attorney
-                    'lpa-id'    => '700000012345'
+                    'lpa-id'    => '700000012346'
                 ],
                 [
                     'reference_number' => '700000000001',
                     'dob'         => '1980-03-01',
                     'first_names' => 'Test Tester',
-                    'last_name'   => 'T’esting',
+                    'last_name'   => 'T\'esting',
                     'postcode'    => 'Ab1 2Cd'
                 ],
             ],
@@ -216,7 +217,7 @@ class FindActorInLpaTest extends TestCase
                         ]
                     ],
                     'role' => 'donor', // successful match for donor
-                    'lpa-id'    => '700000012345'
+                    'lpa-id'    => '700000012346'
                 ],
                 [
                     'reference_number' => '700000000001',

--- a/service-api/app/test/AppTest/Service/Lpa/FindActorInLpaTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/FindActorInLpaTest.php
@@ -31,84 +31,84 @@ class FindActorInLpaTest extends TestCase
     public function returns_actor_and_lpa_details_if_match_found(?array $expectedResponse, array $userData): void
     {
         $lpa = [
-            'uId' => '700000012346',
-            'donor' => [
+            'uId'       => '700000012346',
+            'donor'     => [
                 'uId'       => '700000001111',
                 'dob'       => '1975-10-05',
                 'firstname' => 'Donor',
                 'surname'   => 'Person',
                 'addresses' => [
                     [
-                        'postcode' => 'PY1 3Kd'
-                    ]
-                ]
+                        'postcode' => 'PY1 3Kd',
+                    ],
+                ],
             ],
             'attorneys' => [
                 [
-                    'uId'       => '700000002222',
-                    'dob'       => '1977-11-21',
-                    'firstname' => 'Attorneyone',
-                    'surname'   => 'Person',
-                    'addresses' => [
+                    'uId'          => '700000002222',
+                    'dob'          => '1977-11-21',
+                    'firstname'    => 'Attorneyone',
+                    'surname'      => 'Person',
+                    'addresses'    => [
                         [
-                            'postcode' => 'Gg1 2ff'
-                        ]
+                            'postcode' => 'Gg1 2ff',
+                        ],
                     ],
                     'systemStatus' => false, // inactive attorney
                 ],
                 [
-                    'uId'       => '700000003333',
-                    'dob'       => '1960-05-05',
-                    'firstname' => '', // ghost attorney
-                    'surname'   => '',
-                    'addresses' => [
+                    'uId'          => '700000003333',
+                    'dob'          => '1960-05-05',
+                    'firstname'    => '', // ghost attorney
+                    'surname'      => '',
+                    'addresses'    => [
                         [
-                            'postcode' => 'BB1 9ee'
-                        ]
+                            'postcode' => 'BB1 9ee',
+                        ],
                     ],
                     'systemStatus' => true,
                 ],
                 [
-                    'uId'       => '700000004444',
-                    'dob'       => '1980-03-01',
-                    'firstname' => 'Attorneythree',
-                    'surname'   => 'Person',
-                    'addresses' => [ // multiple addresses
+                    'uId'          => '700000004444',
+                    'dob'          => '1980-03-01',
+                    'firstname'    => 'Attorneythree',
+                    'surname'      => 'Person',
+                    'addresses'    => [ // multiple addresses
                         [
-                            'postcode' => 'Ab1 2Cd'
+                            'postcode' => 'Ab1 2Cd',
                         ],
                         [
-                            'postcode' => 'Bc2 3Df'
-                        ]
+                            'postcode' => 'Bc2 3Df',
+                        ],
                     ],
                     'systemStatus' => true,
                 ],
                 [
-                    'uId'       => '700000001234',
-                    'dob'       => '1980-03-01',
-                    'firstname' => 'Test',
-                    'surname'   => 'T\'esting',
-                    'addresses' => [
+                    'uId'          => '700000001234',
+                    'dob'          => '1980-03-01',
+                    'firstname'    => 'Test',
+                    'surname'      => 'T\'esting',
+                    'addresses'    => [
                         [
-                            'postcode' => 'Ab1 2Cd'
-                        ]
+                            'postcode' => 'Ab1 2Cd',
+                        ],
                     ],
                     'systemStatus' => true,
-                ]
-            ]
+                ],
+            ],
         ];
 
         $this->getAttorneyStatusProphecy
             ->__invoke(
                 [
-                    'uId'       => '700000002222',
-                    'dob'       => '1977-11-21',
-                    'firstname' => 'Attorneyone',
-                    'surname'   => 'Person',
-                    'addresses' => [
+                    'uId'          => '700000002222',
+                    'dob'          => '1977-11-21',
+                    'firstname'    => 'Attorneyone',
+                    'surname'      => 'Person',
+                    'addresses'    => [
                         [
-                            'postcode' => 'Gg1 2ff'
-                        ]
+                            'postcode' => 'Gg1 2ff',
+                        ],
                     ],
                     'systemStatus' => false, // inactive attorney
                 ]
@@ -117,14 +117,14 @@ class FindActorInLpaTest extends TestCase
         $this->getAttorneyStatusProphecy
             ->__invoke(
                 [
-                    'uId'       => '700000003333',
-                    'dob'       => '1960-05-05',
-                    'firstname' => '', // ghost attorney
-                    'surname'   => '',
-                    'addresses' => [
+                    'uId'          => '700000003333',
+                    'dob'          => '1960-05-05',
+                    'firstname'    => '', // ghost attorney
+                    'surname'      => '',
+                    'addresses'    => [
                         [
-                            'postcode' => 'BB1 9ee'
-                        ]
+                            'postcode' => 'BB1 9ee',
+                        ],
                     ],
                     'systemStatus' => true,
                 ]
@@ -133,17 +133,17 @@ class FindActorInLpaTest extends TestCase
         $this->getAttorneyStatusProphecy
             ->__invoke(
                 [
-                    'uId'       => '700000004444',
-                    'dob'       => '1980-03-01',
-                    'firstname' => 'Attorneythree',
-                    'surname'   => 'Person',
-                    'addresses' => [ // multiple addresses
+                    'uId'          => '700000004444',
+                    'dob'          => '1980-03-01',
+                    'firstname'    => 'Attorneythree',
+                    'surname'      => 'Person',
+                    'addresses'    => [ // multiple addresses
                         [
-                            'postcode' => 'Ab1 2Cd'
+                            'postcode' => 'Ab1 2Cd',
                         ],
                         [
-                            'postcode' => 'Bc2 3Df'
-                        ]
+                            'postcode' => 'Bc2 3Df',
+                        ],
                     ],
                     'systemStatus' => true,
                 ]
@@ -152,14 +152,14 @@ class FindActorInLpaTest extends TestCase
         $this->getAttorneyStatusProphecy
             ->__invoke(
                 [
-                    'uId'       => '700000001234',
-                    'dob'       => '1980-03-01',
-                    'firstname' => 'Test',
-                    'surname'   => 'T\'esting',
-                    'addresses' => [
+                    'uId'          => '700000001234',
+                    'dob'          => '1980-03-01',
+                    'firstname'    => 'Test',
+                    'surname'      => 'T\'esting',
+                    'addresses'    => [
                         [
-                            'postcode' => 'Ab1 2Cd'
-                        ]
+                            'postcode' => 'Ab1 2Cd',
+                        ],
                     ],
                     'systemStatus' => true,
                 ]
@@ -180,113 +180,113 @@ class FindActorInLpaTest extends TestCase
         return [
             [
                 [
-                    'actor'     => [
-                        'uId'       => '700000001234',
-                        'dob'       => '1980-03-01',
-                        'firstname' => 'Test',
-                        'surname'   => 'T\'esting',
-                        'addresses' => [
+                    'actor'  => [
+                        'uId'          => '700000001234',
+                        'dob'          => '1980-03-01',
+                        'firstname'    => 'Test',
+                        'surname'      => 'T\'esting',
+                        'addresses'    => [
                             [
-                                'postcode' => 'Ab1 2Cd'
-                            ]
+                                'postcode' => 'Ab1 2Cd',
+                            ],
                         ],
                         'systemStatus' => true,
                     ],
-                    'role' => 'attorney', // successful match for attorney
-                    'lpa-id'    => '700000012346'
+                    'role'   => 'attorney', // successful match for attorney
+                    'lpa-id' => '700000012346',
                 ],
                 [
                     'reference_number' => '700000000001',
-                    'dob'         => '1980-03-01',
-                    'first_names' => 'Test Tester',
-                    'last_name'   => 'T\'esting',
-                    'postcode'    => 'Ab1 2Cd'
+                    'dob'              => '1980-03-01',
+                    'first_names'      => 'Test Tester',
+                    'last_name'        => 'T\'esting',
+                    'postcode'         => 'Ab1 2Cd',
                 ],
             ],
             [
                 [
-                    'actor'     => [
+                    'actor'  => [
                         'uId'       => '700000001111',
                         'dob'       => '1975-10-05',
                         'firstname' => 'Donor',
                         'surname'   => 'Person',
                         'addresses' => [
                             [
-                                'postcode' => 'PY1 3Kd'
-                            ]
-                        ]
+                                'postcode' => 'PY1 3Kd',
+                            ],
+                        ],
                     ],
-                    'role' => 'donor', // successful match for donor
-                    'lpa-id'    => '700000012346'
+                    'role'   => 'donor', // successful match for donor
+                    'lpa-id' => '700000012346',
                 ],
                 [
                     'reference_number' => '700000000001',
-                    'dob'         => '1975-10-05',
-                    'first_names' => 'Donor',
-                    'last_name'   => 'Person',
-                    'postcode'    => 'PY1 3Kd'
-                ],
-            ],
-            [
-                null,
-                [
-                    'reference_number' => '700000000001',
-                    'dob'         => '1982-01-20', // dob will not match
-                    'first_names' => 'Test Tester',
-                    'last_name'   => 'Testing',
-                    'postcode'    => 'Ab1 2Cd'
+                    'dob'              => '1975-10-05',
+                    'first_names'      => 'Donor',
+                    'last_name'        => 'Person',
+                    'postcode'         => 'PY1 3Kd',
                 ],
             ],
             [
                 null,
                 [
                     'reference_number' => '700000000001',
-                    'dob'         => '1980-03-01',
-                    'first_names' => 'Wrong', // firstname will not match
-                    'last_name'   => 'Testing',
-                    'postcode'    => 'Ab1 2Cd'
+                    'dob'              => '1982-01-20', // dob will not match
+                    'first_names'      => 'Test Tester',
+                    'last_name'        => 'Testing',
+                    'postcode'         => 'Ab1 2Cd',
                 ],
             ],
             [
                 null,
                 [
                     'reference_number' => '700000000001',
-                    'dob'         => '1980-03-01',
-                    'first_names' => 'Test Tester',
-                    'last_name'   => 'Incorrect', // surname will not match
-                    'postcode'    => 'Ab1 2Cd'
+                    'dob'              => '1980-03-01',
+                    'first_names'      => 'Wrong', // firstname will not match
+                    'last_name'        => 'Testing',
+                    'postcode'         => 'Ab1 2Cd',
                 ],
             ],
             [
                 null,
                 [
                     'reference_number' => '700000000001',
-                    'dob'         => '1980-03-01',
-                    'first_names' => 'Test Tester',
-                    'last_name'   => 'Testing',
-                    'postcode'    => 'WR0 NG1' // postcode will not match
+                    'dob'              => '1980-03-01',
+                    'first_names'      => 'Test Tester',
+                    'last_name'        => 'Incorrect', // surname will not match
+                    'postcode'         => 'Ab1 2Cd',
+                ],
+            ],
+            [
+                null,
+                [
+                    'reference_number' => '700000000001',
+                    'dob'              => '1980-03-01',
+                    'first_names'      => 'Test Tester',
+                    'last_name'        => 'Testing',
+                    'postcode'         => 'WR0 NG1', // postcode will not match
                 ],
             ],
             [
                 null, // will not find a match as this attorney is inactive
                 [
                     'reference_number' => '700000000001',
-                    'dob'         => '1977-11-21',
-                    'first_names' => 'Attorneyone',
-                    'last_name'   => 'Person',
-                    'postcode'    => 'Gg1 2ff'
+                    'dob'              => '1977-11-21',
+                    'first_names'      => 'Attorneyone',
+                    'last_name'        => 'Person',
+                    'postcode'         => 'Gg1 2ff',
                 ],
             ],
             [
                 null, // will not find a match as this attorney is a ghost
                 [
                     'reference_number' => '700000000001',
-                    'dob'         => '1960-05-05',
-                    'first_names' => 'Attorneytwo',
-                    'last_name'   => 'Person',
-                    'postcode'    => 'BB1 9ee'
+                    'dob'              => '1960-05-05',
+                    'first_names'      => 'Attorneytwo',
+                    'last_name'        => 'Person',
+                    'postcode'         => 'BB1 9ee',
                 ],
-            ]
+            ],
         ];
     }
 }

--- a/service-api/app/test/AppTest/Service/Lpa/FindActorInLpaTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/FindActorInLpaTest.php
@@ -198,7 +198,7 @@ class FindActorInLpaTest extends TestCase
                     'reference_number' => '700000000001',
                     'dob'         => '1980-03-01',
                     'first_names' => 'Test Tester',
-                    'last_name'   => 'Testing',
+                    'last_name'   => 'T"esting',
                     'postcode'    => 'Ab1 2Cd'
                 ],
             ],

--- a/service-api/app/test/AppTest/Service/Lpa/FindActorInLpaTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/FindActorInLpaTest.php
@@ -198,7 +198,7 @@ class FindActorInLpaTest extends TestCase
                     'reference_number' => '700000000001',
                     'dob'         => '1980-03-01',
                     'first_names' => 'Test Tester',
-                    'last_name'   => 'T"esting',
+                    'last_name'   => 'T’esting',
                     'postcode'    => 'Ab1 2Cd'
                 ],
             ],

--- a/service-api/app/test/fixtures/example_lpa.json
+++ b/service-api/app/test/fixtures/example_lpa.json
@@ -50,7 +50,7 @@
         "salutation": "Mrs",
         "firstname": "Ian",
         "middlenames": "Deputy",
-        "surname": "Deputy",
+        "surname": "D’eputy",
         "companyName": "ABC Ltd",
         "addresses": [
           {


### PR DESCRIPTION
# Purpose

https://opgtransform.atlassian.net/browse/UML-2825

Fixes UML-2825

## Approach

Introduced a function using str_ireplace to remove special characters

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [X] I have performed a self-review of my own code
~* [ ] I have added relevant logging with appropriate levels to my code~
~* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
~* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* [X] I have added tests to prove my work
~* [ ] I have added welsh translation tags and updated translation files~
~* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
~* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* [ ] The product team have tested these changes
