### PR TITLE
Uml 2851 change id to be integer

### DIFF
--- a/service-api/app/src/App/src/Service/ActorCodes/ActorCodeService.php
+++ b/service-api/app/src/App/src/Service/ActorCodes/ActorCodeService.php
@@ -66,7 +66,7 @@ class ActorCodeService
 
             $lpa = $this->lpaService->getByUid($uid);
 
-            $actor = ($this->resolveActor)($lpa->getData(), $actorUid);
+            $actor = ($this->resolveActor)($lpa->getData(), (int) $actorUid);
 
             $lpaData = $lpa->getData();
             unset($lpaData['original_attorneys']);

--- a/service-api/app/src/App/src/Service/ActorCodes/CodeValidationStrategyInterface.php
+++ b/service-api/app/src/App/src/Service/ActorCodes/CodeValidationStrategyInterface.php
@@ -27,5 +27,5 @@ interface CodeValidationStrategyInterface
      * @param string $code
      * @throws ActorCodeMarkAsUsedException Thrown when the act of marking a code as used fails
      */
-    public function flagCodeAsUsed(string $code);
+    public function flagCodeAsUsed(string $code): void;
 }

--- a/service-api/app/src/App/src/Service/Lpa/LpaService.php
+++ b/service-api/app/src/App/src/Service/Lpa/LpaService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service\Lpa;
 
 use App\DataAccess\ApiGateway\ActorCodes;
@@ -14,57 +16,30 @@ use DateTime;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
-/**
- * Class LpaService
- *
- * @package App\Service\Lpa
- */
 class LpaService
 {
-    private const ACTIVE_ATTORNEY = 0;
+    private const ACTIVE_ATTORNEY   = 0;
     private const INACTIVE_ATTORNEY = 2;
-    private const ACTIVE_TC = 0;
-
-    private ViewerCodesInterface $viewerCodesRepository;
-    private ViewerCodeActivityInterface $viewerCodeActivityRepository;
-    private LpasInterface $lpaRepository;
-    private UserLpaActorMapInterface $userLpaActorMapRepository;
-    private LoggerInterface $logger;
-    private ActorCodes $actorCodes;
-    private ResolveActor $resolveActor;
-    private GetAttorneyStatus $getAttorneyStatus;
-    private IsValidLpa $isValidLpa;
-    private GetTrustCorporationStatus $getTrustCorporationStatus;
+    private const ACTIVE_TC         = 0;
 
     public function __construct(
-        ViewerCodesInterface $viewerCodesRepository,
-        ViewerCodeActivityInterface $viewerCodeActivityRepository,
-        LpasInterface $lpaRepository,
-        UserLpaActorMapInterface $userLpaActorMapRepository,
-        LoggerInterface $logger,
-        ActorCodes $actorCodes,
-        ResolveActor $resolveActor,
-        GetAttorneyStatus $getAttorneyStatus,
-        IsValidLpa $isValidLpa,
-        GetTrustCorporationStatus $getTrustCorporationStatus
+        private ViewerCodesInterface $viewerCodesRepository,
+        private ViewerCodeActivityInterface $viewerCodeActivityRepository,
+        private LpasInterface $lpaRepository,
+        private UserLpaActorMapInterface $userLpaActorMapRepository,
+        private LoggerInterface $logger,
+        private ActorCodes $actorCodes,
+        private ResolveActor $resolveActor,
+        private GetAttorneyStatus $getAttorneyStatus,
+        private IsValidLpa $isValidLpa,
+        private GetTrustCorporationStatus $getTrustCorporationStatus,
     ) {
-        $this->viewerCodesRepository = $viewerCodesRepository;
-        $this->viewerCodeActivityRepository = $viewerCodeActivityRepository;
-        $this->lpaRepository = $lpaRepository;
-        $this->userLpaActorMapRepository = $userLpaActorMapRepository;
-        $this->logger = $logger;
-        $this->actorCodes = $actorCodes;
-        $this->resolveActor = $resolveActor;
-        $this->getAttorneyStatus = $getAttorneyStatus;
-        $this->isValidLpa = $isValidLpa;
-        $this->getTrustCorporationStatus = $getTrustCorporationStatus;
     }
 
     /**
      * Get an LPA using the ID value
      *
      * @param string $uid Sirius uId of LPA to fetch
-     *
      * @return ?LpaInterface A processed LPA data transfer object
      */
     public function getByUid(string $uid): ?LpaInterface
@@ -110,7 +85,6 @@ class LpaService
      *
      * @param string $token  UserLpaActorToken that map an LPA to a user account
      * @param string $userId The user account ID that must correlate to the $token
-     *
      * @return ?array A structure that contains processed LPA data and metadata
      */
     public function getByUserLpaActorToken(string $token, string $userId): ?array
@@ -132,15 +106,15 @@ class LpaService
         unset($lpaData['original_attorneys']);
 
         $result = [
-            'user-lpa-actor-token'  => $map['Id'],
-            'date'                  => $lpa->getLookupTime()->format('c'),
-            'lpa'                   => $lpaData,
-            'activationKeyDueDate'  => $map['DueBy'] ?? null
+            'user-lpa-actor-token' => $map['Id'],
+            'date'                 => $lpa->getLookupTime()->format('c'),
+            'lpa'                  => $lpaData,
+            'activationKeyDueDate' => $map['DueBy'] ?? null,
         ];
 
         // If an actor has been stored against an LPA then attempt to resolve it from the API return
         if (isset($map['ActorId'])) {
-            $actor = ($this->resolveActor)($lpaData, $map['ActorId']);
+            $actor = ($this->resolveActor)($lpaData, (int) $map['ActorId']);
 
             // If an active attorney is not found then we should not return an lpa
             $result['actor'] = $actor;
@@ -159,7 +133,6 @@ class LpaService
      * Return all LPAs for the given user_id
      *
      * @param string $userId User account ID to fetch LPAs for
-     *
      * @return array An array of LPA data structures containing processed LPA data and metadata
      */
     public function getAllForUser(string $userId): array
@@ -178,7 +151,6 @@ class LpaService
      * Return all LPAs for the given user_id
      *
      * @param string $userId User account ID to fetch LPA and Requests for
-     *
      * @return array An array of LPA data structures containing processed LPA data and metadata
      */
     public function getAllLpasAndRequestsForUser(string $userId): array
@@ -195,7 +167,6 @@ class LpaService
      * @param string  $viewerCode   A code that directly maps to an LPA
      * @param string  $donorSurname The surname of the donor that must correlate to the $viewerCode
      * @param ?string $organisation An organisation name that will be recorded as used against the $viewerCode
-     *
      * @return ?array A structure that contains processed LPA data and metadata
      */
     public function getByViewerCode(string $viewerCode, string $donorSurname, ?string $organisation = null): ?array
@@ -255,26 +226,19 @@ class LpaService
         $lpaData = $lpa->getData();
         unset($lpaData['original_attorneys']);
 
-        $lpaData = [
-            'date' => $lpa->getLookupTime()->format('c'),
-            'expires' => $viewerCodeData['Expires']->format('c'),
+        return [
+            'date'         => $lpa->getLookupTime()->format('c'),
+            'expires'      => $viewerCodeData['Expires']->format('c'),
             'organisation' => $viewerCodeData['Organisation'],
-            'lpa' => $lpaData,
+            'lpa'          => $lpaData,
         ];
-
-        if (isset($viewerCodeData['Cancelled'])) {
-            $lpaData['cancelled'] = $viewerCodeData['Cancelled']->format('c');
-        }
-
-        return $lpaData;
     }
 
     /**
-     * @param $lpaActorMaps Map of LPAs from Dynamo
-     *
+     * @param $lpaActorMaps array Map of LPAs from Dynamo
      * @return array an array with formatted LPA results
      */
-    private function lookupAndFormatLpas($lpaActorMaps): array
+    private function lookupAndFormatLpas(array $lpaActorMaps): array
     {
         $lpaUids = array_column($lpaActorMaps, 'SiriusUid');
 
@@ -296,7 +260,7 @@ class LpaService
             }
 
             $lpaData = $lpa->getData();
-            $actor = ($this->resolveActor)($lpaData, $item['ActorId']);
+            $actor   = ($this->resolveActor)($lpaData, (int) $item['ActorId']);
 
             $added = $item['Added']->format('Y-m-d H:i:s');
             unset($lpaData['original_attorneys']);
@@ -305,10 +269,10 @@ class LpaService
             if (($this->isValidLpa)($lpaData)) {
                 $result[$item['Id']] = [
                     'user-lpa-actor-token' => $item['Id'],
-                    'date' => $lpa->getLookupTime()->format('c'),
-                    'actor' => $actor,
-                    'lpa' => $lpaData,
-                    'added' => $added,
+                    'date'                 => $lpa->getLookupTime()->format('c'),
+                    'actor'                => $actor,
+                    'lpa'                  => $lpaData,
+                    'added'                => $added,
                 ];
             }
         }

--- a/service-api/app/test/AppTest/Service/ActorCodes/ActorCodeServiceTest.php
+++ b/service-api/app/test/AppTest/Service/ActorCodes/ActorCodeServiceTest.php
@@ -59,7 +59,6 @@ class ActorCodeServiceTest extends TestCase
         $this->initValidParameterSet();
 
         $this->codeValidatorProphecy->flagCodeAsUsed('test-code')
-            ->willReturn('id-of-db-row')
             ->shouldBeCalled();
 
         $this->userLpaActorMapInterfaceProphecy->create(
@@ -88,7 +87,6 @@ class ActorCodeServiceTest extends TestCase
         $this->initValidParameterSet();
 
         $this->codeValidatorProphecy->flagCodeAsUsed('test-code')
-            ->willReturn('id-of-db-row')
             ->shouldBeCalled();
 
         $this->userLpaActorMapInterfaceProphecy->activateRecord(
@@ -228,7 +226,7 @@ class ActorCodeServiceTest extends TestCase
         )->shouldBeCalled();
 
         $this->resolveActorProphecy
-            ->__invoke(Argument::type('array'), Argument::type('string'))
+            ->__invoke(Argument::type('array'), Argument::type('int'))
             ->willReturn($mockActor)
             ->shouldBeCalled();
 

--- a/service-api/app/test/AppTest/Service/ActorCodes/Validation/CodesApiValidationStrategyTest.php
+++ b/service-api/app/test/AppTest/Service/ActorCodes/Validation/CodesApiValidationStrategyTest.php
@@ -12,6 +12,7 @@ use App\Exception\ActorCodeValidationException;
 use App\Service\ActorCodes\Validation\CodesApiValidationStrategy;
 use App\Service\Lpa\LpaService;
 use App\Service\Lpa\ResolveActor;
+use DateTime;
 use Exception;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -30,8 +31,8 @@ class CodesApiValidationStrategyTest extends TestCase
     public function initDependencies(): void
     {
         $this->actorCodeApiProphecy = $this->prophesize(ActorCodes::class);
-        $this->lpaServiceProphecy = $this->prophesize(LpaService::class);
-        $this->loggerProphecy = $this->prophesize(LoggerInterface::class);
+        $this->lpaServiceProphecy   = $this->prophesize(LpaService::class);
+        $this->loggerProphecy       = $this->prophesize(LoggerInterface::class);
         $this->resolveActorProphecy = $this->prophesize(ResolveActor::class);
     }
 
@@ -52,9 +53,9 @@ class CodesApiValidationStrategyTest extends TestCase
 
         $actor = new ActorCode(
             [
-                'actor' => 'actor-uid',
+                'actor' => '123456789',
             ],
-            new \DateTime('now')
+            new DateTime('now')
         );
 
         $this->actorCodeApiProphecy
@@ -63,9 +64,9 @@ class CodesApiValidationStrategyTest extends TestCase
 
         $lpa = new Lpa(
             [
-                'uId' => 'lpa-uid'
+                'uId' => 'lpa-uid',
             ],
-            new \DateTime('now')
+            new DateTime('now')
         );
 
         $this->lpaServiceProphecy
@@ -73,14 +74,14 @@ class CodesApiValidationStrategyTest extends TestCase
             ->willReturn($lpa);
 
         $this->resolveActorProphecy
-            ->__invoke($lpa->getData(), 'actor-uid')
+            ->__invoke($lpa->getData(), 123456789)
             ->willReturn(
                 [
-                    'type' => 'primary-attorney',
+                    'type'    => 'primary-attorney',
                     'details' => [
                         'uId' => 'actor-uid',
-                        'dob' => 'actor-dob'
-                    ]
+                        'dob' => 'actor-dob',
+                    ],
                 ]
             );
 
@@ -88,7 +89,7 @@ class CodesApiValidationStrategyTest extends TestCase
 
         $actorUId = $strategy->validateCode('actor-code', 'lpa-uid', 'actor-dob');
 
-        $this->assertEquals('actor-uid', $actorUId);
+        $this->assertEquals('123456789', $actorUId);
     }
 
     /** @test */
