### PR TITLE
UML 3223 fix all multi-button spacing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
       ALLOW_MERIS_LPAS: "false"
       DONT_SEND_LPAS_REGISTERED_AFTER_SEP_2019_TO_CLEANSING_TEAM: "true"
       INSTRUCTIONS_AND_PREFERENCES: "true"
-      ALLOW_GOV_ONE_LOGIN: "true"
+      ALLOW_GOV_ONE_LOGIN: "false"
 
       # Local only
       API_SERVICE_URL: http://api-web

--- a/service-front/app/src/Actor/templates/actor/activation-key-request-received.html.twig
+++ b/service-front/app/src/Actor/templates/actor/activation-key-request-received.html.twig
@@ -27,10 +27,16 @@
                     <h2 class="govuk-heading-l">{% trans %}Have more than one LPA?{% endtrans %}</h2>
                     <p class="govuk-body">{% trans %}You'll need an activation key for each LPA that you'd like to add to your account.{% endtrans %}</p>
 
-                    <a href="{{ path('lpa.add-by-paper', {}, {'startAgain': 'true'})}}" draggable="false" class="govuk-button">{% trans %}Request another activation key{% endtrans %}</a>
-                    <a class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1" href="{{ path('lpa.dashboard') }}">
-                        {% trans %}Back to your LPAs{% endtrans %}
-                    </a>
+                    <div class="moj-button-menu">
+                        <div class="moj-button-menu__wrapper">
+                            <a href="{{ path('lpa.add-by-paper', {}, {'startAgain': 'true'})}}" role="button" draggable="false" class="govuk-button moj-button-menu__item  " data-module="govuk-button">
+                                {% trans %}Request another activation key{% endtrans %}
+                            </a>
+                            <a href="{{ path('lpa.dashboard') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
+                                {% trans %}Back to your LPAs{% endtrans %}
+                            </a>
+                        </div>
+                    </div>
                 </div>
             </div>
         </main>

--- a/service-front/app/src/Actor/templates/actor/activation-key-request-received.html.twig
+++ b/service-front/app/src/Actor/templates/actor/activation-key-request-received.html.twig
@@ -29,10 +29,14 @@
 
                     <div class="moj-button-menu">
                         <div class="moj-button-menu__wrapper">
-                            <a href="{{ path('lpa.add-by-paper', {}, {'startAgain': 'true'})}}" role="button" draggable="false" class="govuk-button moj-button-menu__item  " data-module="govuk-button">
+                            <a href="{{ path('lpa.add-by-paper', {}, {'startAgain': 'true'}) }}" role="button"
+                               draggable="false" class="govuk-button moj-button-menu__item  "
+                               data-module="govuk-button">
                                 {% trans %}Request another activation key{% endtrans %}
                             </a>
-                            <a href="{{ path('lpa.dashboard') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
+                            <a href="{{ path('lpa.dashboard') }}" role="button" draggable="false"
+                               class="govuk-button moj-button-menu__item govuk-button--secondary "
+                               data-module="govuk-button">
                                 {% trans %}Back to your LPAs{% endtrans %}
                             </a>
                         </div>

--- a/service-front/app/src/Actor/templates/actor/add-lpa-triage.html.twig
+++ b/service-front/app/src/Actor/templates/actor/add-lpa-triage.html.twig
@@ -5,7 +5,8 @@
 {% block content %}
     <div class="govuk-width-container">
         <div role="navigation" aria-labelledby="back-link-navigation">
-            <a href="{{ path('lpa.dashboard') }}" class="govuk-back-link" id="back-link-navigation">{% trans %}Back{% endtrans %}</a>
+            <a href="{{ path('lpa.dashboard') }}" class="govuk-back-link"
+               id="back-link-navigation">{% trans %}Back{% endtrans %}</a>
         </div>
 
         <main class="govuk-main-wrapper" id="main-content" role="main">
@@ -53,9 +54,9 @@
 
                                 <div class="govuk-details__text">
                                     <p>
