### PR TITLE
Ensure test screenshots always get uploaded

### DIFF
--- a/.github/workflows/_run-behat-tests.yml
+++ b/.github/workflows/_run-behat-tests.yml
@@ -90,6 +90,7 @@ jobs:
         with:
           name: behat-screenshots
           path: tests/smoke/failed_step_screenshots
+        if: always()
 
       - name: remove gh actions ingress to environment
         env:


### PR DESCRIPTION
# Purpose

Screenshots of failed tests not saved after failures in behat smoke tests.