@@ -100,7 +101,7 @@ class CodesApiValidationStrategyTest extends TestCase
             [
                 'actor' => null,
             ],
-            new \DateTime('now')
+            new DateTime('now')
         );
 
         $this->actorCodeApiProphecy
@@ -122,7 +123,7 @@ class CodesApiValidationStrategyTest extends TestCase
             [
                 'actor' => null,
             ],
-            new \DateTime('now')
+            new DateTime('now')
         );
 
         $this->actorCodeApiProphecy
@@ -144,7 +145,7 @@ class CodesApiValidationStrategyTest extends TestCase
             [
                 'actor' => 'actor-uid',
             ],
-            new \DateTime('now')
+            new DateTime('now')
         );
 
         $this->actorCodeApiProphecy
@@ -169,9 +170,9 @@ class CodesApiValidationStrategyTest extends TestCase
 
         $actor = new ActorCode(
             [
-                'actor' => 'actor-uid',
+                'actor' => '123456789',
             ],
-            new \DateTime('now')
+            new DateTime('now')
         );
 
         $this->actorCodeApiProphecy
@@ -180,9 +181,9 @@ class CodesApiValidationStrategyTest extends TestCase
 
         $lpa = new Lpa(
             [
-                'uId' => 'lpa-uid'
+                'uId' => 'lpa-uid',
             ],
-            new \DateTime('now')
+            new DateTime('now')
         );
 
         $this->lpaServiceProphecy
@@ -191,7 +192,7 @@ class CodesApiValidationStrategyTest extends TestCase
             ->willReturn($lpa);
 
         $this->resolveActorProphecy
-            ->__invoke($lpa->getData(), 'actor-uid')
+            ->__invoke($lpa->getData(), 123456789)
             ->willReturn(null);
 
         $strategy = $this->getCodesApiValidationStrategy();
@@ -207,9 +208,9 @@ class CodesApiValidationStrategyTest extends TestCase
 
         $actor = new ActorCode(
             [
-                'actor' => 'actor-uid',
+                'actor' => '123456789',
             ],
-            new \DateTime('now')
+            new DateTime('now')
         );
 
         $this->actorCodeApiProphecy
@@ -218,9 +219,9 @@ class CodesApiValidationStrategyTest extends TestCase
 
         $lpa = new Lpa(
             [
-                'uId' => 'lpa-uid'
+                'uId' => 'lpa-uid',
             ],
-            new \DateTime('now')
+            new DateTime('now')
         );
 
         $this->lpaServiceProphecy
@@ -229,15 +230,15 @@ class CodesApiValidationStrategyTest extends TestCase
             ->willReturn($lpa);
 
         $this->resolveActorProphecy
-            ->__invoke($lpa->getData(), 'actor-uid')
+            ->__invoke($lpa->getData(), 123456789)
             ->shouldBeCalled()
             ->willReturn(
                 [
-                    'type' => 'primary-attorney',
+                    'type'    => 'primary-attorney',
                     'details' => [
                         'uId' => 'actor-uid',
-                        'dob' => 'different-dob'
-                    ]
+                        'dob' => 'different-dob',
+                    ],
                 ]
             );
 
@@ -256,7 +257,7 @@ class CodesApiValidationStrategyTest extends TestCase
             [
                 'actor' => 'actor-uid',
             ],
-            new \DateTime('now')
+            new DateTime('now')
         );
 
         $this->actorCodeApiProphecy
@@ -290,7 +291,7 @@ class CodesApiValidationStrategyTest extends TestCase
 
         $this->actorCodeApiProphecy
             ->flagCodeAsUsed('actor-code')
-            ->willThrow(new \Exception());
+            ->willThrow(new Exception());
 
         $strategy = $this->getCodesApiValidationStrategy();
 
@@ -305,9 +306,9 @@ class CodesApiValidationStrategyTest extends TestCase
 
         $actor = new ActorCode(
             [
-                'actor' => 'actor-uid',
+                'actor' => '123456789',
             ],
-            new \DateTime('now')
+            new DateTime('now')
         );
 
         $this->actorCodeApiProphecy