-                                    {% trans %}
-                                        Activation keys are sent to donors and attorneys by letter or email.
-                                    {% endtrans %}
+                                        {% trans %}
+                                            Activation keys are sent to donors and attorneys by letter or email.
+                                        {% endtrans %}
                                     </p>
                                 </div>
                                 <div class="govuk-details__text">
@@ -73,9 +74,9 @@
 
                                 <div class="govuk-details__text">
                                     <h3 class="govuk-heading-s">
-                                            {% trans %}
-                                                For LPAs registered before 17 July 2020
-                                            {% endtrans %}
+                                        {% trans %}
+                                            For LPAs registered before 17 July 2020
+                                        {% endtrans %}
                                     </h3>
                                 </div>
 
@@ -120,10 +121,13 @@
                     <div class="moj-button-menu">
                         <div class="moj-button-menu__wrapper">
 
-                            <button role="button" type="submit" data-prevent-double-click="true" draggable="false" class="govuk-button moj-button-menu__item" data-module="govuk-button">
+                            <button role="button" type="submit" data-prevent-double-click="true" draggable="false"
+                                    class="govuk-button moj-button-menu__item" data-module="govuk-button">
                                 {% trans %}Continue{% endtrans %}
                             </button>
-                            <a href="{{ path('lpa.dashboard') }}"  role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
+                            <a href="{{ path('lpa.dashboard') }}" role="button" draggable="false"
+                               class="govuk-button moj-button-menu__item govuk-button--secondary "
+                               data-module="govuk-button">
                                 {% trans %}Cancel{% endtrans %}
                             </a>
 

--- a/service-front/app/src/Actor/templates/actor/add-lpa-triage.html.twig
+++ b/service-front/app/src/Actor/templates/actor/add-lpa-triage.html.twig
@@ -117,15 +117,21 @@
 
                         </fieldset>
                     </div>
+                    <div class="moj-button-menu">
+                        <div class="moj-button-menu__wrapper">
 
-                    <button data-prevent-double-click="true" type="submit"
-                            class="govuk-button">{% trans %}Continue{% endtrans %}</button>
+                            <a role="button" type="submit" data-prevent-double-click="true" draggable="false" class="govuk-button moj-button-menu__item" data-module="govuk-button">
+                                {% trans %}Continue{% endtrans %}
+                            </a>
+                            <a href="{{ path('lpa.dashboard') }}"  role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
+                                {% trans %}Cancel{% endtrans %}
+                            </a>
 
-                    <a href="{{ path('lpa.dashboard') }}" draggable="false"
-                       class="govuk-button govuk-button--secondary">{% trans %}Cancel{% endtrans %}</a>
-
+                        </div>
+                    </div>
                     {{ govuk_form_close() }}
                 </div>
+
             </div>
         </main>
     </div>

--- a/service-front/app/src/Actor/templates/actor/add-lpa-triage.html.twig
+++ b/service-front/app/src/Actor/templates/actor/add-lpa-triage.html.twig
@@ -120,9 +120,9 @@
                     <div class="moj-button-menu">
                         <div class="moj-button-menu__wrapper">
 
-                            <a role="button" type="submit" data-prevent-double-click="true" draggable="false" class="govuk-button moj-button-menu__item" data-module="govuk-button">
+                            <button role="button" type="submit" data-prevent-double-click="true" draggable="false" class="govuk-button moj-button-menu__item" data-module="govuk-button">
                                 {% trans %}Continue{% endtrans %}
-                            </a>
+                            </button>
                             <a href="{{ path('lpa.dashboard') }}"  role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
                                 {% trans %}Cancel{% endtrans %}
                             </a>

--- a/service-front/app/src/Actor/templates/actor/already-requested-activation-key.html.twig
+++ b/service-front/app/src/Actor/templates/actor/already-requested-activation-key.html.twig
@@ -19,14 +19,16 @@
                     {{ govuk_form_element(form.get('__csrf')) }}
                     {{ govuk_form_element(form.get('force_activation')) }}
 
