### PR TITLE
remove early monday morning schedule from everything except github

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,9 +29,6 @@
         "patch"
       ],
       "prPriority": 0,
-      "schedule": [
-        "after 6am and before 9am on Monday"
-      ],
       "stabilityDays": 3,
       "excludePackageNames": [
         "php"
@@ -64,18 +61,12 @@
     "prCreation": "status-success",
     "rangeStrategy": "pin",
     "prPriority": 1,
-    "schedule": [
-      "after 6am and before 9am on Monday"
-    ]
-  },
+  ,
   "vulnerabilityAlerts": {
     "groupName": "Security Alerts",
     "labels": [
       "Dependencies",
       "Renovate"
-    ],
-    "schedule": [
-      "after 6am and before 9am every weekday"
     ],
     "dependencyDashboardApproval": false,
     "stabilityDays": 0,


### PR DESCRIPTION
actions

# Purpose

_remove early monday morning schedule from everything except github, to allow renovate to work its way through large backlog of updates_

## Approach

_Mods to renovate.json_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