@@ -317,20 +318,20 @@ class CodesApiValidationStrategyTest extends TestCase
         $lpa = new Lpa(
             [
                 'donor' => [
-                    'id' => 1,
-                    'uId' => 'donor-uid',
-                    'dob' => 'donor-dob',
-                    'salutation' => 'Mr',
-                    'firstname' => 'Test',
+                    'id'          => 1,
+                    'uId'         => 'donor-uid',
+                    'dob'         => 'donor-dob',
+                    'salutation'  => 'Mr',
+                    'firstname'   => 'Test',
                     'middlenames' => '',
-                    'surname' => 'User',
-                    'addresses' => [
+                    'surname'     => 'User',
+                    'addresses'   => [
                         0 => [],
                     ],
                 ],
-                'uId' => 'lpa-uid',
+                'uId'   => 'lpa-uid',
             ],
-            new \DateTime('now')
+            new DateTime('now')
         );
 
         $this->lpaServiceProphecy
@@ -339,19 +340,19 @@ class CodesApiValidationStrategyTest extends TestCase
             ->willReturn($lpa);
 
         $this->resolveActorProphecy
-            ->__invoke($lpa->getData(), 'actor-uid')
+            ->__invoke($lpa->getData(), 123456789)
             ->shouldBeCalled()
             ->willReturn(
                 [
-                    'type' => 'trust-corporation',
+                    'type'    => 'trust-corporation',
                     'details' => [
-                        'id' => 9,
-                        'uId' => 'actor-uid',
-                        'firstname' => 'trust',
-                        'surname' => 'corporation',
-                        'companyName' => 'trust corporation ltd',
-                        'systemStatus' => true
-                    ]
+                        'id'           => 9,
+                        'uId'          => 123456789,
+                        'firstname'    => 'trust',
+                        'surname'      => 'corporation',
+                        'companyName'  => 'trust corporation ltd',
+                        'systemStatus' => true,
+                    ],
                 ]
             );
 

--- a/service-api/app/test/AppTest/Service/ActorCodes/Validation/DynamoCodeValidationStrategyTest.php
+++ b/service-api/app/test/AppTest/Service/ActorCodes/Validation/DynamoCodeValidationStrategyTest.php
@@ -44,7 +44,7 @@ class DynamoCodeValidationStrategyTest extends TestCase
                 [
                     'Active'     => true,
                     'SiriusUid'  => 'lpa-uid',
-                    'ActorLpaId' => 'actor-lpa-id'
+                    'ActorLpaId' => '123456789'
                 ]
             );
 
@@ -59,11 +59,11 @@ class DynamoCodeValidationStrategyTest extends TestCase
             ->getByUid('lpa-uid')
             ->willReturn($lpa);
 
-        $this->resolveActorProphecy->__invoke($lpa->getData(), 'actor-lpa-id')
+        $this->resolveActorProphecy->__invoke($lpa->getData(), 123456789)
             ->willReturn(
                 [
                     'details' => [
-                        'uId' => 'actor-uid',
+                        'uId' => 123456789,
                         'dob' => 'actor-dob'
                     ]
                 ]
@@ -78,7 +78,7 @@ class DynamoCodeValidationStrategyTest extends TestCase
 
         $actorUId = $strategy->validateCode('actor-code', 'lpa-uid', 'actor-dob');
 
-        $this->assertEquals('actor-uid', $actorUId);
+        $this->assertEquals('123456789', $actorUId);
     }
 
     /** @test */
@@ -188,7 +188,7 @@ class DynamoCodeValidationStrategyTest extends TestCase
                 [
                     'Active'     => true,
                     'SiriusUid'  => 'lpa-uid',
-                    'ActorLpaId' => 'actor-lpa-id'
+                    'ActorLpaId' => '123456789'
                 ]
             );
 
@@ -203,7 +203,7 @@ class DynamoCodeValidationStrategyTest extends TestCase
             ->getByUid('lpa-uid')
             ->willReturn($lpa);
 
-        $this->resolveActorProphecy->__invoke($lpa->getData(), 'actor-lpa-id')
+        $this->resolveActorProphecy->__invoke($lpa->getData(), 123456789)
             ->willReturn(null);
 
         $strategy = new DynamoCodeValidationStrategy(
@@ -228,7 +228,7 @@ class DynamoCodeValidationStrategyTest extends TestCase
                 [
                     'Active'     => true,
                     'SiriusUid'  => 'lpa-uid',
-                    'ActorLpaId' => 'actor-lpa-id'
+                    'ActorLpaId' => '123456789'
                 ]
             );
 
@@ -243,7 +243,7 @@ class DynamoCodeValidationStrategyTest extends TestCase
             ->getByUid('lpa-uid')
             ->willReturn($lpa);
 
