### PR TITLE
UML-2969: Remove always-on severance warning for older lpas

### DIFF
--- a/service-front/app/src/Common/templates/partials/lpa-summary-details/lpa-details.html.twig
+++ b/service-front/app/src/Common/templates/partials/lpa-summary-details/lpa-details.html.twig
@@ -89,20 +89,6 @@
                     </strong>
                 </div>
                 <dl class="govuk-summary-list govuk-summary-list--no-border">
-            {% elseif lpa.registrationDate < date('2019-01-01') %}
-                </dl>
-                <div class="govuk-warning-text">
-                    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                    <strong class="govuk-warning-text__text">
-                        <span class="govuk-warning-text__assistive">{% trans %}Warning{% endtrans %}</span>
-                        {% trans %}
-                            Some words in these instructions or preferences may have been removed by the Court of
-                            Protection. If you need to check this, please see the paper
-                            <abbr title="lasting power of attorney">LPA</abbr>.
-                        {% endtrans %}
-                    </strong>
-                </div>
-                <dl class="govuk-summary-list govuk-summary-list--no-border">
             {% endif %}
         {% endif %}
 


### PR DESCRIPTION
# Purpose
https://opgtransform.atlassian.net/browse/UML-2918
UML-2918

## Approach

Removes special handling of LPAs older than 2019 as it's no longer required

## Learning

## Checklist

* [x] I have performed a self-review of my own code
* ~[ ] I have added relevant logging with appropriate levels to my code~
* ~[ ] New event_codes have been documented on the [wiki page]~(https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
* ~[ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* ~[ ] I have added tests to prove my work~
* ~[ ] I have added welsh translation tags and updated translation files~
* ~[ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~[ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* [x] The product team have tested these changes
