### PR TITLE
UML-2987 Spike PR branch - Not for merge

### DIFF
--- a/mock-integrations/image-request-handler/mock-openapi-examples.yaml
+++ b/mock-integrations/image-request-handler/mock-openapi-examples.yaml
@@ -38,3 +38,15 @@ paths:
                       'iap-700000136361-instructions': 'http://localhost:4010/iap-700000136361-instructions.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AAAAAAAAAAAAA%2F20230110%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20230110T170414Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&X-Amz-Security-Token=FwoGZXIvqfrfffffqB8ObHF9iK0Ae6ydwSr1R7ho%2BkIqn%2FOYVShw77vHhp5XuM945Z5uuqFQTUP128xAiCqgERWsuT7BSLhPeazeR6QjAm0jjH8JTa9YQ1OqBlF6BSY3o6oOvnagVxDwx1SzfEQK%2FMdoPpwOgPQ1qIN714YJfGe0Qp%2FbdAv%2F5tLGG5rgBX98CCuWTszpsWQnaFtfEWhfTG%2BvqUsjavsusT7TmPbHMv7gFqvSoU8Aos7LDt8vgUuA8TrD%2FQs9ZjkxyiOtfadBjItlHw%2BOq8%2BVp29uq0r4r4r22r424r24rkjxnisGe4K9cMD0hNr5PjCXa3c1QRo&X-Amz-Signature=fd5ec81d49482cc2b26aac02ffe94e9d82d3e29b00c368fb1bad707f6066ecf0',
                       'iap-700000136361-preferences': 'http://localhost:4010/iap-700000136361-preferences.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AAAAAAAAAAAAA%2F20230110%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20230110T170414Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&X-Amz-Security-Token=FwoGZXIvYXdzEEsaDA9nffwerfrfrffqiK0Ae6ydwSr1R7ho%2BkIqn%2FOYVShw77vHhp5XuM945Z5uuqFQTUP128xAiCqgERWsuT7BSLhPeazeR6QjAm0jjH8JTa9YQ1OqBlF6BSY3o6oOvnagVxDwx1SzfEQK%2FMdoPpwOgPQ1qIN714YJfGe0Qp%2FbdAv%2F5tLGG5rgBX98CCuWTszpsWQnaFtfEWhfTG%2BvqUsjavsusT7TmPbHMv7gFqvSoU8Aos7LDt8vgUuA8TrD%2FQs9ZjkxyiOtfadBjItlHw%2BOq8%2BVpd24d24d24d24d42dZufWkjxnisGe4K9cMD0hNr5PjCXa3c1QRo&X-Amz-Signature=fd5ec81d49482cc2b26aac02ffe94e9d82d3e29b00c368fb1bad707f83929392'
                     }
+        '500':
+          content:
+            application/json:
+              examples:
+                lpa0138:
+                  value:
+                    errors:
+                      - {
+                          'code': 'OPGDATA-API-SERVERERROR',
+                          'title': 'Internal server error',
+                      }
+