-        $this->resolveActorProphecy->__invoke($lpa->getData(), 'actor-lpa-id')
+        $this->resolveActorProphecy->__invoke($lpa->getData(), 123456789)
             ->willReturn(
                 [
                     'details' => [

--- a/service-api/app/test/AppTest/Service/Lpa/LpaServiceTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/LpaServiceTest.php
@@ -11,6 +11,7 @@ use App\DataAccess\{ApiGateway\ActorCodes,
 use App\DataAccess\Repository\Response\Lpa;
 use App\Service\Lpa\{GetAttorneyStatus, GetTrustCorporationStatus, IsValidLpa, LpaService, ResolveActor};
 use App\Service\ViewerCodes\ViewerCodeService;
+use DateInterval;
 use DateTime;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -37,20 +38,17 @@ class LpaServiceTest extends TestCase
 
     public function setUp(): void
     {
-        $this->viewerCodesInterfaceProphecy = $this->prophesize(Repository\ViewerCodesInterface::class);
+        $this->viewerCodesInterfaceProphecy        = $this->prophesize(Repository\ViewerCodesInterface::class);
         $this->viewerCodeActivityInterfaceProphecy = $this->prophesize(Repository\ViewerCodeActivityInterface::class);
-        $this->lpasInterfaceProphecy = $this->prophesize(Repository\LpasInterface::class);
-        $this->userLpaActorMapInterfaceProphecy = $this->prophesize(Repository\UserLpaActorMapInterface::class);
-        $this->loggerProphecy = $this->prophesize(LoggerInterface::class);
-        $this->actorCodesProphecy = $this->prophesize(ActorCodes::class);
-        $this->resolveActorProphecy = $this->prophesize(ResolveActor::class);
-        $this->getAttorneyStatusProphecy = $this->prophesize(GetAttorneyStatus::class);
-        $this->isValidLpaProphecy = $this->prophesize(IsValidLpa::class);
-        $this->getTrustCorporationStatusProphecy = $this->prophesize(GetTrustCorporationStatus::class);
+        $this->lpasInterfaceProphecy               = $this->prophesize(Repository\LpasInterface::class);
+        $this->userLpaActorMapInterfaceProphecy    = $this->prophesize(Repository\UserLpaActorMapInterface::class);
+        $this->loggerProphecy                      = $this->prophesize(LoggerInterface::class);
+        $this->actorCodesProphecy                  = $this->prophesize(ActorCodes::class);
+        $this->resolveActorProphecy                = $this->prophesize(ResolveActor::class);
+        $this->getAttorneyStatusProphecy           = $this->prophesize(GetAttorneyStatus::class);
+        $this->isValidLpaProphecy                  = $this->prophesize(IsValidLpa::class);
+        $this->getTrustCorporationStatusProphecy   = $this->prophesize(GetTrustCorporationStatus::class);
     }
-
-    //-------------------------------------------------------------------------
-    // Test getByUid()
 
     private function getLpaService(): LpaService
     {
@@ -70,9 +68,9 @@ class LpaServiceTest extends TestCase
 
     private function getViewerCodeService(): ViewerCodeService
     {
-        $viewerCodeRepoProphecy = $this->prophesize(ViewerCodesInterface::class);
+        $viewerCodeRepoProphecy   = $this->prophesize(ViewerCodesInterface::class);
         $userActorLpaRepoProphecy = $this->prophesize(UserLpaActorMapInterface::class);
-        $lpaServiceProphecy = $this->prophesize(LpaService::class);
+        $lpaServiceProphecy       = $this->prophesize(LpaService::class);
 
         return new ViewerCodeService(
             $viewerCodeRepoProphecy->reveal(),
@@ -87,7 +85,7 @@ class LpaServiceTest extends TestCase
         $testUid = '700012349874';
 
         $lpaResponse = new Lpa([
-            'attorneys' => [
+            'attorneys'         => [
                 ['id' => 1, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true],
                 ['id' => 2, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => false],
                 ['id' => 3, 'firstname' => 'A', 'systemStatus' => true],
@@ -95,12 +93,12 @@ class LpaServiceTest extends TestCase
                 ['id' => 5, 'systemStatus' => true],
             ],
             'trustCorporations' => [
-                ['id' => 6, 'companyName' => 'XYZ Ltd', 'systemStatus' => true]
-            ]
+                ['id' => 6, 'companyName' => 'XYZ Ltd', 'systemStatus' => true],
+            ],
         ], new DateTime());
 
         $expectedLpaResponse = new Lpa([
-            'attorneys' => [
+            'attorneys'         => [
                 ['id' => 1, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true],
                 ['id' => 2, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => false],
                 ['id' => 3, 'firstname' => 'A', 'systemStatus' => true],
@@ -115,16 +113,16 @@ class LpaServiceTest extends TestCase
                 ['id' => 5, 'systemStatus' => true],
             ],
             'trustCorporations' => [
-                ['id' => 6, 'companyName' => 'XYZ Ltd', 'systemStatus' => true]
+                ['id' => 6, 'companyName' => 'XYZ Ltd', 'systemStatus' => true],
             ],
             'inactiveAttorneys' => [
                 ['id' => 2, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => false],
             ],
-            'activeAttorneys' => [
+            'activeAttorneys'   => [
                 ['id' => 1, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true],
                 ['id' => 3, 'firstname' => 'A', 'systemStatus' => true],
                 ['id' => 4, 'surname' => 'B', 'systemStatus' => true],
-            ]
+            ],
         ], $lpaResponse->getLookupTime());
 
         //---
@@ -173,30 +171,30 @@ class LpaServiceTest extends TestCase
     {
         $t = new stdClass();
 
-        $t->Token = 'test-token';
-        $t->UserId = 'test-user-id';
+        $t->Token     = 'test-token';
+        $t->UserId    = 'test-user-id';
         $t->SiriusUid = 'test-sirius-uid';
-        $t->ActorId = 1;
-        $t->Lpa = new Lpa(
+        $t->ActorId   = 1;
+        $t->Lpa       = new Lpa(
             [
-                'uId' => $t->SiriusUid,
-                'status' => 'Registered',
-                'attorneys' => [
+                'uId'               => $t->SiriusUid,
+                'status'            => 'Registered',
+                'attorneys'         => [
                     [
-                        'id' => $t->ActorId,
-                        'firstname' => 'Test',
-                        'surname' => 'Test',
-                        'systemStatus' => true
-                    ]
+                        'id'           => $t->ActorId,
+                        'firstname'    => 'Test',
+                        'surname'      => 'Test',
+                        'systemStatus' => true,
+                    ],
                 ],
                 'trustCorporations' => [],
-                'activeAttorneys' => [
+                'activeAttorneys'   => [
                     [
-                        'id' => 1,
-                        'firstname' => 'Test',
-                        'surname' => 'Test',
-                        'systemStatus' => true
-                    ]
+                        'id'           => 1,
+                        'firstname'    => 'Test',
+                        'surname'      => 'Test',
+                        'systemStatus' => true,
+                    ],
                 ],
                 'inactiveAttorneys' => [],
             ],
@@ -204,10 +202,10 @@ class LpaServiceTest extends TestCase
         );
 
         $this->userLpaActorMapInterfaceProphecy->get($t->Token)->willReturn([
-            'Id' => $t->Token,
-            'UserId' => $t->UserId,
+            'Id'        => $t->Token,
+            'UserId'    => $t->UserId,
             'SiriusUid' => $t->SiriusUid,
-            'ActorId' => $t->ActorId,
+            'ActorId'   => $t->ActorId,
         ]);
 
         $this->lpasInterfaceProphecy->get($t->SiriusUid)->willReturn($t->Lpa);
@@ -215,35 +213,35 @@ class LpaServiceTest extends TestCase
         // resolves LPA actor as primary attorney
         $this->resolveActorProphecy
             ->__invoke([
-                'uId' => $t->SiriusUid,
-                'status' => 'Registered',
-                'attorneys' => [
+                'uId'               => $t->SiriusUid,
+                'status'            => 'Registered',
+                'attorneys'         => [
                     [
-                        'id' => $t->ActorId,
-                        'firstname' => 'Test',
-                        'surname' => 'Test',
-                        'systemStatus' => true
-                    ]
+                        'id'           => $t->ActorId,
+                        'firstname'    => 'Test',
+                        'surname'      => 'Test',
+                        'systemStatus' => true,
+                    ],
                 ],
                 'trustCorporations' => [],
-                'activeAttorneys' => [
+                'activeAttorneys'   => [
                     [
-                        'id' => 1,
-                        'firstname' => 'Test',
-                        'surname' => 'Test',
-                        'systemStatus' => true
-                    ]
+                        'id'           => 1,
+                        'firstname'    => 'Test',
+                        'surname'      => 'Test',
+                        'systemStatus' => true,
+                    ],
                 ],
                 'inactiveAttorneys' => [],
-            ], (string) $t->ActorId)
+            ], $t->ActorId)
             ->willReturn([
-                'type' => 'primary-attorney',
+                'type'    => 'primary-attorney',
                 'details' => [
-                    'id' => $t->ActorId,
-                    'firstname' => 'Test',
-                    'surname' => 'Test',
-                    'systemStatus' => true
-                ]
+                    'id'           => $t->ActorId,
+                    'firstname'    => 'Test',
+                    'surname'      => 'Test',
+                    'systemStatus' => true,
+                ],
             ]);
 
         // check valid lpa
@@ -253,10 +251,10 @@ class LpaServiceTest extends TestCase
 
         // attorney status is active
         $this->getAttorneyStatusProphecy->__invoke([
-            'id' => $t->ActorId,
-            'firstname' => 'Test',
-            'surname' => 'Test',
-            'systemStatus' => true
+            'id'           => $t->ActorId,
+            'firstname'    => 'Test',
+            'surname'      => 'Test',
+            'systemStatus' => true,
         ])->willReturn(0);
 
         return $t;
@@ -269,44 +267,44 @@ class LpaServiceTest extends TestCase
     {
         $t = new stdClass();
 
-        $t->Token = 'test-token';
-        $t->UserId = 'test-user-id';
+        $t->Token     = 'test-token';
+        $t->UserId    = 'test-user-id';
         $t->SiriusUid = 'test-sirius-uid';
-        $t->ActorId = 1;
-        $t->Lpa = new Lpa(
+        $t->ActorId   = 1;
+        $t->Lpa       = new Lpa(
             [
-                'uId' => $t->SiriusUid,
-                'status' => 'Registered',
-                'attorneys' => [
+                'uId'               => $t->SiriusUid,
+                'status'            => 'Registered',
+                'attorneys'         => [
                     [
-                        'id' => $t->ActorId,
-                        'firstname' => 'Test',
-                        'surname' => 'Test',
-                        'systemStatus' => true
+                        'id'           => $t->ActorId,
+                        'firstname'    => 'Test',
+                        'surname'      => 'Test',
+                        'systemStatus' => true,
                     ],
                     [
-                        'id' => 2,
-                        'firstname' => 'Test',
-                        'surname' => 'Test',
-                        'systemStatus' => false
-                    ]
+                        'id'           => 2,
+                        'firstname'    => 'Test',
+                        'surname'      => 'Test',
+                        'systemStatus' => false,
+                    ],
                 ],
                 'trustCorporations' => [],
-                'activeAttorneys' => [
+                'activeAttorneys'   => [
                     [
-                        'id' => 1,
-                        'firstname' => 'Test',
-                        'surname' => 'Test',
-                        'systemStatus' => true
-                    ]
+                        'id'           => 1,
+                        'firstname'    => 'Test',
+                        'surname'      => 'Test',
+                        'systemStatus' => true,
+                    ],
                 ],
                 'inactiveAttorneys' => [
                     [
-                        'id' => 2,
-                        'firstname' => 'Test',
-                        'surname' => 'Test',
-                        'systemStatus' => false
-                    ]
+                        'id'           => 2,
+                        'firstname'    => 'Test',
+                        'surname'      => 'Test',
+                        'systemStatus' => false,
+                    ],
                 ],
             ],
             new DateTime()
@@ -314,10 +312,10 @@ class LpaServiceTest extends TestCase
 
         $this->userLpaActorMapInterfaceProphecy->get($t->Token)
             ->willReturn([
-                'Id' => $t->Token,
-                'UserId' => $t->UserId,
+                'Id'        => $t->Token,
+                'UserId'    => $t->UserId,
                 'SiriusUid' => $t->SiriusUid,
-                'ActorId' => $t->ActorId,
+                'ActorId'   => $t->ActorId,
             ]);
 
         $this->lpasInterfaceProphecy->get($t->SiriusUid)->willReturn($t->Lpa);
@@ -325,48 +323,48 @@ class LpaServiceTest extends TestCase
         // resolves LPA actor as primary attorney
         $this->resolveActorProphecy
             ->__invoke([
-                'uId' => $t->SiriusUid,
-                'status' => 'Registered',
-                'attorneys' => [
+                'uId'               => $t->SiriusUid,
+                'status'            => 'Registered',
+                'attorneys'         => [
                     [
-                        'id' => $t->ActorId,
-                        'firstname' => 'Test',
-                        'surname' => 'Test',
-                        'systemStatus' => true
+                        'id'           => $t->ActorId,
+                        'firstname'    => 'Test',
+                        'surname'      => 'Test',
+                        'systemStatus' => true,
                     ],
                     [
-                        'id' => 2,
-                        'firstname' => 'Test',
-                        'surname' => 'Test',
-                        'systemStatus' => false
-                    ]
+                        'id'           => 2,
+                        'firstname'    => 'Test',
+                        'surname'      => 'Test',
+                        'systemStatus' => false,
+                    ],
                 ],
                 'trustCorporations' => [],
-                'activeAttorneys' => [
+                'activeAttorneys'   => [
                     [
-                        'id' => 1,
-                        'firstname' => 'Test',
-                        'surname' => 'Test',
-                        'systemStatus' => true
-                    ]
+                        'id'           => 1,
+                        'firstname'    => 'Test',
+                        'surname'      => 'Test',
+                        'systemStatus' => true,
+                    ],
                 ],
                 'inactiveAttorneys' => [
                     [
-                        'id' => 2,
-                        'firstname' => 'Test',
-                        'surname' => 'Test',
-                        'systemStatus' => false
-                    ]
+                        'id'           => 2,
+                        'firstname'    => 'Test',
+                        'surname'      => 'Test',
+                        'systemStatus' => false,
+                    ],
                 ],
-            ], (string) $t->ActorId)
+            ], $t->ActorId)
             ->willReturn([
-                'type' => 'primary-attorney',
+                'type'    => 'primary-attorney',
                 'details' => [
-                    'id' => $t->ActorId,
-                    'firstname' => 'Test',
-                    'surname' => 'Test',
-                    'systemStatus' => true
-                ]
+                    'id'           => $t->ActorId,
+                    'firstname'    => 'Test',
+                    'surname'      => 'Test',
+                    'systemStatus' => true,
+                ],
             ]);
 
         // check valid lpa
@@ -376,17 +374,17 @@ class LpaServiceTest extends TestCase
 
         // attorney status is active
         $this->getAttorneyStatusProphecy->__invoke([
-            'id' => $t->ActorId,
-            'firstname' => 'Test',
-            'surname' => 'Test',
-            'systemStatus' => true
-       ])->willReturn(0);
+            'id'           => $t->ActorId,
+            'firstname'    => 'Test',
+            'surname'      => 'Test',
+            'systemStatus' => true,
+        ])->willReturn(0);
 
         $this->getAttorneyStatusProphecy->__invoke([
-            'id' => 2,
-            'firstname' => 'Test',
-            'surname' => 'Test',
-            'systemStatus' => false
+            'id'           => 2,
+            'firstname'    => 'Test',
+            'surname'      => 'Test',
+            'systemStatus' => false,
         ])->willReturn(2);
 
         return $t;
@@ -399,42 +397,41 @@ class LpaServiceTest extends TestCase
     {
         $t = new stdClass();
 
-        $t->Token = 'test-token';
-        $t->UserId = 'test-user-id';
+        $t->Token     = 'test-token';
+        $t->UserId    = 'test-user-id';
         $t->SiriusUid = 'test-sirius-uid';
-        $t->ActorId = 1;
-        $t->Lpa = new Lpa(
+        $t->ActorId   = 1;
+        $t->Lpa       = new Lpa(
             [
-                'uId' => $t->SiriusUid,
-                'status' => 'Registered',
-                'attorneys' => [
+                'uId'               => $t->SiriusUid,
+                'status'            => 'Registered',
+                'attorneys'         => [
                     [
-                        'id' => 1,
-                        'firstname' => 'Test',
-                        'surname' => 'Test',
-                        'systemStatus' => false
-                    ]
+                        'id'           => 1,
+                        'firstname'    => 'Test',
+                        'surname'      => 'Test',
+                        'systemStatus' => false,
+                    ],
                 ],
                 'trustCorporations' => [],
-                'activeAttorneys' => [
-                ],
+                'activeAttorneys'   => [],
                 'inactiveAttorneys' => [
                     [
-                        'id' => 1,
-                        'firstname' => 'Test',
-                        'surname' => 'Test',
-                        'systemStatus' => false
-                    ]
+                        'id'           => 1,
+                        'firstname'    => 'Test',
+                        'surname'      => 'Test',
+                        'systemStatus' => false,
+                    ],
                 ],
             ],
             new DateTime()
         );
 
         $this->userLpaActorMapInterfaceProphecy->get($t->Token)->willReturn([
-            'Id' => $t->Token,
-            'UserId' => $t->UserId,
+            'Id'        => $t->Token,
+            'UserId'    => $t->UserId,
             'SiriusUid' => $t->SiriusUid,
-            'ActorId' => $t->ActorId,
+            'ActorId'   => $t->ActorId,
         ]);
 
         $this->lpasInterfaceProphecy->get($t->SiriusUid)->willReturn($t->Lpa);
@@ -442,35 +439,35 @@ class LpaServiceTest extends TestCase
         // resolves LPA actor as primary attorney
         $this->resolveActorProphecy
             ->__invoke([
-                'uId' => $t->SiriusUid,
-                'status' => 'Registered',
-                'attorneys' => [
+                'uId'               => $t->SiriusUid,
+                'status'            => 'Registered',
+                'attorneys'         => [
                     [
-                        'id' => 1,
-                        'firstname' => 'Test',
-                        'surname' => 'Test',
+                        'id'           => 1,
+                        'firstname'    => 'Test',
+                        'surname'      => 'Test',
                         'systemStatus' => false,
                     ],
                 ],
                 'trustCorporations' => [],
-                'activeAttorneys' => [],
+                'activeAttorneys'   => [],
                 'inactiveAttorneys' => [
                     [
-                        'id' => 1,
-                        'firstname' => 'Test',
-                        'surname' => 'Test',
-                        'systemStatus' => false
-                    ]
+                        'id'           => 1,
+                        'firstname'    => 'Test',
+                        'surname'      => 'Test',
+                        'systemStatus' => false,
+                    ],
                 ],
-            ], (string) $t->ActorId)
+            ], $t->ActorId)
             ->willReturn([
-                'type' => 'primary-attorney',
+                'type'    => 'primary-attorney',
                 'details' => [
-                    'id' => $t->ActorId,
-                    'firstname' => 'Test',
-                    'surname' => 'Test',
-                    'systemStatus' => false
-                ]
+                    'id'           => $t->ActorId,
+                    'firstname'    => 'Test',
+                    'surname'      => 'Test',
+                    'systemStatus' => false,
+                ],
             ]);
 
         // check valid lpa
@@ -479,10 +476,10 @@ class LpaServiceTest extends TestCase
         )->willReturn(true);
 
         $this->getAttorneyStatusProphecy->__invoke([
-            'id' => 1,
-            'firstname' => 'Test',
-            'surname' => 'Test',
-            'systemStatus' => false
+            'id'           => 1,
+            'firstname'    => 'Test',
+            'surname'      => 'Test',
+            'systemStatus' => false,
         ])->willReturn(2);
 
         return $t;
