### PR TITLE
UML-2725 implement check for pwned passwords

### DIFF
--- a/service-front/app/src/Actor/src/Form/CreateAccount.php
+++ b/service-front/app/src/Actor/src/Form/CreateAccount.php
@@ -6,6 +6,7 @@ namespace Actor\Form;
 
 use Common\Form\AbstractForm;
 use Common\Form\Element\Email;
+use Common\Validator\CommonPasswordValidator;
 use Common\Validator\EmailAddressValidator;
 use Laminas\Filter\StringToLower;
 use Laminas\Filter\StringTrim;
@@ -92,6 +93,9 @@ class CreateAccount extends AbstractForm implements InputFilterProviderInterface
                                 NotEmpty::IS_EMPTY => 'Enter your password',
                             ],
                         ],
+                    ],
+                    [
+                        'name'    => CommonPasswordValidator::class,
                     ],
                     [
                         'name'    => StringLength::class,

--- a/service-front/app/src/Actor/src/Form/PasswordChange.php
+++ b/service-front/app/src/Actor/src/Form/PasswordChange.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Actor\Form;
 
 use Common\Form\AbstractForm;
+use Common\Validator\CommonPasswordValidator;
 use Laminas\InputFilter\InputFilterProviderInterface;
 use Laminas\Validator\NotEmpty;
 use Laminas\Validator\StringLength;
@@ -87,6 +88,9 @@ class PasswordChange extends AbstractForm implements InputFilterProviderInterfac
                                 StringLength::TOO_SHORT => 'Password must be 12 characters or more',
                             ],
                         ],
+                    ],
+                    [
+                        'name'    => CommonPasswordValidator::class,
                     ],
                 ],
             ],

--- a/service-front/app/src/Actor/templates/actor/form-error-messages.html.twig
+++ b/service-front/app/src/Actor/templates/actor/form-error-messages.html.twig
@@ -15,6 +15,8 @@
 {% trans %}Passwords do not match{% context %}error{% notes %}Create account{% endtrans %}
 {% trans %}Confirm your password{% context %}error{% notes %}Create account, password reset{% endtrans %}
 {% trans %}You must accept the terms of use to create an account{% context %}error{% notes %}Create account{% endtrans %}
+{% trans %}Password is too common{% context %}error{% notes %}Create account, change password{% endtrans %}
+
 
 {# Triage page #}
 {% trans %}Select yes if you have a Use a lasting power of attorney account{% context %}error{% notes %}Triage page{% endtrans %}

--- a/service-front/app/src/Common/src/Validator/CommonPasswordValidator.php
+++ b/service-front/app/src/Common/src/Validator/CommonPasswordValidator.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Common\Validator;
+
+use Laminas\Validator\AbstractValidator;
+use RuntimeException;
+
+class CommonPasswordValidator extends AbstractValidator
+{
+    public const COMMON_PASSWORD = 'common';
+
+    /**
+     * @var string[]
+     */
+    protected array $messageTemplates = [
+        self::COMMON_PASSWORD => 'Password is too common',
+    ];
+
+
+    const TMP_ROOT_PATH = '/tmp/';
+    const PWNED_PW_URL = 'https://www.ncsc.gov.uk/static-assets/documents/PwnedPasswordsTop100k.txt';
+
+    private string $filePathCommonPasswords;
+
+    private string $pwnedPasswordsUrl;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->filePathCommonPasswords = self::TMP_ROOT_PATH.'commonpasswords.txt';
+        $this->pwnedPasswordsUrl = self::PWNED_PW_URL;
+    }
+
+    /**
+     * @param mixed $value
+     * @return bool
+     */
+    public function isValid($value): bool
+    {
+        $isValid = true;
+        $this->checkCommonPasswordsFileExists($this->filePathCommonPasswords);
+
+        if ($this->passwordMatchesCommonPasswords($value, $this->filePathCommonPasswords)) {
+            $this->error(self::COMMON_PASSWORD);
+            $isValid = false;
+        }
+
+        return $isValid;
+    }
+
+    protected function passwordMatchesCommonPasswords(string $searchTerm, string $filePath): bool
+    {
+        $matches = [];
+        $handle = @fopen($filePath, 'r');
+        if ($handle && strlen($searchTerm) > 0) {
+            while (!feof($handle)) {
+                $buffer = fgets($handle);
+                if (false !== strpos($buffer, $searchTerm)) {
+                    $matches[] = $buffer;
+                }
+            }
+            fclose($handle);
+        }
+        //show results:
+        if (count($matches) > 0) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    protected function checkCommonPasswordsFileExists(string $filePath): void
+    {
+        if (file_exists($filePath) & (time() - filemtime($filePath) < 24 * 3600)) {
+            return;
+        } else {
+            $fp = fopen($this->pwnedPasswordsUrl, 'r');
+            if (false !== $fp) {
+                $written = file_put_contents(
+                    "$filePath",
+                    $fp
+                );
+                if (false === $written) {
+                    throw new RuntimeException(sprintf('Unable to download or write common password file to disk'));
+                }
+            }
+        }
+    }
+}

--- a/service-front/app/test/CommonTest/Validator/CommonPasswordValidatorTest.php
+++ b/service-front/app/test/CommonTest/Validator/CommonPasswordValidatorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommonTest\Validator;
+
+use Common\Validator\CommonPasswordValidator;
+use PHPUnit\Framework\TestCase;
+
+class CommonPasswordValidatorTest extends TestCase
+{
+    const PW_FILE_PATH = '/tmp/commonpasswords.txt';
+    const PWNED_PW_URL = 'https://www.ncsc.gov.uk/static-assets/documents/PwnedPasswordsTop100k.txt';
+
+    public function setUp(): void
+    {
+        file_put_contents(
+            self::PW_FILE_PATH,
+            fopen(self::PWNED_PW_URL, 'r')
+        );
+
+        $this->validator = new CommonPasswordValidator();
+    }
+
+    /**
+     * Verify a constraint message is triggered when value is invalid.
+     */
+    public function testValidateOnInvalid()
+    {
+        $this->assertFalse($this->validator->isValid('Password123'));
+        print(count($this->validator->getMessages()));
+        $this->assertArrayHasKey(CommonPasswordValidator::COMMON_PASSWORD, $this->validator->getMessages());
+    }
+
+
+    /**
+     * Verify no constraint message is triggered when value is valid.
+     */
+    public function testValidateOnValid()
+    {
+        $this->assertTrue($this->validator->isValid('Aformidablepw876!'));
+        $this->assertCount(0, $this->validator->getMessages());
+
+    }
+}

--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -37,6 +37,10 @@ FROM php-base AS app
 COPY service-front/app /app
 COPY --from=dependency /app/vendor /app/vendor
 
+# Add common passwords file
+RUN wget -q -O /tmp/commonpasswords.txt "https://www.ncsc.gov.uk/static-assets/documents/PwnedPasswordsTop100k.txt" \
+    && chown www-data /tmp/commonpasswords.txt
+
 #
 # Install development dependencies and tools into production image
 #


### PR DESCRIPTION
# Purpose

Closing due to move to one login. Unlikely this will need to be implemented.

Spike for UML-2725

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
