### PR TITLE
UML-3109 Remove build_admin feature flag from TF

### DIFF
--- a/terraform/environment/admin_load_balancer.tf
+++ b/terraform/environment/admin_load_balancer.tf
@@ -1,5 +1,4 @@
 resource "aws_lb_target_group" "admin" {
-  count                = local.environment.build_admin ? 1 : 0
   name                 = "${local.environment_name}-admin"
   port                 = 80
   protocol             = "HTTP"
@@ -12,11 +11,15 @@ resource "aws_lb_target_group" "admin" {
     path    = "/helloworld"
   }
 
-  depends_on = [aws_lb.admin[0]]
+  depends_on = [aws_lb.admin]
+}
+
+moved {
+  from = aws_lb_target_group.admin[0]
+  to   = aws_lb_target_group.admin
 }
 
 resource "aws_lb" "admin" {
-  count                      = local.environment.build_admin ? 1 : 0
   name                       = "${local.environment_name}-admin"
   internal                   = false #tfsec:ignore:AWS005 - public alb
   load_balancer_type         = "application"
@@ -25,7 +28,7 @@ resource "aws_lb" "admin" {
   enable_deletion_protection = local.environment.load_balancer_deletion_protection_enabled
 
   security_groups = [
-    aws_security_group.admin_loadbalancer[0].id,
+    aws_security_group.admin_loadbalancer.id,
   ]
 
   access_logs {
@@ -35,9 +38,13 @@ resource "aws_lb" "admin" {
   }
 }
 
+moved {
+  from = aws_lb.admin[0]
+  to   = aws_lb.admin
+}
+
 resource "aws_lb_listener" "admin_loadbalancer_http_redirect" {
-  count             = local.environment.build_admin ? 1 : 0
-  load_balancer_arn = aws_lb.admin[0].arn
+  load_balancer_arn = aws_lb.admin.arn
   port              = "80"
   protocol          = "HTTP"
 
@@ -52,9 +59,13 @@ resource "aws_lb_listener" "admin_loadbalancer_http_redirect" {
   }
 }
 
+moved {
+  from = aws_lb_listener.admin_loadbalancer_http_redirect[0]
+  to   = aws_lb_listener.admin_loadbalancer_http_redirect
+}
+
 resource "aws_lb_listener" "admin_loadbalancer" {
-  count             = local.environment.build_admin ? 1 : 0
-  load_balancer_arn = aws_lb.admin[0].arn
+  load_balancer_arn = aws_lb.admin.arn
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-FS-1-2-2019-08"
@@ -66,33 +77,40 @@ resource "aws_lb_listener" "admin_loadbalancer" {
     authenticate_oidc {
       authentication_request_extra_params = {}
       authorization_endpoint              = "${local.admin_cognito_user_pool_domain_name}/oauth2/authorize"
-      client_id                           = aws_cognito_user_pool_client.use_a_lasting_power_of_attorney_admin[0].id
-      client_secret                       = aws_cognito_user_pool_client.use_a_lasting_power_of_attorney_admin[0].client_secret
+      client_id                           = aws_cognito_user_pool_client.use_a_lasting_power_of_attorney_admin.id
+      client_secret                       = aws_cognito_user_pool_client.use_a_lasting_power_of_attorney_admin.client_secret
       issuer                              = "https://cognito-idp.eu-west-1.amazonaws.com/${local.admin_cognito_user_pool_id}"
       on_unauthenticated_request          = "authenticate"
       scope                               = "openid"
       session_cookie_name                 = "AWSELBAuthSessionCookie"
-      session_timeout                     = aws_cognito_user_pool_client.use_a_lasting_power_of_attorney_admin[0].id_token_validity
+      session_timeout                     = aws_cognito_user_pool_client.use_a_lasting_power_of_attorney_admin.id_token_validity
       token_endpoint                      = "${local.admin_cognito_user_pool_domain_name}/oauth2/token"
       user_info_endpoint                  = "${local.admin_cognito_user_pool_domain_name}/oauth2/userInfo"
     }
   }
 
   default_action {
-    target_group_arn = aws_lb_target_group.admin[0].arn
+    target_group_arn = aws_lb_target_group.admin.arn
     type             = "forward"
   }
 }
 
+moved {
+  from = aws_lb_listener.admin_loadbalancer[0]
+  to   = aws_lb_listener.admin_loadbalancer
+}
+
 resource "aws_lb_listener_certificate" "admin_loadbalancer_live_service_certificate" {
-  count           = local.environment.build_admin ? 1 : 0
-  listener_arn    = aws_lb_listener.admin_loadbalancer[0].arn
+  listener_arn    = aws_lb_listener.admin_loadbalancer.arn
   certificate_arn = data.aws_acm_certificate.public_facing_certificate_use.arn
 }
 
+moved {
+  from = aws_lb_listener_certificate.admin_loadbalancer_live_service_certificate[0]
+  to   = aws_lb_listener_certificate.admin_loadbalancer_live_service_certificate
+}
 
 resource "aws_security_group" "admin_loadbalancer" {
-  count       = local.environment.build_admin ? 1 : 0
   name_prefix = "${local.environment_name}-admin-loadbalancer"
   description = "Admin service application load balancer"
   vpc_id      = data.aws_vpc.default.id
@@ -101,35 +119,52 @@ resource "aws_security_group" "admin_loadbalancer" {
   }
 }
 
+moved {
+  from = aws_security_group.admin_loadbalancer[0]
+  to   = aws_security_group.admin_loadbalancer
+}
+
 resource "aws_security_group_rule" "admin_loadbalancer_port_80_redirect_ingress" {
-  count             = local.environment.build_admin ? 1 : 0
   description       = "Port 80 ingress for redirection to port 443"
   type              = "ingress"
   from_port         = 80
   to_port           = 80
   protocol          = "tcp"
   cidr_blocks       = module.allow_list.moj_sites
-  security_group_id = aws_security_group.admin_loadbalancer[0].id
+  security_group_id = aws_security_group.admin_loadbalancer.id
+}
+
+moved {
+  from = aws_security_group_rule.admin_loadbalancer_port_80_redirect_ingress[0]
+  to   = aws_security_group_rule.admin_loadbalancer_port_80_redirect_ingress
 }
 
 resource "aws_security_group_rule" "admin_loadbalancer_ingress" {
-  count             = local.environment.build_admin ? 1 : 0
   description       = "Port 443 ingress from the allow list to the application load balancer"
   type              = "ingress"
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
   cidr_blocks       = module.allow_list.moj_sites
-  security_group_id = aws_security_group.admin_loadbalancer[0].id
+  security_group_id = aws_security_group.admin_loadbalancer.id
+}
+
+moved {
+  from = aws_security_group_rule.admin_loadbalancer_ingress[0]
+  to   = aws_security_group_rule.admin_loadbalancer_ingress
 }
 
 resource "aws_security_group_rule" "admin_loadbalancer_egress" {
-  count             = local.environment.build_admin ? 1 : 0
   description       = "Allow any egress from Use service load balancer"
   type              = "egress"
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:AWS007 - open egress for load balancers
-  security_group_id = aws_security_group.admin_loadbalancer[0].id
+  security_group_id = aws_security_group.admin_loadbalancer.id
+}
+
+moved {
+  from = aws_security_group_rule.admin_loadbalancer_egress[0]
+  to   = aws_security_group_rule.admin_loadbalancer_egress
 }

--- a/terraform/environment/cloudwatch_alarms.tf
+++ b/terraform/environment/cloudwatch_alarms.tf
@@ -108,7 +108,6 @@ resource "aws_cloudwatch_metric_alarm" "viewer_ddos_attack_external" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "admin_ddos_attack_external" {
-  count               = local.environment.build_admin ? 1 : 0
   alarm_name          = "${local.environment_name}_AdminDDoSDetected"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "3"
@@ -121,6 +120,11 @@ resource "aws_cloudwatch_metric_alarm" "admin_ddos_attack_external" {
   treat_missing_data  = "notBreaching"
   alarm_actions       = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
   dimensions = {
-    ResourceArn = aws_lb.admin[0].arn
+    ResourceArn = aws_lb.admin.arn
   }
+}
+
+moved {
+  from = aws_cloudwatch_metric_alarm.admin_ddos_attack_external[0]
+  to   = aws_cloudwatch_metric_alarm.admin_ddos_attack_external
 }

--- a/terraform/environment/cognito_client.tf
+++ b/terraform/environment/cognito_client.tf
@@ -14,7 +14,6 @@ locals {
 }
 
 resource "aws_cognito_user_pool_client" "use_a_lasting_power_of_attorney_admin" {
-  count                                = local.environment.build_admin ? 1 : 0
   provider                             = aws.identity
   name                                 = "${local.environment_name}-admin-auth"
   user_pool_id                         = local.admin_cognito_user_pool_id
@@ -42,6 +41,11 @@ resource "aws_cognito_user_pool_client" "use_a_lasting_power_of_attorney_admin" 
   read_attributes        = []
   write_attributes       = []
 
-  callback_urls = ["https://${aws_route53_record.admin_use_my_lpa[0].fqdn}/oauth2/idpresponse"]
-  logout_urls   = ["https://${aws_route53_record.admin_use_my_lpa[0].fqdn}/"]
+  callback_urls = ["https://${aws_route53_record.admin_use_my_lpa.fqdn}/oauth2/idpresponse"]
+  logout_urls   = ["https://${aws_route53_record.admin_use_my_lpa.fqdn}/"]
+}
+
+moved {
+  from = aws_cognito_user_pool_client.use_a_lasting_power_of_attorney_admin[0]
+  to   = aws_cognito_user_pool_client.use_a_lasting_power_of_attorney_admin
 }

--- a/terraform/environment/config_file.tf
+++ b/terraform/environment/config_file.tf
@@ -14,7 +14,7 @@ locals {
     stats_table                              = aws_dynamodb_table.stats_table.name
     actor_fqdn                               = aws_route53_record.actor-use-my-lpa.fqdn
     viewer_fqdn                              = aws_route53_record.viewer-use-my-lpa.fqdn
-    admin_fqdn                               = local.environment.build_admin ? aws_route53_record.admin_use_my_lpa[0].fqdn : ""
+    admin_fqdn                               = aws_route53_record.admin_use_my_lpa.fqdn
     public_facing_use_fqdn                   = aws_route53_record.public_facing_use_lasting_power_of_attorney.fqdn
     public_facing_view_fqdn                  = aws_route53_record.public_facing_view_lasting_power_of_attorney.fqdn
     viewer_load_balancer_security_group_name = aws_security_group.viewer_loadbalancer.name

--- a/terraform/environment/dns.tf
+++ b/terraform/environment/dns.tf
@@ -107,7 +107,6 @@ resource "aws_route53_record" "actor-use-my-lpa" {
 
 resource "aws_route53_record" "admin_use_my_lpa" {
   # admin.lastingpowerofattorney.opg.service.justice.gov.uk
-  count    = local.environment.build_admin ? 1 : 0
   provider = aws.management
   zone_id  = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
   name     = "${local.dns_namespace_env}admin.lastingpowerofattorney"
@@ -115,11 +114,16 @@ resource "aws_route53_record" "admin_use_my_lpa" {
 
   alias {
     evaluate_target_health = false
-    name                   = aws_lb.admin[0].dns_name
-    zone_id                = aws_lb.admin[0].zone_id
+    name                   = aws_lb.admin.dns_name
+    zone_id                = aws_lb.admin.zone_id
   }
 
   lifecycle {
     create_before_destroy = true
   }
+}
+
+moved {
+  from = aws_route53_record.admin_use_my_lpa[0]
+  to   = aws_route53_record.admin_use_my_lpa
 }

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -52,7 +52,6 @@ variable "environments" {
           maximum = number
         })
       })
-      build_admin                               = bool
       cookie_expires_use                        = number
       cookie_expires_view                       = number
       google_analytics_id_use                   = string

--- a/terraform/environment/terraform.tf
+++ b/terraform/environment/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "<= 1.5.6"
+  required_version = "<= 1.5.7"
 
   backend "s3" {
     bucket         = "opg.terraform.state"

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -21,7 +21,6 @@
           "minimum": 2
         }
       },
-      "build_admin": true,
       "cookie_expires_use": 1440,
       "cookie_expires_view": 1440,
       "google_analytics_id_use": "G-JQHJE49CBB",
@@ -97,7 +96,6 @@
           "minimum": 2
         }
       },
-      "build_admin": true,
       "cookie_expires_use": 1440,
       "cookie_expires_view": 1440,
       "google_analytics_id_use": "G-JQHJE49CBB",
@@ -173,7 +171,6 @@
           "minimum": 2
         }
       },
-      "build_admin": true,
       "cookie_expires_use": 1440,
       "cookie_expires_view": 1440,
       "google_analytics_id_use": "",
@@ -249,7 +246,6 @@
           "minimum": 2
         }
       },
-      "build_admin": true,
       "cookie_expires_use": 1440,
       "cookie_expires_view": 1440,
       "google_analytics_id_use": "G-TX93T4G7SZ",


### PR DESCRIPTION
# Purpose

Simplify the Terraform case by removing a now unnecessary ternary. 

Fixes UML-3109

## Approach

Remove the build_admin flag as it exists in all environments. Use moved resources to refactor the code.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