@@ -495,7 +492,7 @@ class LpaServiceTest extends TestCase
 
         $service = $this->getLpaService();
 
-        $result = $service->getByUserLpaActorToken($t->Token, $t->UserId);
+        $result = $service->getByUserLpaActorToken($t->Token, (string) $t->UserId);
 
         $this->assertIsArray($result);
         $this->assertArrayHasKey('user-lpa-actor-token', $result);
@@ -506,33 +503,33 @@ class LpaServiceTest extends TestCase
         $this->assertEquals($t->Token, $result['user-lpa-actor-token']);
         $this->assertEquals($t->Lpa->getLookupTime()->getTimestamp(), strtotime($result['date']));
         $this->assertEquals([
-            'type' => 'primary-attorney',
+            'type'    => 'primary-attorney',
             'details' => [
-                'id' => $t->ActorId,
-                'firstname' => 'Test',
-                'surname' => 'Test',
-                'systemStatus' => true
-            ]
+                'id'           => $t->ActorId,
+                'firstname'    => 'Test',
+                'surname'      => 'Test',
+                'systemStatus' => true,
+            ],
         ], $result['actor']);
         $this->assertEquals([
-            'uId' => $t->SiriusUid,
-            'status' => 'Registered',
-            'attorneys' => [
+            'uId'               => $t->SiriusUid,
+            'status'            => 'Registered',
+            'attorneys'         => [
                 [
-                    'id' => $t->ActorId,
-                    'firstname' => 'Test',
-                    'surname' => 'Test',
-                    'systemStatus' => true
-                ]
+                    'id'           => $t->ActorId,
+                    'firstname'    => 'Test',
+                    'surname'      => 'Test',
+                    'systemStatus' => true,
+                ],
             ],
             'trustCorporations' => [],
-            'activeAttorneys' => [
+            'activeAttorneys'   => [
                 0 => [
-                    'id' => $t->ActorId,
-                    'firstname' => 'Test',
-                    'surname' => 'Test',
-                    'systemStatus' => true
-                ]
+                    'id'           => $t->ActorId,
+                    'firstname'    => 'Test',
+                    'surname'      => 'Test',
+                    'systemStatus' => true,
+                ],
             ],
             'inactiveAttorneys' => [],
         ], $result['lpa']);