-                    <a href="{{ path('lpa.dashboard') }}" draggable="false" class="govuk-button">
-                        {% trans %}Back to your LPAs{% endtrans %}
-                    </a>
-
-                    <button data-prevent-double-click="true" type="submit" class="govuk-button govuk-button--secondary">
-                        {% trans %}Continue and ask for a new key{% endtrans %}
-                    </button>
-
+                    <div class="moj-button-menu">
+                        <div class="moj-button-menu__wrapper">
+                            <a href="{{ path('lpa.dashboard') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item  " data-module="govuk-button">
+                                {% trans %}Back to your LPAs{% endtrans %}
+                            </a>
+                            <button type="submit" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
+                                {% trans %}Continue and ask for a new key{% endtrans %}
+                            </button>
+                        </div>
+                    </div>
                     {{ govuk_form_close() }}
                 </div>
             </div>

--- a/service-front/app/src/Actor/templates/actor/cannot-find-lpa.html.twig
+++ b/service-front/app/src/Actor/templates/actor/cannot-find-lpa.html.twig
@@ -102,12 +102,16 @@
                         </details>
                     {% endif %}
 
-                    <a href="{{ path('lpa.add-by-paper', {}, {'startAgain': 'true'}) }}" draggable="false"
-                       class="govuk-button">{% trans %}Try again{% endtrans %}</a>
-                    <a class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1"
-                       href="{{ path('lpa.dashboard') }}">
-                        {% trans %}Back to your LPAs{% endtrans %}
-                    </a>
+                    <div class="moj-button-menu">
+                        <div class="moj-button-menu__wrapper">
+                            <a href="{{ path('lpa.add-by-paper', {}, {'startAgain': 'true'}) }}" role="button" draggable="false" class="govuk-button moj-button-menu__item  " data-module="govuk-button">
+                                {% trans %}Try again{% endtrans %}
+                            </a>
+                            <a href="{{ path('lpa.dashboard') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
+                                {% trans %}Back to your LPAs{% endtrans %}
+                            </a>
+                        </div>
+                    </div>
                 </div>
             </div>
         </main>

--- a/service-front/app/src/Actor/templates/actor/cannot-find-lpa.html.twig
+++ b/service-front/app/src/Actor/templates/actor/cannot-find-lpa.html.twig
@@ -104,10 +104,14 @@
 
                     <div class="moj-button-menu">
                         <div class="moj-button-menu__wrapper">
-                            <a href="{{ path('lpa.add-by-paper', {}, {'startAgain': 'true'}) }}" role="button" draggable="false" class="govuk-button moj-button-menu__item  " data-module="govuk-button">
+                            <a href="{{ path('lpa.add-by-paper', {}, {'startAgain': 'true'}) }}" role="button"
+                               draggable="false" class="govuk-button moj-button-menu__item  "
+                               data-module="govuk-button">
                                 {% trans %}Try again{% endtrans %}
                             </a>
-                            <a href="{{ path('lpa.dashboard') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
+                            <a href="{{ path('lpa.dashboard') }}" role="button" draggable="false"
+                               class="govuk-button moj-button-menu__item govuk-button--secondary "
+                               data-module="govuk-button">
                                 {% trans %}Back to your LPAs{% endtrans %}
                             </a>
                         </div>

--- a/service-front/app/src/Actor/templates/actor/check-lpa.html.twig
+++ b/service-front/app/src/Actor/templates/actor/check-lpa.html.twig
@@ -6,7 +6,7 @@
     <div class="govuk-width-container">
         <div role="navigation" aria-labelledby="back-link-navigation">
             <a href="{{ path('lpa.add-by-key') }}" class="govuk-back-link" id="back-link-navigation">
-            {% trans %}Back{% endtrans %}</a>
+                {% trans %}Back{% endtrans %}</a>
         </div>
 
         <main class="govuk-main-wrapper" id="main-content" role="main">
