### PR TITLE
UML-2913 Allow API to access I&P API gateway

### DIFF
--- a/terraform/environment/api_ecs.tf
+++ b/terraform/environment/api_ecs.tf
@@ -223,6 +223,18 @@ data "aws_iam_policy_document" "api_permissions_role" {
       "arn:aws:execute-api:eu-west-1:${local.environment.sirius_account_id}:*/*/POST/exists",
     ]
   }
+
+  statement {
+    sid    = "instructionsandprefsaccess"
+    effect = "Allow"
+    actions = [
+      "execute-api:Invoke",
+    ]
+    resources = [
+      "arn:aws:execute-api:eu-west-1:${local.environment.sirius_account_id}:*/*/GET/image-request/*",
+      "arn:aws:execute-api:eu-west-1:${local.environment.sirius_account_id}:*/*/GET/healthcheck",
+    ]
+  }
 }
 
 //-----------------------------------------------


### PR DESCRIPTION
# Purpose

Allow the API task role to execute-api:Invoke on the Instructions and Preferences API gateway.

Fixes UML-2913

## Approach

Add an extra statement to the `api_permissions_role` resource.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
