### PR TITLE
UML-2353 Change Application layer to block

### DIFF
--- a/terraform/environment/region/actor_load_balancer.tf
+++ b/terraform/environment/region/actor_load_balancer.tf
@@ -1,7 +1,7 @@
 resource "aws_shield_application_layer_automatic_response" "actor" {
   count        = var.associate_alb_with_waf_web_acl_enabled ? 1 : 0
   resource_arn = aws_lb.actor.arn
-  action       = "COUNT"
+  action       = "BLOCK"
 
   provider = aws.region
 }

--- a/terraform/environment/region/viewer_load_balancer.tf
+++ b/terraform/environment/region/viewer_load_balancer.tf
@@ -1,7 +1,7 @@
 resource "aws_shield_application_layer_automatic_response" "viewer" {
   count        = var.associate_alb_with_waf_web_acl_enabled ? 1 : 0
   resource_arn = aws_lb.viewer.arn
-  action       = "COUNT"
+  action       = "BLOCK"
 }
 
 resource "aws_lb_target_group" "viewer" {


### PR DESCRIPTION
# Purpose

Change the `aws_shield_application_layer_automatic_response` resources from COUNT to BLOCK now that we've established that no legitimate traffic will be affected by it.

Fixes UML-2353

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