@@ -72,8 +72,8 @@
                     </div>
 
                     <details class="govuk-details" data-module="govuk-details" data-gaEventType="onClick"
-                         data-gaAction="Details" data-gaCategory="Wrong Details"
-                         data-gaLabel="What to do if the details are wrong">
+                             data-gaAction="Details" data-gaCategory="Wrong Details"
+                             data-gaLabel="What to do if the details are wrong">
                         <summary class="govuk-details__summary">
                             <span class="govuk-details__summary-text">
                                 {% trans %}What to do if the details are wrong{% endtrans %}
@@ -81,7 +81,7 @@
                         </summary>
                         <div class="govuk-details__text">
                             <p>
-                            {% trans %}If the information is wrong, or if a name is misspelt, please call us:{% endtrans %}
+                                {% trans %}If the information is wrong, or if a name is misspelt, please call us:{% endtrans %}
                             </p>
                             {{ include('@partials/contact-details/telephone.html.twig', {heading_level: 2 }) }}
                         </div>
@@ -94,11 +94,14 @@
                     <div class="moj-button-menu">
                         <div class="moj-button-menu__wrapper">
 
-                            <button role="button" data-prevent-double-click="true" type="submit" draggable="false" class="govuk-button moj-button-menu__item  " data-module="govuk-button">
+                            <button role="button" data-prevent-double-click="true" type="submit" draggable="false"
+                                    class="govuk-button moj-button-menu__item  " data-module="govuk-button">
                                 {% trans %}Continue{% endtrans %}</button>
                             </button>
 
-                            <a href="{{ path('lpa.dashboard') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
+                            <a href="{{ path('lpa.dashboard') }}" role="button" draggable="false"
+                               class="govuk-button moj-button-menu__item govuk-button--secondary "
+                               data-module="govuk-button">
                                 {% trans %}Cancel{% endtrans %}
                             </a>
                         </div>

--- a/service-front/app/src/Actor/templates/actor/check-lpa.html.twig
+++ b/service-front/app/src/Actor/templates/actor/check-lpa.html.twig
@@ -91,12 +91,19 @@
 
                     {{ govuk_form_element(form.get('__csrf')) }}
 
-                    <button data-prevent-double-click="true" type="submit" class="govuk-button">
-                        {% trans %}Continue{% endtrans %}</button>
+                    <div class="moj-button-menu">
+                        <div class="moj-button-menu__wrapper">
 
-                    <a href="{{ path('lpa.dashboard') }}" role="button" class="govuk-button govuk-button--secondary">
-                        {% trans %}Cancel{% endtrans %}
-                    </a>
+                            <button role="button" data-prevent-double-click="true" type="submit" draggable="false" class="govuk-button moj-button-menu__item  " data-module="govuk-button">
+                                {% trans %}Continue{% endtrans %}</button>
+                            </button>
+
+                            <a href="{{ path('lpa.dashboard') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
+                                {% trans %}Cancel{% endtrans %}
+                            </a>
+                        </div>
+                    </div>
+
 
                     {{ govuk_form_close() }}
                 </div>

--- a/service-front/app/src/Actor/templates/actor/confirm-lpa-for-key-request.html.twig
+++ b/service-front/app/src/Actor/templates/actor/confirm-lpa-for-key-request.html.twig
@@ -69,17 +69,20 @@
                             {{ govuk_form_element(form.get('__csrf')) }}
                             {{ govuk_form_element(form.get('force_activation')) }}
 
-                            <div class="moj-button-menu">
-                                <div class="moj-button-menu__wrapper">
-                                    <button type="submit" draggable="false" class="govuk-button moj-button-menu__item  " data-module="govuk-button">
-                                        {% trans %}Continue{% endtrans %}</button>
-                                    </button>
-                                    <a href="{{ path('lpa.add') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
-                                        {% trans %}This is not the correct LPA{% endtrans %}
-                                    </a>
-                                </div>
+                        <div class="moj-button-menu">
+                            <div class="moj-button-menu__wrapper">
+
+                                <button role="button" data-prevent-double-click="true" type="submit" draggable="false" class="govuk-button moj-button-menu__item  " data-module="govuk-button">
+                                    {% trans %}Continue{% endtrans %}
+                                </button>
+
+                                <a href="{{ path('lpa.add') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
+                                    {% trans %}This is not the correct LPA{% endtrans %}
+                                </a>
                             </div>
                         </div>
