### PR TITLE
Point at new location of the Dockerfile in codes repo.

### DIFF
--- a/docker-compose.dependencies.yml
+++ b/docker-compose.dependencies.yml
@@ -16,6 +16,7 @@ services:
   codes-gateway:
     build:
       context: ../opg-data-lpa-codes/lambda_functions/v1
+      dockerfile: Dockerfile-Local-Helper
     ports:
       - 4343:4343
     volumes:


### PR DESCRIPTION
When the codes lambdas were updated the Dockerfile name changed. 

This updates UMLPA locally to point at the local test helper dockerfile.