### PR TITLE
Remove curl and libxml upgrade

### DIFF
--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -7,7 +7,6 @@ COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr
 
 RUN set -xe \
   && apk add --update --no-cache fcgi \
-  && apk upgrade --update --no-cache curl libxml2 \
   && install-php-extensions apcu \
   && rm /usr/bin/install-php-extensions
 

--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -7,7 +7,6 @@ COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr
 
 RUN set -xe \
   && apk add --update --no-cache icu gettext fcgi \
-  && apk upgrade --update --no-cache curl libxml2 \
   && install-php-extensions apcu redis-^5 intl gettext \
   && rm /usr/bin/install-php-extensions
 


### PR DESCRIPTION
# Purpose

Curl is breaking in our images as we erroneously still upgrade it when we don't need to. Also removed the libxml upgrade as upgrades need not persist when the image version is bumped (they'll be included)
## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* The product team have tested these changes
