### PR TITLE
UML-3155 Fixes for multi-region account Terraform

### DIFF
--- a/terraform/account/kms.tf
+++ b/terraform/account/kms.tf
@@ -94,6 +94,7 @@ data "aws_iam_policy_document" "cloudwatch_kms" {
       type = "Service"
       identifiers = [
         "logs.${data.aws_region.current.name}.amazonaws.com",
+        "logs.eu-west-2.amazonaws.com",
         "events.amazonaws.com"
       ]
     }

--- a/terraform/account/region/cloudwatch_alarms.tf
+++ b/terraform/account/region/cloudwatch_alarms.tf
@@ -18,6 +18,8 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_high_cpu_utilization" {
   dimensions = {
     CacheClusterId = each.value
   }
+
+  provider = aws.region
 }
 
 resource "aws_cloudwatch_metric_alarm" "elasticache_high_swap_utilization" {
@@ -40,4 +42,6 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_high_swap_utilization" {
   dimensions = {
     CacheClusterId = each.value
   }
+
+  provider = aws.region
 }

--- a/terraform/account/region/lambda_functions.tf
+++ b/terraform/account/region/lambda_functions.tf
@@ -11,7 +11,7 @@ data "aws_ecr_repository" "ship_to_opg_metrics" {
 module "clsf_to_sqs" {
   source            = "./modules/lambda_function"
   count             = var.account.opg_metrics.enabled ? 1 : 0
-  lambda_name       = "clsf-to-sqs"
+  lambda_name       = "clsf-to-sqs-${data.aws_region.current.name}"
   description       = "Function to take Cloudwatch Logs Subscription Filters and send them to SQS"
   working_directory = "/var/task"
   environment_variables = {
@@ -62,7 +62,7 @@ data "aws_kms_alias" "opg_metrics_api_key_encryption" {
 module "ship_to_opg_metrics" {
   source            = "./modules/lambda_function"
   count             = var.account.opg_metrics.enabled ? 1 : 0
-  lambda_name       = "ship-to-opg-metrics"
+  lambda_name       = "ship-to-opg-metrics-${data.aws_region.current.name}"
   description       = "Function to take metrics from SQS and PUT them to OPG Metrics"
   working_directory = "/var/task"
   environment_variables = {

--- a/terraform/account/region/modules/s3_bucket/main.tf
+++ b/terraform/account/region/modules/s3_bucket/main.tf
@@ -74,7 +74,7 @@ resource "aws_s3_bucket_logging" "bucket" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "main" {
-  bucket = aws_s3_bucket.bucket.id 
+  bucket = aws_s3_bucket.bucket.id
 
   rule {
     object_ownership = var.object_ownership

--- a/terraform/account/region/modules/s3_bucket/main.tf
+++ b/terraform/account/region/modules/s3_bucket/main.tf
@@ -6,6 +6,8 @@ resource "aws_s3_bucket" "bucket" {
 resource "aws_s3_bucket_acl" "bucket_acl" {
   bucket = aws_s3_bucket.bucket.id
   acl    = var.acl
+
+  depends_on = [aws_s3_bucket_ownership_controls.main]
 }
 
 resource "aws_s3_bucket_versioning" "bucket_versioning" {
@@ -71,6 +73,14 @@ resource "aws_s3_bucket_logging" "bucket" {
   target_prefix = "log/${aws_s3_bucket.bucket.id}/"
 }
 
+resource "aws_s3_bucket_ownership_controls" "main" {
+  bucket = aws_s3_bucket.bucket.id 
+
+  rule {
+    object_ownership = var.object_ownership
+  }
+}
+
 data "aws_iam_policy_document" "bucket" {
   policy_id = "PutObjPolicy"
 
@@ -113,3 +123,4 @@ data "aws_iam_policy_document" "bucket" {
     }
   }
 }
+

--- a/terraform/account/region/modules/s3_bucket/variables.tf
+++ b/terraform/account/region/modules/s3_bucket/variables.tf
@@ -56,6 +56,16 @@ variable "versioning_enabled" {
   default     = false
 }
 
+variable "object_ownership" {
+  description = "The object ownership setting. Valid values are BucketOwnerPreferred and ObjectWriter."
+  default     = "ObjectWriter"
+
+  validation {
+    condition     = can(regex("BucketOwnerPreferred|ObjectWriter", var.object_ownership))
+    error_message = "object_ownership must be either BucketOwnerPreferred or ObjectWriter"
+  }
+}
+
 locals {
   environment = split("_", terraform.workspace)[0]
 }

--- a/terraform/account/region/s3_lb_access_logs.tf
+++ b/terraform/account/region/s3_lb_access_logs.tf
@@ -139,7 +139,7 @@ data "aws_iam_policy_document" "access_log" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "access_log" {
-  bucket = aws_s3_bucket.access_log.id 
+  bucket = aws_s3_bucket.access_log.id
 
   rule {
     object_ownership = "ObjectWriter"

--- a/terraform/account/region/vpc_flowlogs.tf
+++ b/terraform/account/region/vpc_flowlogs.tf
@@ -8,6 +8,17 @@ resource "aws_flow_log" "vpc_flow_logs" {
 }
 
 resource "aws_cloudwatch_log_group" "vpc_flow_logs" {
+  name              = "vpc_flow_logs-${data.aws_region.current.name}"
+  retention_in_days = 400
+  kms_key_id        = data.aws_kms_alias.cloudwatch_mrk.arn
+
+  provider = aws.region
+}
+
+# Kept around to avoid losing logs after switching to region-specific flow logs group.
+# This can be deleted 400 days after the creation of aws_cloudwatch_log_group.vpc_flow_logs.
+resource "aws_cloudwatch_log_group" "old_vpc_flow_logs" {
+  count             = data.aws_region.current.name == "eu-west-1" ? 1 : 0
   name              = "vpc_flow_logs"
   retention_in_days = 400
   kms_key_id        = data.aws_kms_alias.cloudwatch_mrk.arn

--- a/terraform/environment/region/data_sources.tf
+++ b/terraform/environment/region/data_sources.tf
@@ -153,7 +153,7 @@ data "aws_iam_role" "ecs_autoscaling_service_role" {
 }
 
 data "aws_s3_bucket" "access_log" {
-  bucket = "opg-ual-${var.account_name}-lb-access-logs"
+  bucket = "opg-ual-${var.account_name}-lb-access-logs-${data.aws_region.current.name}"
 
   provider = aws.region
 }

--- a/terraform/environment/region/ship_to_metrics.tf
+++ b/terraform/environment/region/ship_to_metrics.tf
@@ -5,12 +5,12 @@ data "aws_sqs_queue" "ship_to_opg_metrics" {
 
 data "aws_lambda_function" "clsf_to_sqs" {
   count         = var.ship_metrics_queue_enabled ? 1 : 0
-  function_name = "clsf-to-sqs"
+  function_name = "clsf-to-sqs-${data.aws_region.current.name}"
 }
 
 data "aws_lambda_function" "ship_to_opg_metrics" {
   count         = var.ship_metrics_queue_enabled ? 1 : 0
-  function_name = "ship-to-opg-metrics"
+  function_name = "ship-to-opg-metrics-${data.aws_region.current.name}"
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "events" {


### PR DESCRIPTION
# Purpose

Various fixes to ensure resource names are unique and can be created in both eu-west-1 and eu-west-2.

Fixes UML-3155

## Approach

Because we are reusing resource names, the moved {} block cannot be used so the state needs to be manually updated with rm and import commands

tf state rm module.eu_west_1.aws_s3_bucket.access_log
tf import "module.eu_west_1.aws_s3_bucket.old_access_log[0]" opg-ual-[ACCOUNT NAME]-lb-access-logs

tf state rm module.eu_west_1.aws_cloudwatch_log_group.vpc_flow_logs
tf import "module.eu_west_1.aws_cloudwatch_log_group.old_vpc_flow_logs[0]" vpc_flow_logs

tf state rm "module.eu_west_1.module.clsf_to_sqs[0].aws_cloudwatch_log_group.lambda_function"
tf state rm "module.eu_west_1.module.ship-to-opg-metrics[0].aws_cloudwatch_log_group.lambda_function"


## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
