### PR TITLE
Uml 2642 cant request more than one a day final

### DIFF
--- a/service-api/app/src/App/src/DataAccess/DynamoDb/DynamoHydrateTrait.php
+++ b/service-api/app/src/App/src/DataAccess/DynamoDb/DynamoHydrateTrait.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\DataAccess\DynamoDb;
 
+use App\DataAccess\ValueObjects\DateTimeImmutable;
 use Aws\DynamoDb\Marshaler;
 use Aws\Result;
-use DateTime;
 use Exception;
 use UnexpectedValueException;
 
@@ -67,7 +67,7 @@ trait DynamoHydrateTrait
             $thisVal = $marshaler->unmarshalValue($value);
 
             if (in_array($key, $dateFields)) {
-                $thisVal = new DateTime($thisVal);
+                $thisVal = new DateTimeImmutable($thisVal);
             }
 
             $item[$key] = $thisVal;

--- a/service-api/app/src/App/src/DataAccess/ValueObjects/DateTimeImmutable.php
+++ b/service-api/app/src/App/src/DataAccess/ValueObjects/DateTimeImmutable.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataAccess\ValueObjects;
+
+use DateTimeImmutable as GlobalDateTimeImmutable;
+use DateTimeInterface;
+use JsonSerializable;
+
+/**
+ * Simple wrapper class that ensures json_encode returns a nice string instead
+ * of a PHP array.
+ */
+class DateTimeImmutable extends GlobalDateTimeImmutable implements JsonSerializable
+{
+    public function jsonSerialize(): mixed
+    {
+        return $this->format(DateTimeInterface::ATOM);
+    }
+}

--- a/service-api/app/src/App/src/Service/Lpa/AccessForAllLpaService.php
+++ b/service-api/app/src/App/src/Service/Lpa/AccessForAllLpaService.php
@@ -10,7 +10,8 @@ use App\DataAccess\Repository\UserLpaActorMapInterface;
 use App\Exception\ApiException;
 use App\Service\Features\FeatureEnabled;
 use DateInterval;
-use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
 use Psr\Log\LoggerInterface;
 
 class AccessForAllLpaService
@@ -33,16 +34,16 @@ class AccessForAllLpaService
      *
      * @param string $lpaId
      * @param string $actorId
-     * @return DateTime|null
+     * @return DateTimeInterface|null
      */
