### PR TITLE
UML-3024 Move IAM roles to global config

### DIFF
--- a/terraform/environment/api_ecs.tf
+++ b/terraform/environment/api_ecs.tf
@@ -136,22 +136,17 @@ resource "aws_ecs_task_definition" "api" {
   cpu                      = 512
   memory                   = 1024
   container_definitions    = "[${local.api_web}, ${local.api_app} ${local.environment.deploy_opentelemetry_sidecar ? ", ${local.api_aws_otel_collector}" : ""}]"
-  task_role_arn            = aws_iam_role.api_task_role.arn
-  execution_role_arn       = aws_iam_role.execution_role.arn
+  task_role_arn            = module.iam.ecs_task_roles.api_task_role.arn
+  execution_role_arn       = module.iam.ecs_task_roles.execution_role.arn
 }
 
 //----------------
 // Permissions
 
-resource "aws_iam_role" "api_task_role" {
-  name               = "${local.environment_name}-api-task-role"
-  assume_role_policy = data.aws_iam_policy_document.task_role_assume_policy.json
-}
-
 resource "aws_iam_role_policy" "api_permissions_role" {
-  name   = "${local.environment_name}-apiApplicationPermissions"
+  name   = "${local.environment_name}-${local.policy_region_prefix}-apiApplicationPermissions"
   policy = data.aws_iam_policy_document.api_permissions_role.json
-  role   = aws_iam_role.api_task_role.id
+  role   = module.iam.ecs_task_roles.api_task_role.id
 }
 
 /*
@@ -159,7 +154,7 @@ resource "aws_iam_role_policy" "api_permissions_role" {
 */
 data "aws_iam_policy_document" "api_permissions_role" {
   statement {
-    sid    = "xrayaccess"
+    sid    = "${local.policy_region_prefix}XrayAccess"
     effect = "Allow"
 
     actions = [
@@ -174,6 +169,7 @@ data "aws_iam_policy_document" "api_permissions_role" {
   }
 
   statement {
+    sid    = "${local.policy_region_prefix}DynamoDbAccess"
     effect = "Allow"
 
     actions = [
@@ -197,7 +193,7 @@ data "aws_iam_policy_document" "api_permissions_role" {
   }
 
   statement {
-    sid    = "lpacollectionsaccess"
+    sid    = "${local.policy_region_prefix}LpaCollectionAccess"
     effect = "Allow"
 
     actions = [
@@ -211,7 +207,7 @@ data "aws_iam_policy_document" "api_permissions_role" {
   }
 
   statement {
-    sid    = "lpacodesaccess"
+    sid    = "${local.policy_region_prefix}LpaCodesAccess"
     effect = "Allow"
     actions = [
       "execute-api:Invoke",
@@ -225,7 +221,7 @@ data "aws_iam_policy_document" "api_permissions_role" {
   }
 
   statement {
-    sid    = "instructionsandprefsaccess"
+    sid    = "${local.policy_region_prefix}IapImagesAccess"
     effect = "Allow"
     actions = [
       "execute-api:Invoke",

--- a/terraform/environment/ecs_cluster.tf
+++ b/terraform/environment/ecs_cluster.tf
@@ -5,40 +5,10 @@ resource "aws_ecs_cluster" "use-an-lpa" {
     value = "enabled"
   }
 }
-
-data "aws_iam_policy_document" "task_role_assume_policy" {
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      identifiers = ["ecs-tasks.amazonaws.com"]
-      type        = "Service"
-    }
-  }
-}
-
-resource "aws_iam_role" "execution_role" {
-  name               = "${local.environment_name}-execution-role-ecs-cluster"
-  assume_role_policy = data.aws_iam_policy_document.execution_role_assume_policy.json
-}
-
-data "aws_iam_policy_document" "execution_role_assume_policy" {
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      identifiers = ["ecs-tasks.amazonaws.com"]
-      type        = "Service"
-    }
-  }
-}
-
 resource "aws_iam_role_policy" "execution_role" {
   name   = "${local.environment_name}_execution_role"
   policy = data.aws_iam_policy_document.execution_role.json
-  role   = aws_iam_role.execution_role.id
+  role   = module.iam.ecs_execution_role.id
 }
 
 data "aws_iam_policy_document" "execution_role" {

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -105,12 +105,13 @@ variable "environments" {
 }
 
 locals {
-  environment_name  = lower(replace(terraform.workspace, "_", "-"))
-  environment       = contains(keys(var.environments), local.environment_name) ? var.environments[local.environment_name] : var.environments["default"]
-  dns_namespace_acc = local.environment_name == "production" ? "" : "${local.environment.account_name}."
-  dns_namespace_env = local.environment.account_name == "production" ? "" : "${local.environment_name}."
-  dev_wildcard      = local.environment.account_name == "production" ? "" : "*."
-  capacity_provider = local.environment.fargate_spot ? "FARGATE_SPOT" : "FARGATE"
+  environment_name     = lower(replace(terraform.workspace, "_", "-"))
+  environment          = contains(keys(var.environments), local.environment_name) ? var.environments[local.environment_name] : var.environments["default"]
+  dns_namespace_acc    = local.environment_name == "production" ? "" : "${local.environment.account_name}."
+  dns_namespace_env    = local.environment.account_name == "production" ? "" : "${local.environment_name}."
+  dev_wildcard         = local.environment.account_name == "production" ? "" : "*."
+  capacity_provider    = local.environment.fargate_spot ? "FARGATE_SPOT" : "FARGATE"
+  policy_region_prefix = lower(replace(data.aws_region.current.name, "-", ""))
 
   mandatory_moj_tags = {
     business-unit    = "OPG"

--- a/terraform/environment/main.tf
+++ b/terraform/environment/main.tf
@@ -1,0 +1,5 @@
+module "iam" {
+    source = "./modules/iam"
+    
+    environment_name = local.environment_name
+}

--- a/terraform/environment/modules/iam/iam_ecs_execution_role.tf
+++ b/terraform/environment/modules/iam/iam_ecs_execution_role.tf
@@ -1,0 +1,16 @@
+resource "aws_iam_role" "execution_role" {
+  name               = "${var.environment_name}-execution-role-ecs-cluster"
+  assume_role_policy = data.aws_iam_policy_document.execution_role_assume_policy.json
+}
+
+data "aws_iam_policy_document" "execution_role_assume_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      identifiers = ["ecs-tasks.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}

--- a/terraform/environment/modules/iam/iam_ecs_task_roles.tf
+++ b/terraform/environment/modules/iam/iam_ecs_task_roles.tf
@@ -1,0 +1,36 @@
+data "aws_iam_policy_document" "task_role_assume_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      identifiers = ["ecs-tasks.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_iam_role" "admin_task_role" {
+  name               = "${var.environment_name}-admin-task-role"
+  assume_role_policy = data.aws_iam_policy_document.task_role_assume_policy.json
+}
+
+resource "aws_iam_role" "api_task_role" {
+  name               = "${var.environment_name}-api-task-role"
+  assume_role_policy = data.aws_iam_policy_document.task_role_assume_policy.json
+}
+
+resource "aws_iam_role" "actor_task_role" {
+  name               = "${var.environment_name}-actor-task-role"
+  assume_role_policy = data.aws_iam_policy_document.task_role_assume_policy.json
+}
+
+resource "aws_iam_role" "viewer_task_role" {
+  name               = "${var.environment_name}-viewer-task-role"
+  assume_role_policy = data.aws_iam_policy_document.task_role_assume_policy.json
+}
+
+resource "aws_iam_role" "pdf_task_role" {
+  name               = "${var.environment_name}-pdf-task-role"
+  assume_role_policy = data.aws_iam_policy_document.task_role_assume_policy.json
+}

--- a/terraform/environment/modules/iam/outputs.tf
+++ b/terraform/environment/modules/iam/outputs.tf
@@ -1,0 +1,15 @@
+output "ecs_task_roles" {
+  description = "The ECS task roles"
+  value = {
+    admin_task_role  = aws_iam_role.admin_task_role
+    api_task_role    = aws_iam_role.api_task_role
+    actor_task_role  = aws_iam_role.actor_task_role
+    viewer_task_role = aws_iam_role.viewer_task_role
+    pdf_task_role    = aws_iam_role.pdf_task_role
+  }
+}
+
+output "ecs_execution_role" {
+  description = "The ECS execution role"
+  value       = aws_iam_role.execution_role
+}

--- a/terraform/environment/modules/iam/variables.tf
+++ b/terraform/environment/modules/iam/variables.tf
@@ -1,0 +1,4 @@
+variable "environment_name" {
+  description = "The name of the environment"
+  type        = string
+}

--- a/terraform/environment/pdf_ecs.tf
+++ b/terraform/environment/pdf_ecs.tf
@@ -119,17 +119,12 @@ resource "aws_ecs_task_definition" "pdf" {
   cpu                      = 512
   memory                   = 1024
   container_definitions    = "[${local.pdf_app}]"
-  task_role_arn            = aws_iam_role.pdf_task_role.arn
-  execution_role_arn       = aws_iam_role.execution_role.arn
+  task_role_arn            = module.iam.ecs_task_roles.pdf_task_role.arn
+  execution_role_arn       = module.iam.ecs_task_roles.execution_role.arn
 }
 
 //----------------
 // Permissions
-
-resource "aws_iam_role" "pdf_task_role" {
-  name               = "${local.environment_name}-pdf-task-role"
-  assume_role_policy = data.aws_iam_policy_document.task_role_assume_policy.json
-}
 
 //-----------------------------------------------
 // pdf ECS Service Task Container level config


### PR DESCRIPTION
# Purpose

Move the ECS IAM roles from being environment specific to being global in preparation for changes to allow Use to run in multiple regions.

Fixes UML-3024

## Approach

Create IAM module that is called only once.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
