### PR TITLE
UML-3087 Increase PHP pool size 

### DIFF
--- a/service-api/docker/app/fpm-pool.ini
+++ b/service-api/docker/app/fpm-pool.ini
@@ -25,3 +25,6 @@
 ; }
 access.format = '{"time_local":"%{%Y-%m-%dT%H:%M:%S%z}T","client_ip":"%{HTTP_X_FORWARDED_FOR}e","remote_addr":"%R","remote_user":"%u","request":"%m %{REQUEST_URI}e %{SERVER_PROTOCOL}e","status":"%s","body_bytes_sent":"%l","request_time":"%d","request_memory":"%{mega}M","http_referrer":"%{HTTP_REFERER}e","http_user_agent":"%{HTTP_USER_AGENT}e","service_name":"api","request_id":"%{HTTP_X_AMZN_TRACE_ID}e"}'
 ping.path = /ping
+
+pm = static
+pm.max_children = ${OPG_PHP_POOL_CHILDREN_MAX}

--- a/service-api/docker/web/Dockerfile
+++ b/service-api/docker/web/Dockerfile
@@ -6,6 +6,8 @@ RUN apk upgrade && \
 
 # Add Confd to configure nginx on start
 ENV CONFD_VERSION="0.16.0"
+ENV OPG_PHP_POOL_CHILDREN_MAX="25"
+
 RUN wget -q -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64" \
   && chmod +x /usr/local/bin/confd
 

--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -3,6 +3,8 @@
 #
 FROM php:8.1.23-fpm-alpine3.18 AS php-base
 
+ENV OPG_PHP_POOL_CHILDREN_MAX="25"
+
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
 RUN set -xe \

--- a/service-front/docker/app/fpm-pool.ini
+++ b/service-front/docker/app/fpm-pool.ini
@@ -25,3 +25,6 @@
 ; }
 access.format = '{"time_local":"%{%Y-%m-%dT%H:%M:%S%z}T","client_ip":"%{HTTP_X_FORWARDED_FOR}e","remote_addr":"%R","remote_user":"%u","request":"%m %{REQUEST_URI}e %{SERVER_PROTOCOL}e","status":"%s","body_bytes_sent":"%l","request_time":"%d","request_memory":"%{mega}M","http_referrer":"%{HTTP_REFERER}e","http_user_agent":"%{HTTP_USER_AGENT}e","service_name":"front","request_id":"%{HTTP_X_AMZN_TRACE_ID}e"}'
 ping.path = /ping
+
+pm = static
+pm.max_children = ${OPG_PHP_POOL_CHILDREN_MAX}

--- a/terraform/environment/actor_ecs.tf
+++ b/terraform/environment/actor_ecs.tf
@@ -194,6 +194,10 @@ locals {
           name  = "TIMEOUT",
           value = "60"
         },
+        { 
+          name = "OPG_PHP_POOL_CHILDREN_MAX", 
+          value = "25"
+        },
         {
           name  = "CONTAINER_VERSION",
           value = var.container_version

--- a/terraform/environment/actor_ecs.tf
+++ b/terraform/environment/actor_ecs.tf
@@ -194,8 +194,8 @@ locals {
           name  = "TIMEOUT",
           value = "60"
         },
-        { 
-          name = "OPG_PHP_POOL_CHILDREN_MAX", 
+        {
+          name  = "OPG_PHP_POOL_CHILDREN_MAX",
           value = "25"
         },
         {

--- a/terraform/environment/api_ecs.tf
+++ b/terraform/environment/api_ecs.tf
@@ -287,8 +287,8 @@ locals {
           name  = "TIMEOUT",
           value = "60"
         },
-        { 
-          name = "OPG_PHP_POOL_CHILDREN_MAX", 
+        {
+          name  = "OPG_PHP_POOL_CHILDREN_MAX",
           value = "25"
         },
         {

--- a/terraform/environment/api_ecs.tf
+++ b/terraform/environment/api_ecs.tf
@@ -287,6 +287,10 @@ locals {
           name  = "TIMEOUT",
           value = "60"
         },
+        { 
+          name = "OPG_PHP_POOL_CHILDREN_MAX", 
+          value = "25"
+        },
         {
           name  = "CONTAINER_VERSION",
           value = var.container_version


### PR DESCRIPTION
# Purpose

Increase the worker pool size from 4 to 25 in PHP.

Fixes UML-3087

## Approach

Set the pool size to be an environment variable and set the env variable to have a size of 25.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
