### PR TITLE
UML-3204: Allow access to Redis from API

### DIFF
--- a/terraform/environment/region/api_ecs.tf
+++ b/terraform/environment/region/api_ecs.tf
@@ -446,6 +446,18 @@ locals {
         {
           name  = "ALLOW_GOV_ONE_LOGIN",
           value = tostring(var.feature_flags.allow_gov_one_login)
+        },
+        {
+          name  = "LOGIN_SERIAL_CACHE_URL",
+          value = "tls://${data.aws_elasticache_replication_group.brute_force_cache_replication_group.primary_endpoint_address}"
+        },
+        {
+          name  = "LOGIN_SERIAL_CACHE_PORT",
+          value = tostring(data.aws_elasticache_replication_group.brute_force_cache_replication_group.port)
+        },
+        {
+          name  = "LOGIN_SERIAL_CACHE_TIMEOUT",
+          value = "60"
         }
       ]
   })

--- a/terraform/environment/region/api_ecs.tf
+++ b/terraform/environment/region/api_ecs.tf
@@ -138,6 +138,23 @@ resource "aws_security_group_rule" "api_ecs_service_egress" {
   provider = aws.region
 }
 
+//----------------------------------
+// Allow API to access Elasticache
+resource "aws_security_group_rule" "api_ecs_service_elasticache_ingress" {
+  description              = "Allow elasticache ingress for API service"
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 6379
+  protocol                 = "tcp"
+  security_group_id        = data.aws_security_group.brute_force_cache_service.id
+  source_security_group_id = aws_security_group.api_ecs_service.id
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  provider = aws.region
+}
+
 //--------------------------------------
 // Api ECS Service Task level config
 
@@ -153,6 +170,7 @@ resource "aws_ecs_task_definition" "api" {
 
   provider = aws.region
 }
+
 
 //----------------
 // Permissions


### PR DESCRIPTION
# Purpose

Allow access to Redis from the api-app

Fixes UML-3204

## Approach

Add a new security group rule to the Elasticache security group to allow network access from the api-app containers.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
