### PR TITLE
UML-3040 Create ephemeral environments when PR is raised

### DIFF
--- a/.github/workflows/pull-request-path.yml
+++ b/.github/workflows/pull-request-path.yml
@@ -1,4 +1,4 @@
-name: "[Workflow] All branch based pushes"
+name: "[Workflow] PR Environment"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -8,15 +8,10 @@ defaults:
     shell: bash
 
 on:
-  push:
+  pull_request:
     branches:
-      - '*'              # matches every branch that doesn't contain a '/'
-      - '*/*'            # matches every branch containing a single '/'
-      - '**'             # matches every branch
-      - '!main'          # reverse match main
-      - '!dependabot/**' # reverse match dependabot PRs
-      - 'dependabot/docker/**' # match dependabot PRs that update docker
-      - 'dependabot/pip/**' # match dependabot PRs that update pip
+      - main
+
 
 permissions:
   contents: write
@@ -31,6 +26,9 @@ permissions:
   statuses: none
 
 jobs:
+  workspace_name:
+    uses: ministryofjustice/opg-github-workflows/.github/workflows/data-parse-workspace.yml@383650d409aad063a69ce6cc3a013ac538cc1508
+
   workflow_variables:
     runs-on: ubuntu-latest
     name: output workflow variables
@@ -79,8 +77,9 @@ jobs:
     uses: ./.github/workflows/_lint-terraform.yml
     needs:
       - workflow_variables
+      - workspace_name
     with:
-      workspace: ${{ needs.workflow_variables.outputs.parsed_branch }}
+      workspace: ${{ needs.workspace_name.outputs.name }}
     secrets: inherit
     if: |
       always() &&
@@ -148,8 +147,9 @@ jobs:
       - docker_build_scan_push
       - terraform_lint
       - workflow_variables
+      - workspace_name
     with:
-      workspace: ${{ needs.workflow_variables.outputs.parsed_branch }}
+      workspace: ${{ needs.workspace_name.outputs.name }}
       terraform_path: environment
       container_version: ${{ needs.workflow_variables.outputs.parsed_branch }}-${{ needs.workflow_variables.outputs.short_sha }}
       apply: true
@@ -201,8 +201,9 @@ jobs:
     needs:
       - seed_dynamodb
       - workflow_variables
+      - workspace_name
     with:
-      workspace: ${{ needs.workflow_variables.outputs.parsed_branch }}
+      workspace: ${{ needs.workspace_name.outputs.name }}
     secrets: inherit
     if: |
       always() &&
@@ -259,12 +260,13 @@ jobs:
       - ecr_scan_results
       - slack_notify
       - workflow_variables
+      - workspace_name
     steps:
       - name: workflow has ended without issue
         run: |
           echo "${{ needs.workflow_variables.outputs.parsed_branch }} PR environment tested, built and deployed"
           echo "Tag Used: ${{ needs.workflow_variables.outputs.parsed_branch }}-${{ needs.workflow_variables.outputs.short_sha }}"
-          echo "URL: https://${{ needs.workflow_variables.outputs.parsed_branch }}.use-lasting-power-of-attorney.service.gov.uk"
+          echo "URL: https://${{ needs.workspace_name.outputs.name }}.use-lasting-power-of-attorney.service.gov.uk"
     if: |
       always() &&
       needs.ecr_scan_results.result == 'success' &&


### PR DESCRIPTION
# Purpose

Create ephemeral environments when a PR is raised. Currently, one is created on pushing to a non-main branch. This will also give each ephemeral environment a unique name based on its PR number.

Fixes UML-3040

## Approach

Change Github Workflow to run on PR instead of Push. Use common OPG reusable workflow to generate environment name.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
