### PR TITLE
Contrain renovate so that it does not use PHP 8.2

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,9 @@
     "Dependencies",
     "Renovate"
   ],
+  "constraints": {
+    "php": "8.1"
+  }
   "packageRules": [
     {
       "groupName": "Patch & Minor Updates",


### PR DESCRIPTION
# Purpose

https://github.com/renovatebot/renovate/discussions/13637?sort=top

To fix renovate issues with PHP 8.2 being used despite our lock files saying 8.1 (!?)

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* The product team have tested these changes