--- a/mock-integrations/image-request-handler/mock-openapi.yaml
+++ b/mock-integrations/image-request-handler/mock-openapi.yaml
@@ -115,11 +115,6 @@ paths:
                     uId: 700000000047
                     status: 'COLLECTION_NOT_STARTED'
                     signedUrls: {'iap-700000000047-instructions': 'https://my-bucket.s3.amazonaws.com/iap-700000000047-instructions.jpg4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AAAAAAAAAAAAA%2F20230110%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20230110T170414Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&X-Amz-Security-Token=FwoGZXIvqfrfffffqB8ObHF9iK0Ae6ydwSr1R7ho%2BkIqn%2FOYVShw77vHhp5XuM945Z5uuqFQTUP128xAiCqgERWsuT7BSLhPeazeR6QjAm0jjH8JTa9YQ1OqBlF6BSY3o6oOvnagVxDwx1SzfEQK%2FMdoPpwOgPQ1qIN714YJfGe0Qp%2FbdAv%2F5tLGG5rgBX98CCuWTszpsWQnaFtfEWhfTG%2BvqUsjavsusT7TmPbHMv7gFqvSoU8Aos7LDt8vgUuA8TrD%2FQs9ZjkxyiOtfadBjItlHw%2BOq8%2BVp29uq0r4r4r22r424r24rkjxnisGe4K9cMD0hNr5PjCXa3c1QRo&X-Amz-Signature=fd5ec81d49482cc2b26aac02ffe94e9d82d3e29b00c368fb1bad707f6066ecf0', 'iap-700000000047-preferences': 'https://my-bucket.s3.amazonaws.com/iap-700000000047-preferences.jpg4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AAAAAAAAAAAAA%2F20230110%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20230110T170414Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&X-Amz-Security-Token=FwoGZXIvYXdzEEsaDA9nffwerfrfrffqiK0Ae6ydwSr1R7ho%2BkIqn%2FOYVShw77vHhp5XuM945Z5uuqFQTUP128xAiCqgERWsuT7BSLhPeazeR6QjAm0jjH8JTa9YQ1OqBlF6BSY3o6oOvnagVxDwx1SzfEQK%2FMdoPpwOgPQ1qIN714YJfGe0Qp%2FbdAv%2F5tLGG5rgBX98CCuWTszpsWQnaFtfEWhfTG%2BvqUsjavsusT7TmPbHMv7gFqvSoU8Aos7LDt8vgUuA8TrD%2FQs9ZjkxyiOtfadBjItlHw%2BOq8%2BVpd24d24d24d24d42dZufWkjxnisGe4K9cMD0hNr5PjCXa3c1QRo&X-Amz-Signature=fd5ec81d49482cc2b26aac02ffe94e9d82d3e29b00c368fb1bad707f83929392'}
-                lpa0138:
-                  value:
-                    uId: 700000000138
-                    status: 'COLLECTION_COMPLETE'
-                    signedUrls: {'iap-700000000138-instructions': 'http://localhost:4010/iap-700000000138-instructions.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AAAAAAAAAAAAA%2F20230110%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20230110T170414Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&X-Amz-Security-Token=FwoGZXIvqfrfffffqB8ObHF9iK0Ae6ydwSr1R7ho%2BkIqn%2FOYVShw77vHhp5XuM945Z5uuqFQTUP128xAiCqgERWsuT7BSLhPeazeR6QjAm0jjH8JTa9YQ1OqBlF6BSY3o6oOvnagVxDwx1SzfEQK%2FMdoPpwOgPQ1qIN714YJfGe0Qp%2FbdAv%2F5tLGG5rgBX98CCuWTszpsWQnaFtfEWhfTG%2BvqUsjavsusT7TmPbHMv7gFqvSoU8Aos7LDt8vgUuA8TrD%2FQs9ZjkxyiOtfadBjItlHw%2BOq8%2BVp29uq0r4r4r22r424r24rkjxnisGe4K9cMD0hNr5PjCXa3c1QRo&X-Amz-Signature=fd5ec81d49482cc2b26aac02ffe94e9d82d3e29b00c368fb1bad707f6066ecf0', 'iap-700000000138-preferences': 'http://localhost:4010/iap-700000000138-preferences.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AAAAAAAAAAAAA%2F20230110%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20230110T170414Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&X-Amz-Security-Token=FwoGZXIvYXdzEEsaDA9nffwerfrfrffqiK0Ae6ydwSr1R7ho%2BkIqn%2FOYVShw77vHhp5XuM945Z5uuqFQTUP128xAiCqgERWsuT7BSLhPeazeR6QjAm0jjH8JTa9YQ1OqBlF6BSY3o6oOvnagVxDwx1SzfEQK%2FMdoPpwOgPQ1qIN714YJfGe0Qp%2FbdAv%2F5tLGG5rgBX98CCuWTszpsWQnaFtfEWhfTG%2BvqUsjavsusT7TmPbHMv7gFqvSoU8Aos7LDt8vgUuA8TrD%2FQs9ZjkxyiOtfadBjItlHw%2BOq8%2BVpd24d24d24d24d42dZufWkjxnisGe4K9cMD0hNr5PjCXa3c1QRo&X-Amz-Signature=fd5ec81d49482cc2b26aac02ffe94e9d82d3e29b00c368fb1bad707f83929392'}
                 lpa7237:
                   value:
                     uId: 700000137237
