### PR TITLE
Trust corporation shows consecutive number attorney in English and Welsh

### DIFF
--- a/service-front/app/src/Common/templates/partials/lpa-summary-details/lpa-attorney-details.html.twig
+++ b/service-front/app/src/Common/templates/partials/lpa-summary-details/lpa-attorney-details.html.twig
@@ -36,12 +36,12 @@
 {% endfor %}
 
 {% for tc in lpa.trustCorporations %}
-    {% set i = loop.index + lpa.attorneys | length %}
-    <h3 class="govuk-heading-m">{% trans count loop.index with {'%attorneyOrdinal%': i | ordinal } %}%attorneyOrdinal% attorney|%attorneyOrdinal% attorney{% endtrans %}</h3>
+    {% set i = loop.index + lpa.activeAttorneys | length %}
+    <h3 class="govuk-heading-m">{% trans count i with {'%attorneyOrdinal%': i | ordinal } %}%attorneyOrdinal% attorney|%attorneyOrdinal% attorney{% endtrans %}</h3>
     <dl class="govuk-summary-list govuk-summary-list--no-border">
         <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">{% trans %}Name{% endtrans %}</dt>
-            <dd class="govuk-summary-list__value">{{ tc.companyName }} {{ "(Trust corporation)" }}</dd>
+            <dd class="govuk-summary-list__value">{{ tc.companyName }} {% trans %}(Trust corporation){% endtrans %}</dd>
         </div>
         <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">{% trans %}Address{% endtrans %}</dt>


### PR DESCRIPTION
# Purpose

Gives a trust corporation a consecutive number attorney in the attorney list. Changes applied in both English and Welsh.

Fixes [UML-2813](https://opgtransform.atlassian.net/browse/UML-2813)

## Approach

Updated the lpa-attorneys-details.html.twig template to loop over active attorneys instead of all attorneys. 

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