+                        </div>
+
                         {{ govuk_form_close() }}
                     </div>
                 </div>

--- a/service-front/app/src/Actor/templates/actor/confirm-lpa-for-key-request.html.twig
+++ b/service-front/app/src/Actor/templates/actor/confirm-lpa-for-key-request.html.twig
@@ -6,7 +6,8 @@
 
     <div class="govuk-width-container">
         <div role="navigation" aria-labelledby="back-link-navigation">
-            <a href="{{ path('lpa.check-answers') }}" class="govuk-back-link" id="back-link-navigation">{% trans %}Back{% endtrans %}</a>
+            <a href="{{ path('lpa.check-answers') }}" class="govuk-back-link"
+               id="back-link-navigation">{% trans %}Back{% endtrans %}</a>
         </div>
 
         <main class="govuk-main-wrapper" id="main-content" role="main">
@@ -69,18 +70,22 @@
                             {{ govuk_form_element(form.get('__csrf')) }}
                             {{ govuk_form_element(form.get('force_activation')) }}
 
-                        <div class="moj-button-menu">
-                            <div class="moj-button-menu__wrapper">
+                            <div class="moj-button-menu">
+                                <div class="moj-button-menu__wrapper">
 
-                                <button role="button" data-prevent-double-click="true" type="submit" draggable="false" class="govuk-button moj-button-menu__item  " data-module="govuk-button">
-                                    {% trans %}Continue{% endtrans %}
-                                </button>
+                                    <button role="button" data-prevent-double-click="true" type="submit"
+                                            draggable="false" class="govuk-button moj-button-menu__item  "
+                                            data-module="govuk-button">
+                                        {% trans %}Continue{% endtrans %}
+                                    </button>
 
-                                <a href="{{ path('lpa.add') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
-                                    {% trans %}This is not the correct LPA{% endtrans %}
-                                </a>
+                                    <a href="{{ path('lpa.add') }}" role="button" draggable="false"
+                                       class="govuk-button moj-button-menu__item govuk-button--secondary "
+                                       data-module="govuk-button">
+                                        {% trans %}This is not the correct LPA{% endtrans %}
+                                    </a>
+                                </div>
                             </div>
-                        </div>
                         </div>
 
                         {{ govuk_form_close() }}

--- a/service-front/app/src/Actor/templates/actor/confirm-remove-lpa.html.twig
+++ b/service-front/app/src/Actor/templates/actor/confirm-remove-lpa.html.twig
@@ -37,13 +37,19 @@
                         {{ govuk_form_element(form.get('__csrf')) }}
                         {{ govuk_form_element(form.get('actor_lpa_token')) }}
 
-                        <a href="{{ path('lpa.dashboard') }}" role="button" draggable="false" class="govuk-button govuk-button govuk-button--secondary govuk-!-margin-right-1">
-                            {% trans %}Cancel{% endtrans %}
-                        </a>
+                    <div class="moj-button-menu">
+                        <div class="moj-button-menu__wrapper">
 
-                        <button data-prevent-double-click="true" type="submit" class="govuk-button govuk-button--warning govuk-!-margin-right-1 ">
-                            {% trans %}Yes, remove LPA{% endtrans %}
-                        </button>
+                            <a href="{{ path('lpa.dashboard') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item  " data-module="govuk-button">
+                                {% trans %}Cancel{% endtrans %}
+                            </a>
+
+                            <button  data-prevent-double-click="true" type="submit" draggable="false" class="govuk-button govuk-button--warning moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
+                                {% trans %}Yes, remove LPA{% endtrans %}
+                            </button>
+
+                        </div>
+                    </div>
 
                     {{ govuk_form_close() }}
                 </div>

