### PR TITLE
UML 2806 - Add last three months to admin stats page

### DIFF
--- a/service-admin/.idea/runConfigurations/Admin_Service.xml
+++ b/service-admin/.idea/runConfigurations/Admin_Service.xml
@@ -2,10 +2,11 @@
   <configuration default="false" name="Admin Service" type="GoApplicationRunConfiguration" factoryName="Go Application">
     <module name="service-admin" />
     <working_directory value="$PROJECT_DIR$" />
-    <go_parameters value="-i" />
     <envs>
-      <env name="AWS_DYNAMODB_ENDPOINT" value="http://localhost:8000" />
       <env name="ADMIN_JWT_SIGNING_KEY_URL" value="http://localhost:5000" />
+      <env name="AWS_ACCESS_KEY_ID" value="-" />
+      <env name="AWS_DYNAMODB_ENDPOINT" value="http://localhost:8000" />
+      <env name="AWS_SECRET_ACCESS_KEY" value="-" />
     </envs>
     <kind value="FILE" />
     <directory value="$PROJECT_DIR$" />

--- a/service-admin/README.md
+++ b/service-admin/README.md
@@ -1,0 +1,43 @@
+# Service Admin
+
+The Service Admin Portal is an internal tool for investigating queries, searching users' accounts and activation keys, and for internal reporting.
+
+There are two components to run locally:
+
+- Admin service
+- JWT Proxy
+
+## Usage
+
+To run the service-admin service, you can use:
+
+### VS Code
+
+You should be able to use the "Launch" configuration to run the main app.
+Run the proxy using the instructions in [the README](./proxy/README.md).
+
+### Goland
+
+Run both the "JWT Proxy" and the "Admin Service" inside your IDE
+
+### Manual
+
+Install `go`.
+
+```shell
+go mod download # Install dependencies
+go run cmd/admin/main.go
+```
+
+The following environment variables will need to be set:
+
+| Environment variable | Default |
+|---|---------|
+| `AWS_DYNAMODB_ENDPOINT` | `http://localhost:8000` |
+| `ADMIN_JWT_SIGNING_KEY_URL` | `http://localhost:5000` |
+| `AWS_ACCESS_KEY_ID` | - |
+| `AWS_SECRET_ACCESS_KEY` | - |
+
+Run the proxy using the instructions in [the README](./proxy/README.md).
+
+You will be able to access the admin service at http://localhost:5000

--- a/service-admin/internal/server/data/statistics.go
+++ b/service-admin/internal/server/data/statistics.go
@@ -42,6 +42,9 @@ func (s *StatisticsService) GetAllMetrics(ctx context.Context, list []string) (m
 					{
 						"TimePeriod": &types.AttributeValueMemberS{Value: list[3]},
 					},
+          {
+						"TimePeriod": &types.AttributeValueMemberS{Value: list[4]},
+					},
 				},
 			},
 		},

