### PR TITLE
UML-3078 One Login login redirects to dashboard

### DIFF
--- a/service-front/app/src/Actor/src/Handler/OneLoginCallbackHandler.php
+++ b/service-front/app/src/Actor/src/Handler/OneLoginCallbackHandler.php
@@ -12,6 +12,7 @@ use Common\Handler\Traits\Session;
 use Common\Service\OneLogin\OneLoginService;
 use Facile\OpenIDClient\Session\AuthSession;
 use Laminas\Diactoros\Response\HtmlResponse;
+use Mezzio\Authentication\UserInterface;
 use Mezzio\Helper\UrlHelper;
 use Mezzio\Session\SessionMiddleware;
 use Mezzio\Template\TemplateRendererInterface;
@@ -68,17 +69,22 @@ class OneLoginCallbackHandler extends AbstractHandler implements LoggerAware, Se
             throw new RuntimeException('Required parameters not passed for authentication', 500);
         }
 
-        return new HtmlResponse('<h1>Hello World</h1>');
+        $user = $this->oneLoginService->callback($authParams['code'], $authParams['state'], $authSession);
 
-        //TODO: UML-3078
-//        $user = $this->oneLoginService->callback($authParams['code'], $authParams['state'], $authSession);
-//        //Add user to session
-//        if (! is_null($user)) {
-//            if (empty($user->getDetail('LastLogin'))) {
-//                return $this->redirectToRoute('lpa.add');
-//            } else {
-//                return $this->redirectToRoute('lpa.dashboard');
-//            }
-//        }
+        if (! is_null($user)) {
+            $session->set(UserInterface::class, [
+                'username' => $user->getIdentity(),
+                'roles'    => $user->getRoles(),
+                'details'  => $user->getDetails(),
+            ]);
+            $session->regenerate();
+            if (empty($user->getDetail('LastLogin'))) {
+                return $this->redirectToRoute('lpa.add', [], [], $ui_locale === 'cy' ? $ui_locale : null);
+            } else {
+                return $this->redirectToRoute('lpa.dashboard', [], [], $ui_locale === 'cy' ? $ui_locale : null);
+            }
+        }
+
+        return new HtmlResponse('<h1>User not found</h1>');
     }
 }

--- a/service-front/app/src/Common/src/ConfigProvider.php
+++ b/service-front/app/src/Common/src/ConfigProvider.php
@@ -113,6 +113,7 @@ class ConfigProvider
 
                 // Auth
                 UserInterface::class => Entity\UserFactory::class,
+                Service\OneLogin\OneLoginService::class => Service\OneLogin\OneLoginServiceFactory::class,
 
                 // Handlers
                 Handler\CookiesPageHandler::class => Handler\Factory\CookiesPageHandlerFactory::class,

--- a/service-front/app/src/Common/src/Entity/User.php
+++ b/service-front/app/src/Common/src/Entity/User.php
@@ -19,6 +19,7 @@ class User implements UserInterface
 
     protected bool $needsReset;
     protected ?DateTime $lastLogin;
+    protected ?string $subject;
 
     public function __construct(protected string $identity, array $roles, array $details)
     {
@@ -30,6 +31,7 @@ class User implements UserInterface
 
         $this->email      = $details['Email'];
         $this->needsReset = !empty($details['NeedsReset']);
+        $this->subject    = $details['Subject'] ?? null;
 
         if (!empty($details['LastLogin'])) {
             $this->setLastLogin($details['LastLogin']);
@@ -78,11 +80,15 @@ class User implements UserInterface
      */
     public function getDetails(): array
     {
-        return [
+        $array = [
             'Email'      => $this->email,
             'LastLogin'  => $this->lastLogin,
             'NeedsReset' => $this->needsReset,
         ];
+        if ($this->subject !== null) {
+            $array['Subject'] = $this->subject;
+        }
+        return $array;
     }
 
     /**

--- a/service-front/app/src/Common/src/Service/OneLogin/OneLoginService.php
+++ b/service-front/app/src/Common/src/Service/OneLogin/OneLoginService.php
@@ -6,13 +6,30 @@ namespace Common\Service\OneLogin;
 
 use Common\Service\ApiClient\Client as ApiClient;
 use Facile\OpenIDClient\Session\AuthSession;
+use Mezzio\Authentication\UserInterface;
+use Psr\Log\LoggerInterface;
 
 class OneLoginService
 {
     public const OIDC_AUTH_INTERFACE = 'oidcauthinterface';
 
-    public function __construct(private ApiClient $apiClient)
-    {
+    /**
+     * @var callable
+     */
+    private $userModelFactory;
+
+    public function __construct(
+        private ApiClient $apiClient,
+        callable $userModelFactory,
+        private LoggerInterface $logger,
+    ) {
+        $this->userModelFactory = function (
+            string $identity,
+            array $roles = [],
+            array $details = [],
+        ) use ($userModelFactory): UserInterface {
+            return $userModelFactory($identity, $roles, $details);
+        };
     }
 
     public function authenticate(string $uiLocale, string $redirectUrl): ?array
@@ -23,12 +40,39 @@ class OneLoginService
         ]);
     }
 
