### PR TITLE
UML-3155 Add explicit provider for S3 resource

### DIFF
--- a/terraform/account/region/s3_lb_access_logs.tf
+++ b/terraform/account/region/s3_lb_access_logs.tf
@@ -150,6 +150,8 @@ resource "aws_s3_bucket_ownership_controls" "access_log" {
   rule {
     object_ownership = "ObjectWriter"
   }
+
+  provider = aws.region
 }
 
 resource "aws_s3_bucket_public_access_block" "access_log" {


### PR DESCRIPTION
# Purpose

Add an explicit provider for aws_s3_bucket_ownership_controls.access_log

Fixes UML-3155

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