@@ -173,6 +168,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error500'
+              examples:
+                lpa0138:
+                  value:
+                    errors:
+                      - {'code': 'OPGDATA-API-SERVERERROR', 'title': 'Internal server error'}
         '502':
           description: Error pushing to upstream SQS queue or s3 bucket
           content:

--- a/mock-integrations/image-request-handler/mock-responses.js
+++ b/mock-integrations/image-request-handler/mock-responses.js
@@ -1,11 +1,16 @@
 var lpa = "lpa" + context.request.pathParams.uid.slice(-4);
 
 switch (lpa) {
-    case 'lpa0138':
     case 'lpa6361':
     case 'lpa7237':
     case 'lpa0252':
         respond().withExampleName(lpa);
+        break;
+    case 'lpa0138':
+        respond()
+            .withStatusCode(500)
+            .withFile("responses/lpa0138.json").template()
+            .usingDefaultBehaviour();
         break;
     case 'lpa0344':
         var lpaStore = stores.open('lpa0344');

--- a/mock-integrations/image-request-handler/responses/lpa0138.json
+++ b/mock-integrations/image-request-handler/responses/lpa0138.json
@@ -1,0 +1,4 @@
+{
+  "code": "OPGDATA-API-SERVERERROR",
+  "title": "Internal server error"
+}

--- a/service-api/app/src/App/src/Service/Lpa/LpaService.php
+++ b/service-api/app/src/App/src/Service/Lpa/LpaService.php
@@ -238,7 +238,11 @@ class LpaService
             (($lpaData['applicationHasGuidance'] ?? false) || ($lpaData['applicationHasRestrictions'] ?? false))
         ) {
             $this->logger->info('The LPA has instructions and/or preferences. Fetching images');
-            $result['iap'] = $this->iapRepository->getInstructionsAndPreferencesImages((int) $lpaData['uId']);
+
+            try {
+                $result['iap'] = $this->iapRepository->getInstructionsAndPreferencesImages((int) $lpaData['uId']);
+            } catch (\Exception) {
+            }
         }
 
         if (!is_null($organisation)) {

--- a/service-front/app/src/Actor/src/Handler/ViewLpaSummaryHandler.php
+++ b/service-front/app/src/Actor/src/Handler/ViewLpaSummaryHandler.php
@@ -78,7 +78,11 @@ class ViewLpaSummaryHandler extends AbstractHandler implements UserAware
                 ($lpaData->lpa->getApplicationHasRestrictions() ?? false)
             )
         ) {
-            $renderData['iap_images'] = $this->instAndPrefImagesService->getImagesById($identity, $actorLpaToken);
+            try {
+                $renderData['iap_images'] = $this->instAndPrefImagesService->getImagesById($identity, $actorLpaToken);
+            } catch (\Exception) {
+//                maybe return a flag to say whether it should have returned images
+            }
         }
 
         return new HtmlResponse(

--- a/service-front/app/src/Common/templates/partials/lpa-summary-details/lpa-details.html.twig
+++ b/service-front/app/src/Common/templates/partials/lpa-summary-details/lpa-details.html.twig
@@ -101,6 +101,8 @@
                         {% if lpa.applicationHasGuidance %}
                             {% if feature_enabled("instructions_and_preferences") and iap_images is defined %}
                                 {% trans %}Yes, the donor made preferences on their LPA.{% endtrans %}
+                            {% elseif feature_enabled("instructions_and_preferences") %}
+                                {% trans %}Sorry{% endtrans %}
                             {% else %}
                                 {% trans %}Yes, the donor made preferences on their LPA.{% endtrans %}
                                 <br>{% trans %}To view these, ask to see the paper LPA.{% endtrans %}


### PR DESCRIPTION
#  Not for Merge
## Purpose

Draft spike branch to still show summary page when image extraction service is down. 

Fixes UML-3049

## Approach

Recreating the error by mocking with the mock-image-request-handler to return a 500 error with an lpa that already existed. Will need to create a new mock lpa in the mock-data-lpa and mock-image-request-handler side.

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
