### PR TITLE
fix aws keys for admin portal local running

### DIFF
--- a/service-admin/.idea/runConfigurations/Admin_Service.xml
+++ b/service-admin/.idea/runConfigurations/Admin_Service.xml
@@ -4,11 +4,13 @@
     <working_directory value="$PROJECT_DIR$" />
     <envs>
       <env name="ADMIN_JWT_SIGNING_KEY_URL" value="http://localhost:5000" />
-      <env name="AWS_ACCESS_KEY_ID" value="-" />
+      <env name="AWS_ACCESS_KEY_ID" value="devkey" />
       <env name="AWS_DYNAMODB_ENDPOINT" value="http://localhost:8000" />
-      <env name="AWS_SECRET_ACCESS_KEY" value="-" />
+      <env name="AWS_SECRET_ACCESS_KEY" value="secretdevkey" />
+      <env name="AWS_ENDPOINT_URL" value="http://localhost:4566" />
     </envs>
     <kind value="FILE" />
+    <package value="github.com/ministryofjustice/opg-use-an-lpa/service-admin" />
     <directory value="$PROJECT_DIR$" />
     <filePath value="$PROJECT_DIR$/cmd/admin/main.go" />
     <method v="2" />


### PR DESCRIPTION
# Purpose

_fix aws keys for admin portal running locally ( hyphen is no longer allowed as a key)_

## Approach

_Updated in Goland_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
