### PR TITLE
UML-3146 Disable apply shared TF in PR workflow

### DIFF
--- a/.github/workflows/path-to-live.yml
+++ b/.github/workflows/path-to-live.yml
@@ -108,9 +108,7 @@ jobs:
     with:
       workspace: development
       terraform_path: account
-      # TODO: Remove this line when ready to apply - temporarily disabled to prevent accidental changes
-      apply: false
-      # apply: true
+      apply: true
       specific_path: all
     secrets: inherit
 
@@ -122,9 +120,7 @@ jobs:
     with:
       workspace: preproduction
       terraform_path: account
-      # TODO: Remove this line when ready to apply - temporarily disabled to prevent accidental changes
-      apply: false
-      # apply: true
+      apply: true
       specific_path: all
     secrets: inherit
 
@@ -166,9 +162,7 @@ jobs:
     with:
       workspace: production
       terraform_path: account
-      # TODO: Remove this line when ready to apply. Temporarily disabled to prevent accidental changes
-      apply: false
-      # apply: true
+      apply: true
       specific_path: all
     secrets: inherit
 


### PR DESCRIPTION
# Purpose

Prevent other pull requests from overwriting changes to Terraform shared / account

Fixes UML-3146

## Approach

Disable applying the Terraform shared / account during the PR workflow and do only a plan. Also, temporarily disabled in (Pre-)production to allow this PR to be merged.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