@@ -545,7 +542,7 @@ class LpaServiceTest extends TestCase
 
         $service = $this->getLpaService();
 
-        $result = $service->getByUserLpaActorToken($t->Token, $t->UserId);
+        $result = $service->getByUserLpaActorToken($t->Token, (string) $t->UserId);
 
         $this->assertNotNull($result);
         $this->assertNotNull($result['actor']);
@@ -558,7 +555,7 @@ class LpaServiceTest extends TestCase
 
         $service = $this->getLpaService();
 
-        $result = $service->getByUserLpaActorToken($t->Token, $t->UserId);
+        $result = $service->getByUserLpaActorToken($t->Token, (string) $t->UserId);
 
         $this->assertNotNull($result);
         $this->assertNotNull($result['actor']);
@@ -571,7 +568,7 @@ class LpaServiceTest extends TestCase
 
         $service = $this->getLpaService();
 
-        $result = $service->getByUserLpaActorToken($t->Token, 'different-user-id');
+        $result = $service->getByUserLpaActorToken($t->Token, (string) 123);
 
         $this->assertNull($result);
     }
@@ -586,7 +583,7 @@ class LpaServiceTest extends TestCase
 
         $service = $this->getLpaService();
 
-        $result = $service->getByUserLpaActorToken($t->Token, $t->UserId);
+        $result = $service->getByUserLpaActorToken($t->Token, (string) $t->UserId);
 
         $this->assertNull($result);
     }
@@ -598,7 +595,7 @@ class LpaServiceTest extends TestCase
 
         $service = $this->getLpaService();
 
-        $result = $service->getByUserLpaActorToken($t->Token, $t->UserId);
+        $result = $service->getByUserLpaActorToken($t->Token, (string) $t->UserId);
 
         $this->assertEmpty($result);
     }
@@ -614,35 +611,35 @@ class LpaServiceTest extends TestCase
 
         $t->mapResults = [
             [
-                'Id' => 'token-1',
+                'Id'        => 'token-1',
                 'SiriusUid' => 'uid-1',
-                'ActorId' => 1,
-                'Added'   => new DateTime('now')
+                'ActorId'   => 1,
+                'Added'     => new DateTime('now'),
             ],
             [
-                'Id' => 'token-2',
+                'Id'        => 'token-2',
                 'SiriusUid' => 'uid-2',
-                'ActorId' => 2,
-                'Added'   => new DateTime('now')
+                'ActorId'   => 2,
+                'Added'     => new DateTime('now'),
             ],
             [
-                'Id' => 'token-3',
-                'SiriusUid' => 'uid-3',
-                'ActorId' => 3,
-                'ActivateBy' => (new DateTime('now'))->add(new \DateInterval('P1Y'))->getTimeStamp(),
-                'Added'   => new DateTime('now')
-            ]
+                'Id'         => 'token-3',
+                'SiriusUid'  => 'uid-3',
+                'ActorId'    => 3,
+                'ActivateBy' => (new DateTime('now'))->add(new DateInterval('P1Y'))->getTimeStamp(),
+                'Added'      => new DateTime('now'),
+            ],
         ];
 
         $t->lpaResults = [
             'uid-1' => new Lpa([
-                'uId'       => 'uid-1',
-                'status'    => 'Registered',
+                'uId'    => 'uid-1',
+                'status' => 'Registered',
             ], new DateTime()),
             'uid-2' => new Lpa([
-                'uId'       => 'uid-2',
-                'status'    => 'Registered',
-            ], new DateTime())
+                'uId'    => 'uid-2',
+                'status' => 'Registered',
+            ], new DateTime()),
         ];
 
         $this->userLpaActorMapInterfaceProphecy->getByUserId($t->UserId)->willReturn($t->mapResults);
