### PR TITLE
UML-3208 script to preventing email addresses turning into links

### DIFF
--- a/scripts/modify_emails.py
+++ b/scripts/modify_emails.py
@@ -1,0 +1,21 @@
+# Take a list of emails addresses from a CSV and produce a CSV with the email address in column 1 and with a modified version of the email address in column 2 with a zero-width space (ZWS) character inserted before each . character.
+
+# Open the file with the email addresses and skip the header row
+with open('email_addresses.csv', 'r') as f:
+    next(f)
+    email_addresses = f.read()
+
+# Split the email addresses into a list
+email_addresses = email_addresses.split('\n')
+
+# Convert the email addresses into a dictionary with the email address as the key and the modified email address as the value
+email_addresses_dict = {}
+
+for email_address in email_addresses:
+    email_addresses_dict[email_address] = email_address.replace('.', '&#8203;.')
+
+# Write the headers first then write dictionary to a CSV file
+with open('email_addresses_with_zws.csv', 'w') as f:
+    f.write('email address,ModifiedEmail\n')
+    for key in email_addresses_dict.keys():
+        f.write("%s,%s\n"%(key,email_addresses_dict[key]))


### PR DESCRIPTION
# Purpose

Python script to preventing email addresses turning into links when sending them on Notify. 
Achieves this by adding a zero-width space `&#8203;` before each character.
Takes a csv file with a list of email addresses and outputs a file with the original email list and the modified emails. 

Fixes UML-3208

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
