### PR TITLE
replace no longer allowed hyphens with word

### DIFF
--- a/service-admin/.vscode/launch.json
+++ b/service-admin/.vscode/launch.json
@@ -14,8 +14,8 @@
             "env": {
                 "AWS_DYNAMODB_ENDPOINT": "http://localhost:8000",
                 "ADMIN_JWT_SIGNING_KEY_URL": "http://localhost:5000",
-                "AWS_ACCESS_KEY_ID": "-",
-                "AWS_SECRET_ACCESS_KEY": "-",
+                "AWS_ACCESS_KEY_ID": "devkey",
+                "AWS_SECRET_ACCESS_KEY": "secretkey",
                 "ADMIN_LOGOUT_URL": "https://login-admin-lastingpowerofattorney.auth.eu-west-1.amazoncognito.com/logout",
             }
         }

--- a/service-admin/README.md
+++ b/service-admin/README.md
@@ -35,8 +35,8 @@ The following environment variables will need to be set:
 |---|---------|
 | `AWS_DYNAMODB_ENDPOINT` | `http://localhost:8000` |
 | `ADMIN_JWT_SIGNING_KEY_URL` | `http://localhost:5000` |
-| `AWS_ACCESS_KEY_ID` | - |
-| `AWS_SECRET_ACCESS_KEY` | - |
+| `AWS_ACCESS_KEY_ID` | devkey |
+| `AWS_SECRET_ACCESS_KEY` | secretdevkey |
 
 Run the proxy using the instructions in [the README](./proxy/README.md).
 


### PR DESCRIPTION
# Purpose

_Hyphens no long allowed in AWS secrets (this issue affects for local running only)_

## Approach

_Use word instead of hyphen_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