@@ -660,10 +657,12 @@ class LpaServiceTest extends TestCase
         )->willReturn(true);
 
         if ($includeActivated) {
-            $t->lpaResults['uid-3'] = new Lpa([
-                                                  'uId' => 'uid-3',
-                                                  'status' => 'Registered'
-                                              ], new DateTime());
+            $t->lpaResults['uid-3'] = new Lpa(
+                [
+                   'status' => 'Registered',
+                    'uId'    => 'uid-3',
+                ], new DateTime()
+            );
             $this->lpasInterfaceProphecy->lookup(['uid-1', 'uid-2', 'uid-3'])->willReturn($t->lpaResults);
 
             // check valid lpa
@@ -761,38 +760,38 @@ class LpaServiceTest extends TestCase
 
         $t->mapResults = [
             [
-                'Id' => 'token-1',
+                'Id'        => 'token-1',
                 'SiriusUid' => 'uid-1',
-                'ActorId' => 1,
-                'Added'   => new DateTime('today')
+                'ActorId'   => 1,
+                'Added'     => new DateTime('today'),
             ],
             [
-                'Id' => 'token-2',
+                'Id'        => 'token-2',
                 'SiriusUid' => 'uid-2',
-                'ActorId' => 2,
-                'Added'   => new DateTime('today')
-            ]
+                'ActorId'   => 2,
+                'Added'     => new DateTime('today'),
+            ],
         ];
 
         $lpa1 = new Lpa([
-            'uId'       => 'uid-1',
-            'status'    => 'Registered',
-            'donor'     => [
-                'linked' => [['id' => 1, 'uId' => 'person-1']]
+            'uId'    => 'uid-1',
+            'status' => 'Registered',
+            'donor'  => [
+                'linked' => [['id' => 1, 'uId' => 'person-1']],
             ],
         ], new DateTime());
 
         $lpa2 = new Lpa([
-            'uId'       => 'uid-2',
-            'status'    => 'Registered',
-            'donor'     => [
-                'linked' => [['id' => 2, 'uId' => 'person-2']]
+            'uId'    => 'uid-2',
+            'status' => 'Registered',
+            'donor'  => [
+                'linked' => [['id' => 2, 'uId' => 'person-2']],
             ],
         ], new DateTime());
 
         $t->lpaResults = [
             'uid-1' => $lpa1,
-            'uid-2' => $lpa2
+            'uid-2' => $lpa2,
         ];
 
         $this->userLpaActorMapInterfaceProphecy->getByUserId($t->UserId)->willReturn($t->mapResults);
@@ -802,22 +801,22 @@ class LpaServiceTest extends TestCase
         // resolves the donor as the actor for LPA 1
         $this->resolveActorProphecy->__invoke(
             $lpa1->getData(),
-            '1'
+            1
         )->willReturn([
-            'type' => 'donor',
+            'type'    => 'donor',
             'details' => [
-                'linked' => [['id' => 1, 'uId' => 'person-1']]
+                'linked' => [['id' => 1, 'uId' => 'person-1']],
             ],
         ]);
 
         // resolves the donor as the actor for LPA 2
         $this->resolveActorProphecy->__invoke(
             $lpa2->getData(),
-            '2'
+            2
         )->willReturn([
-            'type' => 'donor',
+            'type'    => 'donor',
             'details' => [
-                'linked' => [['id' => 2, 'uId' => 'person-2']]
+                'linked' => [['id' => 2, 'uId' => 'person-2']],
             ],
         ]);
 
@@ -875,28 +874,28 @@ class LpaServiceTest extends TestCase
     {
         $t = new stdClass();
 
-        $t->ViewerCode = 'test-viewer-code';
+        $t->ViewerCode   = 'test-viewer-code';
         $t->Organisation = 'test-organisation';
         $t->DonorSurname = 'test-donor-surename';
-        $t->SiriusUid = 'test-sirius-uid';
-        $t->Expires = new DateTime('+1 hour');
+        $t->SiriusUid    = 'test-sirius-uid';
+        $t->Expires      = new DateTime('+1 hour');
 
         $t->Lpa = new Lpa([
-            'uId' => $t->SiriusUid,
-            'donor' => [
+            'uId'               => $t->SiriusUid,
+            'donor'             => [
                 'surname' => $t->DonorSurname,
             ],
-            'attorneys' => [],
+            'attorneys'         => [],
             'trustCorporations' => [],
-            'activeAttorneys' => [],
-            'inactiveAttorneys' => []
+            'activeAttorneys'   => [],
+            'inactiveAttorneys' => [],
         ], new DateTime());
 
 
         $this->viewerCodesInterfaceProphecy->get($t->ViewerCode)->willReturn([
-            'ViewerCode' => $t->ViewerCode,
-            'SiriusUid' => $t->SiriusUid,
-            'Expires' => $t->Expires,
+            'ViewerCode'   => $t->ViewerCode,
+            'SiriusUid'    => $t->SiriusUid,
+            'Expires'      => $t->Expires,
             'Organisation' => $t->Organisation,
         ]);
 
@@ -1021,7 +1020,7 @@ class LpaServiceTest extends TestCase
 
         $this->viewerCodesInterfaceProphecy->get($t->ViewerCode)->willReturn([
             'ViewerCode' => $t->ViewerCode,
-            'SiriusUid' => $t->SiriusUid,
+            'SiriusUid'  => $t->SiriusUid,
             //'Expires' => $t->Expires,             <-- Expires is removed
             'Organisation' => $t->Organisation,
         ]);
@@ -1044,17 +1043,17 @@ class LpaServiceTest extends TestCase
         //---
 
         $this->viewerCodesInterfaceProphecy->get($t->ViewerCode)->willReturn([
-            'ViewerCode' => $t->ViewerCode,
-            'SiriusUid' => $t->SiriusUid,
-            'Expires' => new DateTime('1 hour'),
-            'Cancelled' => true,
+            'ViewerCode'   => $t->ViewerCode,
+            'SiriusUid'    => $t->SiriusUid,
+            'Expires'      => new DateTime('1 hour'),
+            'Cancelled'    => true,
             'Organisation' => $t->Organisation,
         ]);
 
         //---
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Share code cancelled");
+        $this->expectExceptionMessage('Share code cancelled');
 
         $service->getByViewerCode($t->ViewerCode, $t->DonorSurname, null);
     }
@@ -1069,16 +1068,16 @@ class LpaServiceTest extends TestCase
         //---
 
         $this->viewerCodesInterfaceProphecy->get($t->ViewerCode)->willReturn([
-            'ViewerCode' => $t->ViewerCode,
-            'SiriusUid' => $t->SiriusUid,
-            'Expires' => new DateTime('-1 hour'),
+            'ViewerCode'   => $t->ViewerCode,
+            'SiriusUid'    => $t->SiriusUid,
+            'Expires'      => new DateTime('-1 hour'),
             'Organisation' => $t->Organisation,
         ]);
 
         //---
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Share code expired");
+        $this->expectExceptionMessage('Share code expired');
 
         $service->getByViewerCode($t->ViewerCode, $t->DonorSurname, null);
     }

--- a/service-api/app/test/AppTest/Service/Lpa/ResolveActorTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/ResolveActorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AppTest\Service\Lpa;
 
 use App\Service\Lpa\GetAttorneyStatus;
@@ -18,16 +20,12 @@ class ResolveActorTest extends TestCase
 
     public function setUp(): void
     {
-        $this->loggerProphecy = $this->prophesize(LoggerInterface::class);
         $this->getAttorneyStatusProphecy = $this->prophesize(GetAttorneyStatus::class);
     }
 
     private function getActorResolver(): ResolveActor
     {
-        return new ResolveActor(
-            $this->loggerProphecy->reveal(),
-            $this->getAttorneyStatusProphecy->reveal()
-        );
+        return new ResolveActor();
     }
 
     /** @test */
@@ -36,27 +34,27 @@ class ResolveActorTest extends TestCase
         $lpa = [
             'donor' => [
                 'id'  => 1,
-                'uId' => '123456789012'
-            ]
+                'uId' => '123456789012',
+            ],
         ];
 
         $resolver = $this->getActorResolver();
 
-        $result = $resolver($lpa, '1');
+        $result = $resolver($lpa, 1);
 
         $this->assertEquals(
             [
-                'type' => 'donor',
+                'type'    => 'donor',
                 'details' => $lpa['donor'],
             ],
             $result
         );
 
-        $result = $resolver($lpa, '123456789012');
+        $result = $resolver($lpa, 123456789012);
 
         $this->assertEquals(
             [
-                'type' => 'donor',
+                'type'    => 'donor',
                 'details' => $lpa['donor'],
             ],
             $result
@@ -68,19 +66,19 @@ class ResolveActorTest extends TestCase
     {
         $lpa = [
             'donor' => [
-                'id'  => 1,
-                'uId' => '123456789013',
+                'id'     => 1,
+                'uId'    => '123456789013',
                 'linked' => [['id' => 1, 'uId' => '123456789013'], ['id' => 2, 'uId' => '123456789012']],
-            ]
+            ],
         ];
 
         $resolver = $this->getActorResolver();
 
-        $result = $resolver($lpa, '2');
+        $result = $resolver($lpa, 2);
 
         $this->assertEquals(
             [
-                'type' => 'donor',
+                'type'    => 'donor',
                 'details' => $lpa['donor'],
             ],
             $result
@@ -92,19 +90,19 @@ class ResolveActorTest extends TestCase
     {
         $lpa = [
             'donor' => [
-                'id'  => 1,
-                'uId' => '123456789013',
+                'id'     => 1,
+                'uId'    => '123456789013',
                 'linked' => [['id' => 1, 'uId' => '123456789013'], ['id' => 2, 'uId' => '123456789012']],
-            ]
+            ],
         ];
 
         $resolver = $this->getActorResolver();
 
-        $result = $resolver($lpa, '123456789012');
+        $result = $resolver($lpa, 123456789012);
 
         $this->assertEquals(
             [
-                'type' => 'donor',
+                'type'    => 'donor',
                 'details' => $lpa['donor'],
             ],
             $result
@@ -116,15 +114,15 @@ class ResolveActorTest extends TestCase
     {
         $lpa = [
             'donor' => [
-                'id'  => 1,
-                'uId' => '123456789013',
+                'id'     => 1,
+                'uId'    => '123456789013',
                 'linked' => [['id' => 1, 'uId' => '123456789013'], ['id' => 2, 'uId' => '123456789012']],
-            ]
+            ],
         ];
 
         $resolver = $this->getActorResolver();
 
-        $result = $resolver($lpa, '3');
+        $result = $resolver($lpa, 3);
 
         $this->assertNull($result);
     }
@@ -134,15 +132,15 @@ class ResolveActorTest extends TestCase
     {
         $lpa = [
             'donor' => [
-                'id'  => 1,
-                'uId' => '123456789013',
+                'id'     => 1,
+                'uId'    => '123456789013',
                 'linked' => [['id' => 1, 'uId' => '123456789013'], ['id' => 2, 'uId' => '123456789012']],
-            ]
+            ],
         ];
 
         $resolver = $this->getActorResolver();
 
-        $result = $resolver($lpa, '123456789999');
+        $result = $resolver($lpa, 123456789999);
 
         $this->assertNull($result);
     }
@@ -153,57 +151,57 @@ class ResolveActorTest extends TestCase
     public function can_find_actor_who_is_an_attorney()
     {
         $lpa = [
-            'donor' => [
+            'donor'     => [
                 'id' => 1,
             ],
-            'original_attorneys' => [
+            'attorneys' => [
                 ['id' => 1, 'uId' => '123456789012', 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true],
                 ['id' => 3, 'uId' => '234567890123', 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true],
-                ['id' => 7, 'uId' => '345678901234', 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true]
+                ['id' => 7, 'uId' => '345678901234', 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true],
             ],
         ];
 
         $this->getAttorneyStatusProphecy
             ->__invoke(
                 [
-                    'id' => 3,
-                    'uId' => '234567890123',
-                    'firstname' => 'A',
-                    'surname' => 'B',
-                    'systemStatus' => true
+                    'id'           => 3,
+                    'uId'          => '234567890123',
+                    'firstname'    => 'A',
+                    'surname'      => 'B',
+                    'systemStatus' => true,
                 ]
             )
             ->willReturn(0);
 
         $resolver = $this->getActorResolver();
 
-        $result = $resolver($lpa, '3');
+        $result = $resolver($lpa, 3);
 
         $this->assertEquals(
             [
-                'type' => 'primary-attorney',
+                'type'    => 'primary-attorney',
                 'details' => [
-                    'id' => 3,
-                    'uId' => '234567890123',
-                    'firstname' => 'A',
-                    'surname' => 'B',
-                    'systemStatus' => true
+                    'id'           => 3,
+                    'uId'          => '234567890123',
+                    'firstname'    => 'A',
+                    'surname'      => 'B',
+                    'systemStatus' => true,
                 ],
             ],
             $result
         );
 
-        $result = $resolver($lpa, '234567890123');
+        $result = $resolver($lpa, 234567890123);
 
         $this->assertEquals(
             [
-                'type' => 'primary-attorney',
+                'type'    => 'primary-attorney',
                 'details' => [
-                    'id' => 3,
-                    'uId' => '234567890123',
-                    'firstname' => 'A',
-                    'surname' => 'B',
-                    'systemStatus' => true
+                    'id'           => 3,
+                    'uId'          => '234567890123',
+                    'firstname'    => 'A',
+                    'surname'      => 'B',
+                    'systemStatus' => true,
                 ],
             ],
             $result
@@ -214,17 +212,17 @@ class ResolveActorTest extends TestCase
      * @test
      * @dataProvider ghostAttorneyDataProvider
      */
-    public function can_not_find_actor_who_is_a_ghost_attorney(string $actorId, array $attorneyData)
+    public function can_not_find_actor_who_is_a_ghost_attorney(int $actorId, array $attorneyData)
     {
         $lpa = [
-            'donor' => [
-                'id' => 1,
-                'uId' => '456789012345'
+            'donor'              => [
+                'id'  => 1,
+                'uId' => '456789012345',
             ],
             'original_attorneys' => [
                 ['id' => 2, 'uId' => '123456789012', 'systemStatus' => true],
                 ['id' => 3, 'uId' => '234567890123', 'firstname' => 'A', 'systemStatus' => true],
-                ['id' => 7, 'uId' => '345678901234', 'surname' => 'B', 'systemStatus' => true]
+                ['id' => 7, 'uId' => '345678901234', 'surname' => 'B', 'systemStatus' => true],
             ],
         ];
 
@@ -242,28 +240,28 @@ class ResolveActorTest extends TestCase
     {
         return [
             [
-                '2',
-                ['id' => 2, 'uId' => '123456789012', 'systemStatus' => true]
+                2,
+                ['id' => 2, 'uId' => '123456789012', 'systemStatus' => true],
             ],
             [
-                '123456789012',
-                ['id' => 2, 'uId' => '123456789012', 'systemStatus' => true]
+                123456789012,
+                ['id' => 2, 'uId' => '123456789012', 'systemStatus' => true],
             ],
             [
-                '3',
+                3,
                 ['id' => 3, 'uId' => '234567890123', 'firstname' => 'A', 'systemStatus' => true],
             ],
             [
-                '234567890123',
+                234567890123,
                 ['id' => 3, 'uId' => '234567890123', 'firstname' => 'A', 'systemStatus' => true],
             ],
             [
-                '7',
-                ['id' => 7, 'uId' => '345678901234', 'surname' => 'B', 'systemStatus' => true]
+                7,
+                ['id' => 7, 'uId' => '345678901234', 'surname' => 'B', 'systemStatus' => true],
             ],
             [
-                '345678901234',
-                ['id' => 7, 'uId' => '345678901234', 'surname' => 'B', 'systemStatus' => true]
+                345678901234,
+                ['id' => 7, 'uId' => '345678901234', 'surname' => 'B', 'systemStatus' => true],
             ],
         ];
     }
@@ -272,35 +270,35 @@ class ResolveActorTest extends TestCase
     public function can_not_find_actor_who_is_an_inactive_attorney(): void
     {
         $lpa = [
-            'donor' => [
+            'donor'              => [
                 'id'  => 1,
-                'uId' => '456789012345'
+                'uId' => '456789012345',
             ],
             'original_attorneys' => [
                 ['id' => 1, 'uId' => '123456789012', 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true],
                 ['id' => 3, 'uId' => '234567890123', 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => false],
-                ['id' => 7, 'uId' => '345678901234', 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true]
+                ['id' => 7, 'uId' => '345678901234', 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true],
             ],
         ];
 
         $this->getAttorneyStatusProphecy
             ->__invoke(
                 [
-                    'id' => 3,
-                    'uId' => '234567890123',
-                    'firstname' => 'A',
-                    'surname' => 'B',
-                    'systemStatus' => false
+                    'id'           => 3,
+                    'uId'          => '234567890123',
+                    'firstname'    => 'A',
+                    'surname'      => 'B',
+                    'systemStatus' => false,
                 ],
             )
             ->willReturn(2);
 
         $resolver = $this->getActorResolver();
 
-        $result = $resolver($lpa, '3');
+        $result = $resolver($lpa, 3);
         $this->assertNull($result);
 
-        $result = $resolver($lpa, '234567890123');
+        $result = $resolver($lpa, 234567890123);
         $this->assertNull($result);
     }
 
@@ -310,16 +308,16 @@ class ResolveActorTest extends TestCase
     public function can_find_actor_who_is_a_trust_corporation()
     {
         $lpa = [
-            'donor' => [
+            'donor'             => [
                 'id' => 1,
             ],
             'trustCorporations' => [
                 [
-                    'id' => 9,
-                    'uId' => '700000151998',
-                    'firstname' => 'trust',
-                    'surname' => 'corporation',
-                    'companyName' => 'trust corporation ltd',
+                    'id'           => 9,
+                    'uId'          => '700000151998',
+                    'firstname'    => 'trust',
+                    'surname'      => 'corporation',
+                    'companyName'  => 'trust corporation ltd',
                     'systemStatus' => true,
                 ],
             ],
@@ -327,35 +325,35 @@ class ResolveActorTest extends TestCase
 
         $resolver = $this->getActorResolver();
 
-        $result = $resolver($lpa, '700000151998');
+        $result = $resolver($lpa, 700000151998);
 
         $this->assertEquals(
             [
-                'type' => 'trust-corporation',
+                'type'    => 'trust-corporation',
                 'details' => [
-                    'id' => 9,
-                    'uId' => '700000151998',
-                    'firstname' => 'trust',
-                    'surname' => 'corporation',
-                    'companyName' => 'trust corporation ltd',
-                    'systemStatus' => true
+                    'id'           => 9,
+                    'uId'          => '700000151998',
+                    'firstname'    => 'trust',
+                    'surname'      => 'corporation',
+                    'companyName'  => 'trust corporation ltd',
+                    'systemStatus' => true,
                 ],
             ],
             $result
         );
 
-        $result = $resolver($lpa, '9');
+        $result = $resolver($lpa, 9);
 
         $this->assertEquals(
             [
-                'type' => 'trust-corporation',
+                'type'    => 'trust-corporation',
                 'details' => [
-                    'id' => 9,
-                    'uId' => '700000151998',
-                    'firstname' => 'trust',
-                    'surname' => 'corporation',
-                    'companyName' => 'trust corporation ltd',
-                    'systemStatus' => true
+                    'id'           => 9,
+                    'uId'          => '700000151998',
+                    'firstname'    => 'trust',
+                    'surname'      => 'corporation',
+                    'companyName'  => 'trust corporation ltd',
+                    'systemStatus' => true,
                 ],
             ],
             $result


### PR DESCRIPTION
# Purpose

Fixes UML-2851

## Approach

Ensures all usages of ResolveActor use an integer for ActorID

## Learning

Converting a dynamic codebase to static is tricksy.

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [x] The product team have tested these changes
