### PR TITLE
UML-3108 Add option to enable eu-west-2

### DIFF
--- a/terraform/account/locals.tf
+++ b/terraform/account/locals.tf
@@ -37,6 +37,11 @@ variable "accounts" {
         bucket_name_suffix = string
       })
       s3_access_log_bucket_name = string
+      regions = map(
+        object({
+          enabled = bool
+        })
+      )
     })
   )
 }

--- a/terraform/account/region.tf
+++ b/terraform/account/region.tf
@@ -1,6 +1,8 @@
 module "eu_west_1" {
   source = "./region"
 
+  count = local.account.regions.eu_west_1.enabled ? 1 : 0
+
   account                  = local.account
   account_name             = local.account_name
   environment_name         = local.environment
@@ -18,9 +20,15 @@ module "eu_west_1" {
   }
 }
 
+moved {
+  from = module.eu_west_1
+  to   = module.eu_west_1[0]
+}
+
 module "eu_west_2" {
-  count  = local.environment == "development" ? 1 : 0
   source = "./region"
+
+  count = local.account.regions.eu_west_2.enabled ? 1 : 0
 
   account                  = local.account
   account_name             = local.account_name

--- a/terraform/account/region/workspace_cleanup.tf
+++ b/terraform/account/region/workspace_cleanup.tf
@@ -11,9 +11,6 @@ resource "aws_dynamodb_table" "workspace_cleanup_table" {
     attribute_name = "ExpiresTTL"
     enabled        = true
   }
-  lifecycle {
-    prevent_destroy = true
-  }
 
   provider = aws.region
 }

--- a/terraform/account/terraform.tfvars.json
+++ b/terraform/account/terraform.tfvars.json
@@ -32,7 +32,15 @@
         "trail_name_suffix": "development-ual",
         "bucket_name_suffix": "dev.ual.opg.service.justice.gov.uk"
       },
-      "s3_access_log_bucket_name": "s3-access-logs-opg-opg-use-an-lpa-development"
+      "s3_access_log_bucket_name": "s3-access-logs-opg-opg-use-an-lpa-development",
+      "regions": {
+        "eu_west_1": {
+          "enabled": true
+        },
+        "eu_west_2": {
+          "enabled": false
+        }
+      }
     },
     "preproduction": {
       "account_id": "888228022356",
@@ -61,7 +69,15 @@
         "trail_name_suffix": "preproduction-ual",
         "bucket_name_suffix": "preprod.ual.opg.service.justice.gov.uk"
       },
-      "s3_access_log_bucket_name": "s3-access-logs-opg-opg-use-an-lpa-preprod"
+      "s3_access_log_bucket_name": "s3-access-logs-opg-opg-use-an-lpa-preprod",
+      "regions": {
+        "eu_west_1": {
+          "enabled": true
+        },
+        "eu_west_2": {
+          "enabled": false
+        }
+      }
     },
     "production": {
       "account_id": "690083044361",
@@ -90,7 +106,15 @@
         "trail_name_suffix": "production-ual",
         "bucket_name_suffix": "prod.ual.opg.service.justice.gov.uk"
       },
-      "s3_access_log_bucket_name": "s3-access-logs-opg-opg-use-an-lpa-production"
+      "s3_access_log_bucket_name": "s3-access-logs-opg-opg-use-an-lpa-production",
+      "regions": {
+        "eu_west_1": {
+          "enabled": true
+        },
+        "eu_west_2": {
+          "enabled": false
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
# Purpose

Add an option to enable eu-west-2 in the account terraform. 

Fixes UML-3108

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