-    public function callback(string $code, string $state, AuthSession $authCredentials): ?array
+    public function callback(string $code, string $state, AuthSession $authCredentials): ?UserInterface
     {
-        return $this->apiClient->httpPost('/v1/auth/callback', [
+        $userData = $this->apiClient->httpPost('/v1/auth/callback', [
             'code'         => $code,
             'state'        => $state,
             'auth_session' => $authCredentials,
         ]);
+
+        $this->logger->info(
+            'Authentication successful for account with Id {id}',
+            [
+                'id'         => $userData['Id'],
+                'last-login' => $userData['LastLogin'] ?? 'never',
+            ]
+        );
+
+        $filteredDetails = [
+            'Email'   => $userData['Email'],
+            'Subject' => $userData['Identity'],
+        ];
+
+        if (array_key_exists('LastLogin', $userData)) {
+            $filteredDetails['LastLogin'] = $userData['LastLogin'];
+        }
+
+        if (!empty($userData['NeedsReset'])) {
+            $filteredDetails['NeedsReset'] = $userData['NeedsReset'];
+        }
+
+        return ($this->userModelFactory)(
+            $userData['Id'],
+            [],
+            $filteredDetails
+        );
     }
 }

--- a/service-front/app/src/Common/src/Service/OneLogin/OneLoginServiceFactory.php
+++ b/service-front/app/src/Common/src/Service/OneLogin/OneLoginServiceFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Service\OneLogin;
+
+use Common\Service\ApiClient\Client;
+use Mezzio\Authentication\UserInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+class OneLoginServiceFactory
+{
+    public function __invoke(ContainerInterface $container): OneLoginService
+    {
+        return new OneLoginService(
+            $container->get(Client::class),
+            $container->get(UserInterface::class),
+            $container->get(LoggerInterface::class)
+        );
+    }
+}

--- a/service-front/app/src/Common/src/Service/Session/EncryptedCookiePersistence.php
+++ b/service-front/app/src/Common/src/Service/Session/EncryptedCookiePersistence.php
@@ -21,6 +21,7 @@ use Dflydev\FigCookies\FigRequestCookies;
 use Dflydev\FigCookies\FigResponseCookies;
 use Dflydev\FigCookies\Modifier\SameSite;
 use Dflydev\FigCookies\SetCookie;
+use Fig\Http\Message\StatusCodeInterface;
 use Mezzio\Authentication\UserInterface;
 use Mezzio\Session\Session;
 use Mezzio\Session\SessionCookiePersistenceInterface;
@@ -99,7 +100,11 @@ class EncryptedCookiePersistence implements SessionPersistenceInterface
         // Encode to string
         $sessionData = $this->encrypter->encodeCookieValue($session->toArray());
 
-        $sameSite = $session->has(UserInterface::class) ? SameSite::strict() : SameSite::lax();
+        $sameSite =
+            $session->has(UserInterface::class)
+            && $response->getStatusCode() !== StatusCodeInterface::STATUS_FOUND
+                ? SameSite::strict()
+                : SameSite::lax();
 
         $sessionCookie = SetCookie::create($this->cookieName)
             ->withValue($sessionData)


### PR DESCRIPTION
# Purpose

Logging in via One Login now redirects user to the dashboard.

Fixes UML-3078

## Approach

Largely replicating code implemented elsewhere (UserService, PhpSession and LoginPageHandler).

## Learning

Chrome does not keep cookies when redirecting and SameSite=Strict ([link](https://stackoverflow.com/questions/42216700/how-can-i-redirect-after-oauth2-with-samesite-strict-and-still-get-my-cookies/64216367#64216367))

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
