### PR TITLE
UML-3155 Enable account resources in eu-west-2

### DIFF
--- a/terraform/account/region.tf
+++ b/terraform/account/region.tf
@@ -16,3 +16,22 @@ module "eu_west_1" {
     aws.shared     = aws.shared
   }
 }
+
+module "eu_west_2" {
+  source = "./region"
+
+  account                  = local.account
+  account_name             = local.account_name
+  environment_name         = local.environment
+  lambda_container_version = var.lambda_container_version
+
+  depends_on = [
+    module.cloudwatch_mrk,
+  ]
+
+  providers = {
+    aws.region     = aws.eu_west_2
+    aws.management = aws.management
+    aws.shared     = aws.shared
+  }
+}

--- a/terraform/account/region/cloudwatch.tf
+++ b/terraform/account/region/cloudwatch.tf
@@ -10,7 +10,7 @@ resource "aws_cloudwatch_log_group" "use-an-lpa" {
 }
 
 data "aws_kms_alias" "cloudwatch_mrk" {
-  name = "alias/cloudwatch_encryption"
+  name = "alias/cloudwatch-encryption-mrk"
 
   provider = aws.region
 }

--- a/terraform/environment/shared_data_sources.tf
+++ b/terraform/environment/shared_data_sources.tf
@@ -65,7 +65,7 @@ data "aws_kms_alias" "pagerduty_sns" {
 }
 
 data "aws_kms_alias" "cloudwatch_encryption" {
-  name = "alias/cloudwatch_encryption"
+  name = "alias/cloudwatch-encryption-mrk"
 }
 
 //--------------------

--- a/terraform/environment/terraform.tf
+++ b/terraform/environment/terraform.tf
@@ -60,6 +60,19 @@ provider "aws" {
 }
 
 provider "aws" {
+  region = "eu-west-2"
+  alias  = "eu_west_2"
+  default_tags {
+    tags = local.default_tags
+  }
+  assume_role {
+    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.default_role}"
+    session_name = "terraform-session"
+  }
+}
+
+
+provider "aws" {
   region = "us-east-1"
   alias  = "us-east-1"
   default_tags {


### PR DESCRIPTION
# Purpose

Enable Terraform account level resources in eu-west-2 for all environments. This is required to continue developing the environment Terraform code for multi-region.

Fixes UML-3155

## Approach

Add a region stanza for eu_west_2 in account Terraform.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
