### PR TITLE
Remove /home from admin service url.

### DIFF
--- a/scripts/pipeline/post_release_slack_notification/post_release_slack_notification.py
+++ b/scripts/pipeline/post_release_slack_notification/post_release_slack_notification.py
@@ -44,7 +44,7 @@ class MessageGenerator:
         mapping = {
             'use_url': 'https://{}/home'.format(use_url) if use_url is not None else 'Use URL not provided',
             'view_url': 'https://{}/home'.format(view_url) if view_url is not None else 'View URL not provided',
-            'admin_url': 'https://{}/home'.format(admin_url) if admin_url is not None else 'Admin URL not provided',
+            'admin_url': 'https://{}'.format(admin_url) if admin_url is not None else 'Admin URL not provided',
             'gh_actions_build_url': f"{gh_server}/{gh_repository}/actions/runs/{gh_run_id}",
             'gh_actor': str(os.getenv('GITHUB_ACTOR', 'actor not included')),
             'commit_message': commit_message or 'Commit message not provided'


### PR DESCRIPTION
# Purpose

Fixes broken admin link in slack notification

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* The product team have tested these changes