--- a/service-front/app/src/Actor/templates/actor/confirm-remove-lpa.html.twig
+++ b/service-front/app/src/Actor/templates/actor/confirm-remove-lpa.html.twig
@@ -13,13 +13,13 @@
                             {
                                 '%firstname%': lpa.getDonor.firstname,
                                 '%surname%': lpa.getDonor.surname,
-                            }
-                        %}Are you sure you want to remove %firstname% %surname%'s LPA?{% endtrans %}</h1>
+                            } %}Are you sure you want to remove %firstname% %surname%'s LPA?{% endtrans %}</h1>
 
                     <p class="govuk-body"><strong>{% trans %}LPA type:{% endtrans %}</strong> {{ lpaType }}</p>
 
                     {% if lpa is not null and lpa.status|lower == 'registered' %}
-                        <p class="govuk-body">{% trans %}This <abbr title="lasting power of attorney">LPA</abbr> is registered{% endtrans %}</p>
+                        <p class="govuk-body">{% trans %}This <abbr
+                                    title="lasting power of attorney">LPA</abbr> is registered{% endtrans %}</p>
                     {% endif %}
 
                     {% if lpa is not null and (lpa.status|lower == 'registered' or lpa.status|lower == 'cancelled') %}
@@ -34,17 +34,20 @@
                         </ul>
                     {% endif %}
                     {{ govuk_form_open(form) }}
-                        {{ govuk_form_element(form.get('__csrf')) }}
-                        {{ govuk_form_element(form.get('actor_lpa_token')) }}
+                    {{ govuk_form_element(form.get('__csrf')) }}
+                    {{ govuk_form_element(form.get('actor_lpa_token')) }}
 
                     <div class="moj-button-menu">
                         <div class="moj-button-menu__wrapper">
 
-                            <a href="{{ path('lpa.dashboard') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item  " data-module="govuk-button">
+                            <a href="{{ path('lpa.dashboard') }}" role="button" draggable="false"
+                               class="govuk-button moj-button-menu__item  " data-module="govuk-button">
                                 {% trans %}Cancel{% endtrans %}
                             </a>
 
-                            <button  data-prevent-double-click="true" type="submit" draggable="false" class="govuk-button govuk-button--warning moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
+                            <button data-prevent-double-click="true" type="submit" draggable="false"
+                                    class="govuk-button govuk-button--warning moj-button-menu__item govuk-button--secondary "
+                                    data-module="govuk-button">
                                 {% trans %}Yes, remove LPA{% endtrans %}
                             </button>
 

--- a/service-front/app/src/Actor/templates/actor/request-activation-key/before-requesting-activation-key-info.html.twig
+++ b/service-front/app/src/Actor/templates/actor/request-activation-key/before-requesting-activation-key-info.html.twig
@@ -5,7 +5,8 @@
 {% block content %}
     <div class="govuk-width-container">
         <div role="navigation" aria-labelledby="back-link-navigation">
-            <a href="{{ path('lpa.add') }}" class="govuk-back-link" id="back-link-navigation">{% trans %}Back{% endtrans %}</a>
+            <a href="{{ path('lpa.add') }}" class="govuk-back-link"
+               id="back-link-navigation">{% trans %}Back{% endtrans %}</a>
         </div>
 
         <main class="govuk-main-wrapper" id="main-content" role="main">
@@ -40,7 +41,10 @@
                     </ul>
 
 
-                    <details class="govuk-details govuk-!-margin-bottom-7" data-module="govuk-details" data-gaEventType="onClick" data-gaAction="Details" data-gaCategory="Unkown Reference Number" data-gaLabel="I do not know the LPA reference number">
+                    <details class="govuk-details govuk-!-margin-bottom-7" data-module="govuk-details"
+                             data-gaEventType="onClick" data-gaAction="Details"
+                             data-gaCategory="Unkown Reference Number"
+                             data-gaLabel="I do not know the LPA reference number">
                         <summary class="govuk-details__summary">
                             <span class="govuk-details__summary-text">
                                 {% trans %}I do not know the LPA reference number{% endtrans %}