--- a/service-admin/internal/server/data/statistics.go
+++ b/service-admin/internal/server/data/statistics.go
@@ -42,7 +42,7 @@ func (s *StatisticsService) GetAllMetrics(ctx context.Context, list []string) (m
 					{
 						"TimePeriod": &types.AttributeValueMemberS{Value: list[3]},
 					},
-          {
+					{
 						"TimePeriod": &types.AttributeValueMemberS{Value: list[4]},
 					},
 				},

--- a/service-admin/internal/server/data/statistics_test.go
+++ b/service-admin/internal/server/data/statistics_test.go
@@ -43,7 +43,7 @@ func TestGetAllMetrics(t *testing.T) {
 	}{
 		{
 			name: "find metric values for last 3 months",
-			list: []string{"2022-11", "2022-10", "2022-09", "Total"},
+			list: []string{"2022-11", "2022-10", "2022-09", "2022-08", "Total"},
 			batchGetItemFunc: func(ctx context.Context, params *dynamodb.BatchGetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.BatchGetItemOutput, error) {
 				return &dynamodb.BatchGetItemOutput{
 					Responses: map[string][]map[string]types.AttributeValue{
@@ -65,6 +65,12 @@ func TestGetAllMetrics(t *testing.T) {
 								"lpas_added":            &types.AttributeValueMemberN{Value: "3"},
 								"lpa_removed_evet":      &types.AttributeValueMemberN{Value: "1"},
 								"account_created_event": &types.AttributeValueMemberN{Value: "4"},
+							},
+              {
+								"TimePeriod":            &types.AttributeValueMemberS{Value: "2022-08"},
+								"lpas_added":            &types.AttributeValueMemberN{Value: "1"},
+								"lpa_removed_evet":      &types.AttributeValueMemberN{Value: "1"},
+								"account_created_event": &types.AttributeValueMemberN{Value: "1"},
 							},
 							{
 								"TimePeriod":            &types.AttributeValueMemberS{Value: "Total"},
@@ -92,6 +98,11 @@ func TestGetAllMetrics(t *testing.T) {
 					"lpa_removed_evet":      1,
 					"account_created_event": 4,
 				},
+        "2022-08": {
+					"lpas_added":            1,
+					"lpa_removed_evet":      1,
+					"account_created_event": 1,
+				},
 				"Total": {
 					"lpas_added":            12,
 					"lpa_removed_evet":      12,
@@ -102,7 +113,7 @@ func TestGetAllMetrics(t *testing.T) {
 		},
 		{
 			name: "doesn't find a metric for time period",
-			list: []string{"2022-11", "2022-10", "2022-09", "Total"},
+			list: []string{"2022-11", "2022-10", "2022-09", "2022-08", "Total"},
 			batchGetItemFunc: func(ctx context.Context, params *dynamodb.BatchGetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.BatchGetItemOutput, error) {
 				return &dynamodb.BatchGetItemOutput{}, nil
 			},
@@ -111,7 +122,7 @@ func TestGetAllMetrics(t *testing.T) {
 		},
 		{
 			name: "error whilst searching for metrics",
-			list: []string{"2022-11", "2022-10", "2022-09", "Total"},
+			list: []string{"2022-11", "2022-10", "2022-09", "2022-08", "Total"},
 			batchGetItemFunc: func(ctx context.Context, params *dynamodb.BatchGetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.BatchGetItemOutput, error) {
 				return &dynamodb.BatchGetItemOutput{}, errors.New("some error")
 			},

--- a/service-admin/internal/server/data/statistics_test.go
+++ b/service-admin/internal/server/data/statistics_test.go
@@ -66,7 +66,7 @@ func TestGetAllMetrics(t *testing.T) {
 								"lpa_removed_evet":      &types.AttributeValueMemberN{Value: "1"},
 								"account_created_event": &types.AttributeValueMemberN{Value: "4"},
 							},
-              {
+							{
 								"TimePeriod":            &types.AttributeValueMemberS{Value: "2022-08"},
 								"lpas_added":            &types.AttributeValueMemberN{Value: "1"},
 								"lpa_removed_evet":      &types.AttributeValueMemberN{Value: "1"},
@@ -98,7 +98,7 @@ func TestGetAllMetrics(t *testing.T) {
 					"lpa_removed_evet":      1,
 					"account_created_event": 4,
 				},
-        "2022-08": {
+				"2022-08": {
 					"lpas_added":            1,
 					"lpa_removed_evet":      1,
 					"account_created_event": 1,

--- a/service-admin/internal/server/handlers/stats.go
+++ b/service-admin/internal/server/handlers/stats.go
@@ -71,7 +71,9 @@ func getPeriodsToBeChecked(timeProvider TimeProvider) []string {
 	currentMonth := currentTime.Format(timeLayout)
 	lastMonth := firstDay.Format(timeLayout)
 	monthBeforeLast := lastDay.Format(timeLayout)
-	checkList := []string{currentMonth, lastMonth, monthBeforeLast, "Total"}
+  threeMonthsAgo := last3Month.Format(timeLayout)
+  
+	checkList := []string{currentMonth, lastMonth, monthBeforeLast, threeMonthsAgo, "Total"}
 
 	return checkList
 }

--- a/service-admin/internal/server/handlers/stats.go
+++ b/service-admin/internal/server/handlers/stats.go
@@ -71,8 +71,8 @@ func getPeriodsToBeChecked(timeProvider TimeProvider) []string {
 	currentMonth := currentTime.Format(timeLayout)
 	lastMonth := firstDay.Format(timeLayout)
 	monthBeforeLast := lastDay.Format(timeLayout)
-  threeMonthsAgo := last3Month.Format(timeLayout)
-  
+	threeMonthsAgo := last3Month.Format(timeLayout)
+
 	checkList := []string{currentMonth, lastMonth, monthBeforeLast, threeMonthsAgo, "Total"}
 
 	return checkList

--- a/service-admin/web/templates/stats.page.gohtml
+++ b/service-admin/web/templates/stats.page.gohtml
@@ -14,6 +14,7 @@
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header"></th>
+          <th scope="col" class="govuk-table__header">3 months previous</th>
           <th scope="col" class="govuk-table__header">2 months previous</th>
           <th scope="col" class="govuk-table__header">Previous Month</th>
           <th scope="col" class="govuk-table__header">Current Month</th>
@@ -36,6 +37,7 @@
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header"></th>
+          <th scope="col" class="govuk-table__header">3 months previous</th>
           <th scope="col" class="govuk-table__header">2 months previous</th>
           <th scope="col" class="govuk-table__header">Previous Month</th>
           <th scope="col" class="govuk-table__header">Current Month</th>
@@ -58,6 +60,7 @@
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header"></th>
+          <th scope="col" class="govuk-table__header">3 months previous</th>
           <th scope="col" class="govuk-table__header">2 months previous</th>
           <th scope="col" class="govuk-table__header">Previous Month</th>
           <th scope="col" class="govuk-table__header">Current Month</th>
@@ -74,6 +77,7 @@
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header"></th>
+          <th scope="col" class="govuk-table__header">3 months previous</th>
           <th scope="col" class="govuk-table__header">2 months previous</th>
           <th scope="col" class="govuk-table__header">Previous Month</th>
           <th scope="col" class="govuk-table__header">Current Month</th>


### PR DESCRIPTION
# Purpose

- Adds column for "three months previous" to admin stats page

<img width="1000" alt="image" src="https://github.com/ministryofjustice/opg-use-an-lpa/assets/96028224/18b548c3-2e8f-489d-a939-919f4d089ae5">


Fixes UML-2806

## Approach

Adapted existing code to add a '3 months ago' a column.

## Learning
No readme to build or run the Service Admin. This slowed down setting up.
## Checklist

* [x] I have performed a self-review of my own code
~* [ ] I have added relevant logging with appropriate levels to my code~
~* [ ] New event_codes have been documented on the [wiki page]~~(https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
~* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* [x] I have added tests to prove my work
~* [ ] I have added welsh translation tags and updated translation files~
~* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
~* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* [ ] The product team have tested these changes