-    public function hasActivationCode(string $lpaId, string $actorId): ?DateTime
+    public function hasActivationCode(string $lpaId, string $actorId): ?DateTimeInterface
     {
         $response = $this->actorCodes->checkActorHasCode($lpaId, $actorId);
         if (is_null($response->getData()['Created'])) {
             return null;
         }
 
-        $createdDate = DateTime::createFromFormat('Y-m-d', $response->getData()['Created']);
+        $createdDate = DateTimeImmutable::createFromFormat('Y-m-d', $response->getData()['Created']);
 
         $this->logger->notice(
             'Activation key exists for actor {actorId} on LPA {lpaId}',

--- a/service-api/app/src/App/src/Service/Lpa/AddAccessForAllLpa.php
+++ b/service-api/app/src/App/src/Service/Lpa/AddAccessForAllLpa.php
@@ -12,9 +12,12 @@ use DateTimeImmutable;
 use Exception;
 use Psr\Log\LoggerInterface;
 use App\Service\Features\FeatureEnabled;
+use DateTimeInterface;
 
 class AddAccessForAllLpa
 {
+    private const CODE_ARRIVAL_INTERVAL = 'P10D';
+
     /**
      * @param FindActorInLpa                      $findActorInLpa
      * @param LpaService                          $lpaService
@@ -69,10 +72,10 @@ class AddAccessForAllLpa
                 (string) $resolvedActor['actor']['uId'],
             );
 
-            if ($hasActivationCode instanceof DateTime) {
-                $activationKeyDueDate = DateTimeImmutable::createFromMutable($hasActivationCode);
+            if ($hasActivationCode instanceof DateTimeInterface) {
+                $activationKeyDueDate = DateTimeImmutable::createFromInterface($hasActivationCode);
                 $activationKeyDueDate = $activationKeyDueDate
-                    ->add(new DateInterval('P10D'))
+                    ->add(new DateInterval(self::CODE_ARRIVAL_INTERVAL))
                     ->format('Y-m-d');
             }
         }
@@ -80,9 +83,10 @@ class AddAccessForAllLpa
         throw new BadRequestException(
             'Activation key already requested for LPA',
             [
-                'donor'                => $lpaAddedData['donor'],
-                'caseSubtype'          => $lpaAddedData['caseSubtype'],
-                'activationKeyDueDate' => $activationKeyDueDate,
+                'donor'                      => $lpaAddedData['donor'],
+                'caseSubtype'                => $lpaAddedData['caseSubtype'],
+                'activationKeyDueDate'       => $activationKeyDueDate,
+                'activationKeyRequestedDate' => $lpaAddedData['activationKeyRequestedDate'],
             ],
         );
     }
@@ -112,10 +116,10 @@ class AddAccessForAllLpa
             (string) $resolvedActor['actor']['uId']
         );
 
-        if ($hasActivationCode instanceof DateTime) {
-            $activationKeyDueDate = DateTimeImmutable::createFromMutable($hasActivationCode);
+        if ($hasActivationCode instanceof DateTimeInterface) {
+            $activationKeyDueDate = DateTimeImmutable::createFromInterface($hasActivationCode);
             $activationKeyDueDate = $activationKeyDueDate
-                ->add(new DateInterval('P10D'))
+                ->add(new DateInterval(self::CODE_ARRIVAL_INTERVAL))
                 ->format('Y-m-d');
 
             throw new BadRequestException(

--- a/service-api/app/src/App/src/Service/Lpa/LpaAlreadyAdded.php
+++ b/service-api/app/src/App/src/Service/Lpa/LpaAlreadyAdded.php
@@ -53,22 +53,24 @@ class LpaAlreadyAdded
         }
 
         $response = [
-            'donor'                => [
+            'donor'                      => [
                 'uId'         => $lpa['lpa']['donor']['uId'],
                 'firstname'   => $lpa['lpa']['donor']['firstname'],
                 'middlenames' => $lpa['lpa']['donor']['middlenames'],
                 'surname'     => $lpa['lpa']['donor']['surname'],
             ],
-            'caseSubtype'          => $lpa['lpa']['caseSubtype'],
-            'lpaActorToken'        => $record['Id'],
-            'activationKeyDueDate' => $lpa['activationKeyDueDate'] ?? null,
+            'caseSubtype'                => $lpa['lpa']['caseSubtype'],
+            'lpaActorToken'              => $record['Id'],
+            'activationKeyDueDate'       => $lpa['activationKeyDueDate'] ?? null,
+            'activationKeyRequestedDate' => $lpa['activationKeyRequestedDate'] ?? null,
         ];
 
         if (array_key_exists('ActivateBy', $record)) {
             $response['notActivated'] = true;
         }
 
-        return $response;
+        // filtering removes all falsy values - including null.
+        return array_filter($response);
     }
 
     /**

--- a/service-api/app/test/AppTest/DataAccess/DynamoDb/ActorCodesTest.php
+++ b/service-api/app/test/AppTest/DataAccess/DynamoDb/ActorCodesTest.php
@@ -6,7 +6,7 @@ namespace AppTest\DataAccess\DynamoDb;
 
 use App\DataAccess\DynamoDb\ActorCodes;
 use Aws\DynamoDb\DynamoDbClient;
-use DateTime;
+use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -74,7 +74,7 @@ class ActorCodesTest extends TestCase
         $this->assertEquals($testCode, $result['ActorCode']);
         $this->assertEquals($testSiriusUid, $result['SiriusUid']);
         $this->assertEquals($testActive, $result['Active']);
-        $this->assertInstanceOf(DateTime::class, $result['Expires']);
+        $this->assertInstanceOf(DateTimeInterface::class, $result['Expires']);
         $this->assertEquals($testExpires, $result['Expires']->format('c'));
         $this->assertEquals($testActorId, $result['ActorLpaId']);
     }

--- a/service-api/app/test/AppTest/Service/Lpa/LpaAlreadyAddedTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/LpaAlreadyAddedTest.php
@@ -114,6 +114,7 @@ class LpaAlreadyAddedTest extends TestCase
                         'Id'         => $this->userLpaActorToken,
                         'SiriusUid'  => $this->lpaUid,
                         'ActivateBy' => (new DateTimeImmutable('now'))->format('Y-m-d H:i:s'),
+                        'DueBy'      => '0000-00-00T00:00:00+00:00',
                     ],
                 ]
             );
@@ -122,8 +123,8 @@ class LpaAlreadyAddedTest extends TestCase
             ->getByUserLpaActorToken($this->userLpaActorToken, $this->userId)
             ->willReturn(
                 [
-                    'user-lpa-actor-token' => $this->userLpaActorToken,
-                    'lpa'                  => [
+                    'user-lpa-actor-token'      => $this->userLpaActorToken,
+                    'lpa'                       => [
                         'uId'                  => $this->lpaUid,
                         'caseSubtype'          => 'hw',
                         'donor'                => [
@@ -132,24 +133,26 @@ class LpaAlreadyAddedTest extends TestCase
                             'middlenames' => '',
                             'surname'     => 'Person',
                         ],
-                        'activationKeyDueDate' => null,
                     ],
+                    'activationKeyDueDate'       => '0000-00-00T00:00:00+00:00',
+                    'activationKeyRequestedDate' => '0000-00-00T00:00:00+00:00',
                 ]
             );
 
         $lpaAddedData = ($this->getLpaAlreadyAddedService())($this->userId, $this->lpaUid);
         $this->assertEquals(
             [
-                'donor'                => [
+                'donor'                      => [
                     'uId'         => '700000000444',
                     'firstname'   => 'Another',
                     'middlenames' => '',
                     'surname'     => 'Person',
                 ],
-                'caseSubtype'          => 'hw',
-                'lpaActorToken'        => $this->userLpaActorToken,
-                'notActivated'         => true,
-                'activationKeyDueDate' => null,
+                'caseSubtype'                => 'hw',
+                'lpaActorToken'              => $this->userLpaActorToken,
+                'notActivated'               => true,
+                'activationKeyDueDate'       => '0000-00-00T00:00:00+00:00',
+                'activationKeyRequestedDate' => '0000-00-00T00:00:00+00:00',
             ],
             $lpaAddedData
         );
@@ -254,8 +257,13 @@ class LpaAlreadyAddedTest extends TestCase
             ->willReturn(
                 [
                     [
-                        'Id'        => $this->userLpaActorToken,
-                        'SiriusUid' => $this->lpaUid,
+                        'Id'         => $this->userLpaActorToken,
+                        'UserId'     => $this->userId,
+                        'SiriusUid'  => $this->lpaUid,
+                        'Added'      => '0000-00-00T00:00:00+00:00',
+                        'Updated'    => '0000-00-00T00:00:00+00:00',
+                        'ActivateBy' => '0000-00-00T00:00:00+00:00',
+                        'DueBy'      => '0000-00-00T00:00:00+00:00',
                     ],
                 ]
             );
@@ -264,8 +272,8 @@ class LpaAlreadyAddedTest extends TestCase
             ->getByUserLpaActorToken($this->userLpaActorToken, $this->userId)
             ->willReturn(
                 [
-                    'user-lpa-actor-token' => $this->userLpaActorToken,
-                    'lpa'                  => [
+                    'user-lpa-actor-token'       => $this->userLpaActorToken,
+                    'lpa'                        => [
                         'uId'         => $this->lpaUid,
                         'caseSubtype' => 'hw',
                         'donor'       => [
@@ -275,21 +283,25 @@ class LpaAlreadyAddedTest extends TestCase
                             'surname'     => 'Person',
                         ],
                     ],
+                    'activationKeyDueDate'       => '0000-00-00T00:00:00+00:00',
+                    'activationKeyRequestedDate' => '0000-00-00T00:00:00+00:00',
                 ]
             );
 
         $lpaAddedData = ($this->getLpaAlreadyAddedService())($this->userId, $this->lpaUid);
         $this->assertEquals(
             [
-                'donor'                => [
+                'donor'                      => [
                     'uId'         => '700000000444',
                     'firstname'   => 'Another',
                     'middlenames' => '',
                     'surname'     => 'Person',
                 ],
-                'caseSubtype'          => 'hw',
-                'lpaActorToken'        => $this->userLpaActorToken,
-                'activationKeyDueDate' => null,
+                'caseSubtype'                => 'hw',
+                'lpaActorToken'              => $this->userLpaActorToken,
+                'notActivated'               => true,
+                'activationKeyDueDate'       => '0000-00-00T00:00:00+00:00',
+                'activationKeyRequestedDate' => '0000-00-00T00:00:00+00:00',
             ],
             $lpaAddedData
         );

--- a/service-front/app/features/actor-add-an-older-lpa.feature
+++ b/service-front/app/features/actor-add-an-older-lpa.feature
@@ -74,6 +74,12 @@ Feature: Add an older LPA
     Then I am told a new activation key is posted to the provided postcode
 
   @ui @integration
+  Scenario: The user cannot request a new key on the same day as another attempt
+    Given I have already requested an activation key that day
+    When I request an activation key for my lpa
+    Then I am told that I cannot request another activation key on the same day
+
+  @ui @integration
   Scenario: The user is unable to request key for an LPA that they have already added
     Given I am on the add an older LPA page
     And I have added an LPA to my account

--- a/service-front/app/features/context/Integration/LpaContext.php
+++ b/service-front/app/features/context/Integration/LpaContext.php
@@ -23,6 +23,8 @@ use Common\Service\Lpa\Response\LpaMatch;
 use Common\Service\Lpa\ViewerCodeService;
 use Common\Service\Notify\NotifyService;
 use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
 use Fig\Http\Message\StatusCodeInterface;
 use GuzzleHttp\Handler\MockHandler;
 use PHPUnit\Framework\Assert;
@@ -1444,7 +1446,7 @@ class LpaContext extends BaseIntegrationContext
      */
     public function iAmToldThatIHaveAnActivationKeyForThisLPAAndWhereToFindIt()
     {
-        $createdDate = (new DateTime())->modify('-14 days');
+        $createdDate = (new DateTimeImmutable())->modify('-14 days')->format(DateTimeInterface::ATOM);
 
         // API call for requesting activation code
         $this->apiFixtures->append(
@@ -1452,18 +1454,18 @@ class LpaContext extends BaseIntegrationContext
                 StatusCodeInterface::STATUS_BAD_REQUEST,
                 json_encode(
                     [
-                        'title' => 'Bad Request',
+                        'title'   => 'Bad Request',
                         'details' => 'LPA has an activation key already',
-                        'data' => [
-                            'donor' => [
-                                'uId' => $this->lpa['donor']['uId'],
-                                'firstname' => $this->lpa['donor']['firstname'],
+                        'data'    => [
+                            'donor'                => [
+                                'uId'         => $this->lpa['donor']['uId'],
+                                'firstname'   => $this->lpa['donor']['firstname'],
                                 'middlenames' => $this->lpa['donor']['middlenames'],
-                                'surname' => $this->lpa['donor']['surname'],
+                                'surname'     => $this->lpa['donor']['surname'],
                             ],
-                            'caseSubtype' => $this->lpa['caseSubtype'],
-                            'activationKeyDueDate' => $createdDate->format('c')
-                        ]
+                            'caseSubtype'          => $this->lpa['caseSubtype'],
+                            'activationKeyDueDate' => $createdDate,
+                        ],
                     ]
                 ),
                 self::ADD_OLDER_LPA_VALIDATE
@@ -1474,7 +1476,7 @@ class LpaContext extends BaseIntegrationContext
 
         $result = $addOlderLpa->validate(
             $this->userIdentity,
-            intval($this->referenceNo),
+            (int) $this->referenceNo,
             $this->userFirstname,
             $this->userSurname,
             DateTime::createFromFormat('Y-m-d', $this->userDob),
@@ -1490,7 +1492,7 @@ class LpaContext extends BaseIntegrationContext
         $keyExistsDTO = new ActivationKeyExists();
         $keyExistsDTO->setDonor($donor);
         $keyExistsDTO->setCaseSubtype($this->lpa['caseSubtype']);
-        $keyExistsDTO->setDueDate($createdDate->format('c'));
+        $keyExistsDTO->setDueDate(new DateTimeImmutable($createdDate));
 
         $response = new AccessForAllApiResult(
             AccessForAllResult::HAS_ACTIVATION_KEY,

--- a/service-front/app/features/context/UI/RequestActivationKeyContext.php
+++ b/service-front/app/features/context/UI/RequestActivationKeyContext.php
@@ -1552,14 +1552,17 @@ class RequestActivationKeyContext implements Context
                         'title'   => 'Bad request',
                         'details' => 'Activation key already requested for LPA',
                         'data'    => [
-                            'donor'                => [
+                            'donor'       => [
                                 'uId'         => $this->lpa->donor->uId,
                                 'firstname'   => $this->lpa->donor->firstname,
                                 'middlenames' => $this->lpa->donor->middlenames,
                                 'surname'     => $this->lpa->donor->surname,
                             ],
-                            'caseSubtype'          => $this->lpa->caseSubtype,
-                            'activationKeyDueDate' => '2022-01-30',
+                            'caseSubtype' => $this->lpa->caseSubtype,
+                            'activationKeyDueDate'
+                                => (new DateTimeImmutable('+5 days'))->format(DateTimeInterface::ATOM),
+                            'activationKeyRequestedDate'
+                                => (new DateTimeImmutable('-9 days'))->format(DateTimeInterface::ATOM),
                         ],
                     ]
                 ),

--- a/service-front/app/features/context/UI/RequestActivationKeyContext.php
+++ b/service-front/app/features/context/UI/RequestActivationKeyContext.php
@@ -12,7 +12,6 @@ use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Fig\Http\Message\StatusCodeInterface;
-use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Assert;
 use Psr\Http\Message\RequestInterface;
 

--- a/service-front/app/src/Actor/templates/actor/already-requested-activation-key-today.html.twig
+++ b/service-front/app/src/Actor/templates/actor/already-requested-activation-key-today.html.twig
@@ -1,0 +1,50 @@
+{% extends '@actor/layout.html.twig' %}
+
+{% block html_title %}{% trans %}You've already asked for an activation key for this LPA today{% endtrans %} - {{ parent() }}{% endblock %}
+
+{% block content %}
+    <div class="govuk-width-container">
+
+        {{ include('@partials/account-bar.html.twig') }}
+        {{ include('@partials/welsh-switch.html.twig') }}
+
+        <main class="govuk-main-wrapper" id="main-content" role="main">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds">
+                    <h1 class="govuk-heading-xl">{% trans %}You've already asked for an activation key for this LPA today{% endtrans %}</h1>
+
+                    <dl class="govuk-summary-list govuk-summary-list">
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key">
+                                {% trans %}Donor name{% endtrans %}
+                            </dt>
+                            <dd class="govuk-summary-list__value">
+                                {{ actor_name(donor) }}
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row">
+                            <dt class="govuk-summary-list__key">
+                                {% trans %}Type of LPA{% endtrans %}
+                            </dt>
+                            <dd class="govuk-summary-list__value">
+                                {% if caseSubtype|lower == "pfa" %}
+                                    {% trans %}Property and finance{% endtrans %}
+                                {% else %}
+                                    {% trans %}Health and welfare{% endtrans %}
+                                {% endif %}
+                            </dd>
+                        </div>
+                    </dl>
+
+                    <p class="govuk-body">{% trans %}We'll post you a letter with your activation key for this LPA. It will be sent to the address we have for you on our records. We send the key by post because it's more secure.{% endtrans %}</p>
+                    <p class="govuk-body">{% trans with {'%dueDate%' : lpa_date(dueDate)} %}You should hear from us or get the activation key letter by %dueDate%. If not, please contact us.{% endtrans %}</p>
+
+                    <a href="{{ path('lpa.dashboard') }}" draggable="false" class="govuk-button">
+                        {% trans %}Back to your LPAs{% endtrans %}
+                    </a>
+                </div>
+            </div>
+        </main>
+        {{ include('@actor/partials/new-use-service.html.twig') }}
+    </div>
+{% endblock %}

--- a/service-front/app/src/Common/src/Service/Lpa/AddAccessForAllLpa.php
+++ b/service-front/app/src/Common/src/Service/Lpa/AddAccessForAllLpa.php
@@ -12,6 +12,7 @@ use Common\Service\Lpa\Response\Parse\ParseLpaMatch;
 use Common\Service\Lpa\Response\Parse\ParseActivationKeyExists;
 use Common\Service\Lpa\Response\Parse\ParseLpaAlreadyAdded;
 use DateTimeInterface;
+use Exception;
 use Fig\Http\Message\StatusCodeInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -48,6 +49,16 @@ class AddAccessForAllLpa
     ) {
     }
 
+    /**
+     * @param string            $userToken
+     * @param int               $lpaUid
+     * @param string            $firstnames
+     * @param string            $lastname
+     * @param DateTimeInterface $dob
+     * @param string            $postcode
+     * @return AccessForAllApiResult
+     * @throws Exception
+     */
     public function validate(
         string $userToken,
         int $lpaUid,
@@ -160,6 +171,7 @@ class AddAccessForAllLpa
      * @param string $message
      * @param array  $additionalData
      * @return AccessForAllApiResult
+     * @throws Exception
      */
     private function badRequestReturned(int $lpaUid, string $message, array $additionalData): AccessForAllApiResult
     {

--- a/service-front/app/src/Common/src/Service/Lpa/Response/ActivationKeyExists.php
+++ b/service-front/app/src/Common/src/Service/Lpa/Response/ActivationKeyExists.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Common\Service\Lpa\Response;
 
 use Common\Entity\CaseActor;
+use DateTimeInterface;
 
 class ActivationKeyExists extends Response
 {
     protected CaseActor $donor;
     protected string $caseSubtype;
-    protected string $activationKeyDueDate;
+    protected ?DateTimeInterface $activationKeyDueDate;
+    protected ?DateTimeInterface $activationKeyRequestedDate;
 
     public function getDonor(): ?CaseActor
     {
@@ -22,9 +24,14 @@ class ActivationKeyExists extends Response
         return $this->caseSubtype;
     }
 
-    public function getDueDate(): ?string
+    public function getDueDate(): ?DateTimeInterface
     {
         return $this->activationKeyDueDate;
+    }
+
+    public function getRequestedDate(): ?DateTimeInterface
+    {
+        return $this->activationKeyRequestedDate;
     }
 
     public function setDonor(CaseActor $donor): void
@@ -37,8 +44,13 @@ class ActivationKeyExists extends Response
         $this->caseSubtype = $caseSubtype;
     }
 
-    public function setDueDate(string $activationKeyDueDate): void
+    public function setDueDate(DateTimeInterface $activationKeyDueDate): void
     {
         $this->activationKeyDueDate = $activationKeyDueDate;
+    }
+
+    public function setRequestedDate(DateTimeInterface $activationKeyRequestedDate): void
+    {
+        $this->activationKeyRequestedDate = $activationKeyRequestedDate;
     }
 }

--- a/service-front/app/src/Common/src/Service/Lpa/Response/Parse/ParseActivationKeyExists.php
+++ b/service-front/app/src/Common/src/Service/Lpa/Response/Parse/ParseActivationKeyExists.php
@@ -44,23 +44,4 @@ class ParseActivationKeyExists
 
         return $response;
     }
-
-    /**
-     * @param array{donor: array, caseSubtype: string} $data
-     * @return bool
-     */
-    private function isValidData(array $data): bool
-    {
-        if (
-            !isset($data['donor']['uId']) ||
-            !array_key_exists('firstname', $data['donor']) ||
-            !array_key_exists('middlenames', $data['donor']) ||
-            !array_key_exists('surname', $data['donor']) ||
-            !isset($data['caseSubtype'])
-        ) {
-            return false;
-        }
-
-        return true;
-    }
 }

--- a/service-front/app/src/Common/src/Service/Lpa/Response/Parse/ParseActivationKeyExists.php
+++ b/service-front/app/src/Common/src/Service/Lpa/Response/Parse/ParseActivationKeyExists.php
@@ -44,4 +44,23 @@ class ParseActivationKeyExists
 
         return $response;
     }
+
+    /**
+     * @param array{donor: array, caseSubtype: string} $data
+     * @return bool
+     */
+    private function isValidData(array $data): bool
+    {
+        if (
+            !isset($data['donor']['uId']) ||
+            !array_key_exists('firstname', $data['donor']) ||
+            !array_key_exists('middlenames', $data['donor']) ||
+            !array_key_exists('surname', $data['donor']) ||
+            !isset($data['caseSubtype'])
+        ) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/service-front/app/src/Common/src/Service/Lpa/Response/Parse/ParseActivationKeyExists.php
+++ b/service-front/app/src/Common/src/Service/Lpa/Response/Parse/ParseActivationKeyExists.php
@@ -6,6 +6,8 @@ namespace Common\Service\Lpa\Response\Parse;
 
 use Common\Service\Lpa\LpaFactory;
 use Common\Service\Lpa\Response\ActivationKeyExists;
+use DateTimeImmutable;
+use DateTimeInterface;
 use Exception;
 use InvalidArgumentException;
 
@@ -22,7 +24,12 @@ class ParseActivationKeyExists
     }
 
     /**
-     * @param array{donor: array, caseSubtype: string} $data
+     * @param array{
+     *     donor: array,
+     *     caseSubtype: string,
+     *     activationKeyDueDate: ?string,
+     *     activationKeyRequestedDate: ?string
+     * } $data
      * @return ActivationKeyExists
      * @throws Exception
      */
@@ -39,7 +46,21 @@ class ParseActivationKeyExists
         $response->setCaseSubtype($data['caseSubtype']);
 
         if (isset($data['activationKeyDueDate'])) {
-            $response->setDueDate($data['activationKeyDueDate']);
+            $response->setDueDate(
+                DateTimeImmutable::createFromFormat(
+                    DateTimeInterface::ATOM,
+                    $data['activationKeyDueDate']
+                )
+            );
+        }
+
+        if (isset($data['activationKeyRequestedDate'])) {
+            $response->setRequestedDate(
+                DateTimeImmutable::createFromFormat(
+                    DateTimeInterface::ATOM,
+                    $data['activationKeyRequestedDate']
+                )
+            );
         }
 
         return $response;

--- a/service-front/app/src/Common/src/Service/Lpa/Response/Parse/ParseLpaMatch.php
+++ b/service-front/app/src/Common/src/Service/Lpa/Response/Parse/ParseLpaMatch.php
@@ -44,24 +44,4 @@ class ParseLpaMatch
 
         return $response;
     }
-
-    /**
-     * @param array{donor: array, caseSubtype: string, lpaActorToken: string} $data
-     * @return bool
-     */
-    private function isValidData(array $data): bool
-    {
-        if (
-            // if the actor is the donor then the attorney data wont exist
-            !isset($data['donor']['uId']) ||
-            !array_key_exists('firstname', $data['donor']) ||
-            !array_key_exists('middlenames', $data['donor']) ||
-            !array_key_exists('surname', $data['donor']) ||
-            !isset($data['caseSubtype'])
-        ) {
-            return false;
-        }
-
-        return true;
-    }
 }

--- a/service-front/app/src/Common/src/Service/Lpa/Response/Parse/ParseLpaMatch.php
+++ b/service-front/app/src/Common/src/Service/Lpa/Response/Parse/ParseLpaMatch.php
@@ -44,4 +44,24 @@ class ParseLpaMatch
 
         return $response;
     }
+
+    /**
+     * @param array{donor: array, caseSubtype: string, lpaActorToken: string} $data
+     * @return bool
+     */
+    private function isValidData(array $data): bool
+    {
+        if (
+            // if the actor is the donor then the attorney data wont exist
+            !isset($data['donor']['uId']) ||
+            !array_key_exists('firstname', $data['donor']) ||
+            !array_key_exists('middlenames', $data['donor']) ||
+            !array_key_exists('surname', $data['donor']) ||
+            !isset($data['caseSubtype'])
+        ) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/service-front/app/test/CommonTest/Service/Lpa/Response/ActivationKeyExistsResponseTest.php
+++ b/service-front/app/test/CommonTest/Service/Lpa/Response/ActivationKeyExistsResponseTest.php
@@ -6,6 +6,7 @@ namespace CommonTest\Service\Lpa\Response;
 
 use Common\Entity\CaseActor;
 use Common\Service\Lpa\Response\ActivationKeyExists;
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
 class ActivationKeyExistsResponseTest extends TestCase
@@ -30,10 +31,10 @@ class ActivationKeyExistsResponseTest extends TestCase
         $dto = new ActivationKeyExists();
         $dto->setDonor($donor);
         $dto->setCaseSubtype('pfa');
-        $dto->setDueDate('2021-12-06');
+        $dto->setDueDate(new DateTimeImmutable('2021-12-06'));
 
         $this->assertEquals($donor, $dto->getDonor());
         $this->assertEquals('pfa', $dto->getCaseSubtype());
-        $this->assertEquals('2021-12-06', $dto->getDueDate());
+        $this->assertEquals('2021-12-06', $dto->getDueDate()->format('Y-m-d'));
     }
 }