@@ -53,10 +57,14 @@
                     </details>
                     <div class="moj-button-menu">
                         <div class="moj-button-menu__wrapper">
-                            <a href="{{ path('lpa.add-by-paper', {}, {'startAgain': 'true'}) }}" role="button" draggable="false" class="govuk-button moj-button-menu__item  " data-module="govuk-button">
+                            <a href="{{ path('lpa.add-by-paper', {}, {'startAgain': 'true'}) }}" role="button"
+                               draggable="false" class="govuk-button moj-button-menu__item  "
+                               data-module="govuk-button">
                                 {% trans %}Continue{% endtrans %}
                             </a>
-                            <a href="{{ path('lpa.dashboard') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
+                            <a href="{{ path('lpa.dashboard') }}" role="button" draggable="false"
+                               class="govuk-button moj-button-menu__item govuk-button--secondary "
+                               data-module="govuk-button">
                                 {% trans %}Cancel{% endtrans %}
                             </a>
                         </div>

--- a/service-front/app/src/Actor/templates/actor/request-activation-key/before-requesting-activation-key-info.html.twig
+++ b/service-front/app/src/Actor/templates/actor/request-activation-key/before-requesting-activation-key-info.html.twig
@@ -51,10 +51,16 @@
                             <p>{% trans %}On the LPA, the donor told us who they wanted the registered paper LPA sent to. This may have been the donor or an attorney. If a professional, such as a solicitor, helped to make the LPA, it may have been sent to them.{% endtrans %}</p>
                         </div>
                     </details>
-
-                    <a href="{{ path('lpa.add-by-paper', {}, {'startAgain': 'true'}) }}" class="govuk-button">{% trans %}Continue{% endtrans %}</a>
-                    <a href="{{ path('lpa.dashboard') }}" draggable="false" class="govuk-button govuk-button--secondary">{% trans %}Cancel{% endtrans %}</a>
-
+                    <div class="moj-button-menu">
+                        <div class="moj-button-menu__wrapper">
+                            <a href="{{ path('lpa.add-by-paper', {}, {'startAgain': 'true'}) }}" role="button" draggable="false" class="govuk-button moj-button-menu__item  " data-module="govuk-button">
+                                {% trans %}Continue{% endtrans %}
+                            </a>
+                            <a href="{{ path('lpa.dashboard') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
+                                {% trans %}Cancel{% endtrans %}
+                            </a>
+                        </div>
+                    </div>
                 </div>
             </div>
         </main>

--- a/service-front/app/src/Actor/templates/actor/send-activation-key-confirmation.html.twig
+++ b/service-front/app/src/Actor/templates/actor/send-activation-key-confirmation.html.twig
@@ -26,11 +26,18 @@
                     <h2 class="govuk-heading-m">{% trans %}Have more than one LPA?{% endtrans %}</h2>
                     <p class="govuk-body">{% trans %}You'll need an activation key for each LPA that you'd like to add to your account.{% endtrans %}</p>
 
-                    <a href="{{ path('lpa.add-by-paper', {}, {'startAgain': 'true'}) }}" draggable="false" class="govuk-button">{% trans %}Request another activation key{% endtrans %}</a>
-                    <a class="govuk-button govuk-button--secondary govuk-!-margin-bottom-1" href="{{ path('lpa.dashboard') }}">
-                        {% trans %}Back to your LPAs{% endtrans %}
-                    </a>
+                <div class="moj-button-menu">
+                    <div class="moj-button-menu__wrapper">
+                        <a href="{{ path('lpa.add-by-paper', {}, {'startAgain': 'true'}) }}" role="button" draggable="false" class="govuk-button moj-button-menu__item  " data-module="govuk-button">
+                            {% trans %}Request another activation key{% endtrans %}
+                        </a>
+                        <a href="{{ path('lpa.dashboard') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
+                            {% trans %}Back to your LPAs{% endtrans %}
+                        </a>
+                    </div>
                 </div>
