### PR TITLE
UML-3269 Enable prod eu-west-2 for account level resources

### DIFF
--- a/terraform/account/region/cloudwatch_alarms.tf
+++ b/terraform/account/region/cloudwatch_alarms.tf
@@ -1,6 +1,6 @@
 locals {
   # HACK: Without this, we would need to do a targetted apply on the replication group before the alarms can be created
-  brute_force_cache_replication_group_members = [ for i in range(0, aws_elasticache_replication_group.brute_force_cache_replication_group.num_cache_clusters) : "${aws_elasticache_replication_group.brute_force_cache_replication_group.replication_group_id}-00${i+1}" ]
+  brute_force_cache_replication_group_members = [for i in range(0, aws_elasticache_replication_group.brute_force_cache_replication_group.num_cache_clusters) : "${aws_elasticache_replication_group.brute_force_cache_replication_group.replication_group_id}-00${i + 1}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "elasticache_high_cpu_utilization" {

--- a/terraform/account/region/cloudwatch_alarms.tf
+++ b/terraform/account/region/cloudwatch_alarms.tf
@@ -1,5 +1,10 @@
+locals {
+  # HACK: Without this, we would need to do a targetted apply on the replication group before the alarms can be created
+  brute_force_cache_replication_group_members = [ for i in range(0, aws_elasticache_replication_group.brute_force_cache_replication_group.num_cache_clusters) : "${aws_elasticache_replication_group.brute_force_cache_replication_group.replication_group_id}-00${i+1}" ]
+}
+
 resource "aws_cloudwatch_metric_alarm" "elasticache_high_cpu_utilization" {
-  for_each                  = toset(aws_elasticache_replication_group.brute_force_cache_replication_group.member_clusters)
+  for_each                  = toset(local.brute_force_cache_replication_group_members)
   actions_enabled           = true
   alarm_actions             = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
   alarm_description         = "High CPU usage on ${lower(each.value)}"
@@ -23,7 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_high_cpu_utilization" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "elasticache_high_swap_utilization" {
-  for_each                  = toset(aws_elasticache_replication_group.brute_force_cache_replication_group.member_clusters)
+  for_each                  = toset(local.brute_force_cache_replication_group_members)
   actions_enabled           = true
   alarm_actions             = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
   alarm_description         = "High swap mem usage on ${lower(each.value)}"

--- a/terraform/account/terraform.tfvars.json
+++ b/terraform/account/terraform.tfvars.json
@@ -112,7 +112,7 @@
           "enabled": true
         },
         "eu_west_2": {
-          "enabled": false
+          "enabled": true
         }
       }
     }


### PR DESCRIPTION
# Purpose

Enable account level resources in eu-west-2 for production. This will allow (scaled to zero) resources to be created in eu-west-2 in a different PR.

Fixes UML-3269

## Approach

Switch flag from false to true.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