--- a/service-front/app/test/CommonTest/Service/Lpa/Response/Parse/ParseAccessForAllLpaMatchResponseTest.php
+++ b/service-front/app/test/CommonTest/Service/Lpa/Response/Parse/ParseAccessForAllLpaMatchResponseTest.php
@@ -23,7 +23,7 @@ class ParseAccessForAllLpaMatchResponseTest extends TestCase
 
     private ObjectProphecy|LpaFactory $lpaFactory;
 
-    /** @var array<string, string|array<string, ?string>> $response */
+    /** @var array<string, ?string|array<string, ?string>>  */
     private array $response;
 
     public function setUp(): void

--- a/service-front/app/test/CommonTest/Service/Lpa/Response/Parse/ParseAccessForAllLpaMatchResponseTest.php
+++ b/service-front/app/test/CommonTest/Service/Lpa/Response/Parse/ParseAccessForAllLpaMatchResponseTest.php
@@ -23,7 +23,7 @@ class ParseAccessForAllLpaMatchResponseTest extends TestCase
 
     private ObjectProphecy|LpaFactory $lpaFactory;
 
-    /** @var array<string, ?string|array<string, ?string>>  */
+    /** @var array<string, string|array<string, ?string>> $response */
     private array $response;
 
     public function setUp(): void