+            </div>
+
             </div>
         </main>
     </div>

--- a/service-front/app/src/Actor/templates/actor/send-activation-key-confirmation.html.twig
+++ b/service-front/app/src/Actor/templates/actor/send-activation-key-confirmation.html.twig
@@ -18,7 +18,8 @@
                     <p class="govuk-body">{% trans %}We'll send you a letter with your activation key for this LPA. We'll post it to the address we have for you. We send it by post because it's more secure.{% endtrans %}</p>
                     <p class="govuk-body">{% trans %}Once you've got the activation key, you'll be able to use it to add the LPA to your account.{% endtrans %}</p>
                     <p class="govuk-body">{% trans %}We've sent you an email to confirm all these details.{% endtrans %}</p>
-                    <p class="govuk-body"><strong>{% trans with {'%date%': lpa_date(date)} %}You should get the letter by %date%{% endtrans %}</p>
+                    <p class="govuk-body"><strong>{% trans with {'%date%': lpa_date(date)} %}You should get the letter
+                            by %date%{% endtrans %}</p>
                     <p class="govuk-body">{% trans %}If you do not get it by this date, please contact us. You'll need to give us the LPA reference number when you call.{% endtrans %}</p>
 
                     {{ include('@partials/contact-details/telephone.html.twig', {heading_level: 2 }) }}
@@ -26,17 +27,21 @@
                     <h2 class="govuk-heading-m">{% trans %}Have more than one LPA?{% endtrans %}</h2>
                     <p class="govuk-body">{% trans %}You'll need an activation key for each LPA that you'd like to add to your account.{% endtrans %}</p>
 
-                <div class="moj-button-menu">
-                    <div class="moj-button-menu__wrapper">
-                        <a href="{{ path('lpa.add-by-paper', {}, {'startAgain': 'true'}) }}" role="button" draggable="false" class="govuk-button moj-button-menu__item  " data-module="govuk-button">
-                            {% trans %}Request another activation key{% endtrans %}
-                        </a>
-                        <a href="{{ path('lpa.dashboard') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
-                            {% trans %}Back to your LPAs{% endtrans %}
-                        </a>
+                    <div class="moj-button-menu">
+                        <div class="moj-button-menu__wrapper">
+                            <a href="{{ path('lpa.add-by-paper', {}, {'startAgain': 'true'}) }}" role="button"
+                               draggable="false" class="govuk-button moj-button-menu__item  "
+                               data-module="govuk-button">
+                                {% trans %}Request another activation key{% endtrans %}
+                            </a>
+                            <a href="{{ path('lpa.dashboard') }}" role="button" draggable="false"
+                               class="govuk-button moj-button-menu__item govuk-button--secondary "
+                               data-module="govuk-button">
+                                {% trans %}Back to your LPAs{% endtrans %}
+                            </a>
+                        </div>
                     </div>
                 </div>
-            </div>
 
             </div>
         </main>


### PR DESCRIPTION
# Purpose
Fix spacing between buttons on all pages where there are 2 buttons next to each other ” Spacing is too narrow.
A clone of one ticket that only addressed one button. 
see attachment for where the problem has occurred elsewhere. 

acceptance criteria - please list all pages that have 2 buttons and then check they all have the appropriate space. 

[Team UaL Miro board](https://miro.com/app/board/uXjVOjVLfTY=/?moveToWidget=3458764570121456246&cot=14)  this is the page where @Sarah Mills has put all the pages. search for service flow if link doesn’t go to the right place.

Fixes UML-3223

## Approach

## Learning

## Checklist

* [x] I have performed a self-review of my own code
~* [ ] I have added relevant logging with appropriate levels to my code~
~* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
~* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
~* [ ] I have added tests to prove my work~
~* [ ] I have added welsh translation tags and updated translation files~
~* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
~* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* [ ] The product team have tested these changes
