### PR TITLE
UML-3177 Remove hardcoded region from applications

### DIFF
--- a/service-api/app/config/autoload/envs.global.php
+++ b/service-api/app/config/autoload/envs.global.php
@@ -26,7 +26,7 @@ return [
     ],
 
     'aws' => [
-        'region'  => 'eu-west-1',
+        'region' => getenv('AWS_REGION') ?: 'eu-west-1',
         'version' => 'latest',
 
         'DynamoDb' => [

--- a/service-api/app/features/bootstrap/config.php
+++ b/service-api/app/features/bootstrap/config.php
@@ -18,7 +18,7 @@ return [
     ],
 
     'aws' => [
-        'region' => 'eu-west-1',
+        'region' => getenv('AWS_REGION') ?: null,
         'version' => 'latest',
 
         'DynamoDb' => [

--- a/service-api/app/features/bootstrap/config.php
+++ b/service-api/app/features/bootstrap/config.php
@@ -18,7 +18,7 @@ return [
     ],
 
     'aws' => [
-        'region' => getenv('AWS_REGION') ?: null,
+        'region' => getenv('AWS_REGION') ?: 'eu-west-1',
         'version' => 'latest',
 
         'DynamoDb' => [

--- a/service-api/app/src/App/src/DataAccess/ApiGateway/RequestSignerFactory.php
+++ b/service-api/app/src/App/src/DataAccess/ApiGateway/RequestSignerFactory.php
@@ -15,6 +15,8 @@ class RequestSignerFactory
 
         $token = $config['codes_api']['static_auth_token'] ?? null;
 
-        return new RequestSigner(new SignatureV4('execute-api', $config['aws']['region']), $token);
+        $aws_region = $config['aws']['region'] ?? 'eu-west-1';
+
+        return new RequestSigner(new SignatureV4('execute-api', $aws_region), $token);
     }
 }

--- a/service-api/app/src/App/src/DataAccess/ApiGateway/RequestSignerFactory.php
+++ b/service-api/app/src/App/src/DataAccess/ApiGateway/RequestSignerFactory.php
@@ -15,6 +15,6 @@ class RequestSignerFactory
 
         $token = $config['codes_api']['static_auth_token'] ?? null;
 
-        return new RequestSigner(new SignatureV4('execute-api', 'eu-west-1'), $token);
+        return new RequestSigner(new SignatureV4('execute-api', $config['aws']['region']), $token);
     }
 }

--- a/service-api/app/test/BehatTest/DataAccess/ApiGateway/PactLpasFactory.php
+++ b/service-api/app/test/BehatTest/DataAccess/ApiGateway/PactLpasFactory.php
@@ -26,7 +26,7 @@ class PactLpasFactory
 
         return new Lpas(
             new HttpClient(),
-            new SignatureV4('execute-api', 'eu-west-1'),
+            new SignatureV4('execute-api', $config['aws']['region']),
             $apiHost,
             $container->get(RequestTracing::TRACE_PARAMETER_NAME),
             $container->get(SiriusLpaSanitiser::class),

--- a/service-front/app/config/autoload/envs.global.php
+++ b/service-front/app/config/autoload/envs.global.php
@@ -12,7 +12,7 @@ return [
         'uri' => getenv('PDF_SERVICE_URL') ?: null,
     ],
     'aws'            => [
-        'region'  => getenv('AWS_REGION') ?: null,
+        'region'  => getenv('AWS_REGION') ?: 'eu-west-1',
         'version' => 'latest',
         'Kms'     => [
             'endpoint' => getenv('AWS_ENDPOINT_KMS') ?: null,

--- a/service-front/app/config/autoload/envs.global.php
+++ b/service-front/app/config/autoload/envs.global.php
@@ -12,7 +12,7 @@ return [
         'uri' => getenv('PDF_SERVICE_URL') ?: null,
     ],
     'aws'            => [
-        'region'  => 'eu-west-1',
+        'region'  => getenv('AWS_REGION') ?: null,
         'version' => 'latest',
         'Kms'     => [
             'endpoint' => getenv('AWS_ENDPOINT_KMS') ?: null,


### PR DESCRIPTION
# Purpose

Remove hardcoded eu-west-1 references from applications.

Fixes UML-3177

## Approach

Change the config to load the region name from the ECS-supplied AWS_REGION environment variable instead of being hardcoded to 'eu-west-1'.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