--- a/service-front/app/test/CommonTest/Service/Lpa/Response/Parse/ParseActivationKeyExistsResponseTest.php
+++ b/service-front/app/test/CommonTest/Service/Lpa/Response/Parse/ParseActivationKeyExistsResponseTest.php
@@ -25,14 +25,15 @@ class ParseActivationKeyExistsResponseTest extends TestCase
     public function setUp(): void
     {
         $this->response = [
-            'donor'                => [
+            'donor'                      => [
                 'uId'         => '12345',
                 'firstname'   => 'Example',
                 'middlenames' => 'Donor',
                 'surname'     => 'Person',
             ],
-            'caseSubtype'          => 'hw',
-            'activationKeyDueDate' => '2021-12-06',
+            'caseSubtype'                => 'hw',
+            'activationKeyDueDate'       => '2021-12-06T00:00:00+00:00',
+            'activationKeyRequestedDate' => '2021-12-06T00:00:00+00:00',
         ];
 
         $this->donor = new CaseActor();
@@ -57,7 +58,8 @@ class ParseActivationKeyExistsResponseTest extends TestCase
         $this->assertInstanceOf(ActivationKeyExists::class, $result);
         $this->assertEquals($this->donor, $result->getDonor());
         $this->assertEquals('hw', $result->getCaseSubtype());
-        $this->assertEquals('2021-12-06', $result->getDueDate());
+        $this->assertEquals('2021-12-06', $result->getDueDate()->format('Y-m-d'));
+        $this->assertEquals('2021-12-06', $result->getRequestedDate()->format('Y-m-d'));
     }
 
     /** @test */


### PR DESCRIPTION
# Purpose

As a user that has requested an activation key for the same LPA more than once I need to know which key will work

Fixes UML-2642

## Approach

Add an updated date to the API and pass that to the frontend so it can be used in deciding the content to show on this page.

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
