### PR TITLE
LPAL-3281 Update TF DNS module with SPF/DMARC records

### DIFF
--- a/terraform/environment/region/dns.tf
+++ b/terraform/environment/region/dns.tf
@@ -23,13 +23,14 @@ resource "aws_service_discovery_private_dns_namespace" "internal_ecs" {
 module "public_facing_view_lasting_power_of_attorney" {
   source = "./modules/dns"
 
-  dns_namespace_env = var.dns_namespace_env
-  is_active_region  = local.is_active_region
-  current_region    = data.aws_region.current.name
-  zone_id           = data.aws_route53_zone.live_service_view_lasting_power_of_attorney.zone_id
-  loadbalancer      = aws_lb.viewer
-  dns_name          = data.aws_route53_zone.live_service_view_lasting_power_of_attorney.name
-  environment_name  = var.environment_name
+  dns_namespace_env          = var.dns_namespace_env
+  is_active_region           = local.is_active_region
+  current_region             = data.aws_region.current.name
+  zone_id                    = data.aws_route53_zone.live_service_view_lasting_power_of_attorney.zone_id
+  loadbalancer               = aws_lb.viewer
+  dns_name                   = data.aws_route53_zone.live_service_view_lasting_power_of_attorney.name
+  environment_name           = var.environment_name
+  create_block_email_records = true
 
   providers = {
     aws.us-east-1  = aws.us-east-1
@@ -40,16 +41,17 @@ module "public_facing_view_lasting_power_of_attorney" {
 module "viewer_use_my_lpa" {
   source = "./modules/dns"
 
-  dns_namespace_env   = var.dns_namespace_env
-  is_active_region    = local.is_active_region
-  current_region      = data.aws_region.current.name
-  zone_id             = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
-  loadbalancer        = aws_lb.viewer
-  dns_name            = "view.lastingpowerofattorney"
-  service_name        = "viewer"
-  create_alarm        = true
-  create_health_check = true
-  environment_name    = var.environment_name
+  dns_namespace_env          = var.dns_namespace_env
+  is_active_region           = local.is_active_region
+  current_region             = data.aws_region.current.name
+  zone_id                    = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
+  loadbalancer               = aws_lb.viewer
+  dns_name                   = "view.lastingpowerofattorney"
+  service_name               = "viewer"
+  create_alarm               = true
+  create_health_check        = true
+  environment_name           = var.environment_name
+  create_block_email_records = true
 
   providers = {
     aws.us-east-1  = aws.us-east-1
@@ -60,13 +62,14 @@ module "viewer_use_my_lpa" {
 module "public_facing_use_lasting_power_of_attorney" {
   source = "./modules/dns"
 
-  dns_namespace_env = var.dns_namespace_env
-  is_active_region  = local.is_active_region
-  current_region    = data.aws_region.current.name
-  zone_id           = data.aws_route53_zone.live_service_use_lasting_power_of_attorney.zone_id
-  dns_name          = data.aws_route53_zone.live_service_use_lasting_power_of_attorney.name
-  loadbalancer      = aws_lb.actor
-  environment_name  = var.environment_name
+  dns_namespace_env          = var.dns_namespace_env
+  is_active_region           = local.is_active_region
+  current_region             = data.aws_region.current.name
+  zone_id                    = data.aws_route53_zone.live_service_use_lasting_power_of_attorney.zone_id
+  dns_name                   = data.aws_route53_zone.live_service_use_lasting_power_of_attorney.name
+  loadbalancer               = aws_lb.actor
+  environment_name           = var.environment_name
+  create_block_email_records = true
 
   providers = {
     aws.us-east-1  = aws.us-east-1
@@ -77,16 +80,17 @@ module "public_facing_use_lasting_power_of_attorney" {
 module "actor_use_my_lpa" {
   source = "./modules/dns"
 
-  dns_namespace_env   = var.dns_namespace_env
-  is_active_region    = local.is_active_region
-  current_region      = data.aws_region.current.name
-  zone_id             = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
-  loadbalancer        = aws_lb.actor
-  dns_name            = "use.lastingpowerofattorney"
-  service_name        = "actor"
-  create_alarm        = true
-  create_health_check = true
-  environment_name    = var.environment_name
+  dns_namespace_env          = var.dns_namespace_env
+  is_active_region           = local.is_active_region
+  current_region             = data.aws_region.current.name
+  zone_id                    = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
+  loadbalancer               = aws_lb.actor
+  dns_name                   = "use.lastingpowerofattorney"
+  service_name               = "actor"
+  create_alarm               = true
+  create_health_check        = true
+  environment_name           = var.environment_name
+  create_block_email_records = true
 
   providers = {
     aws.us-east-1  = aws.us-east-1
@@ -97,14 +101,15 @@ module "actor_use_my_lpa" {
 module "admin_use_my_lpa" {
   source = "./modules/dns"
 
-  dns_namespace_env = var.dns_namespace_env
-  is_active_region  = local.is_active_region
-  current_region    = data.aws_region.current.name
-  zone_id           = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
-  loadbalancer      = aws_lb.admin
-  service_name      = "admin"
-  dns_name          = "admin.lastingpowerofattorney"
-  environment_name  = var.environment_name
+  dns_namespace_env          = var.dns_namespace_env
+  is_active_region           = local.is_active_region
+  current_region             = data.aws_region.current.name
+  zone_id                    = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
+  loadbalancer               = aws_lb.admin
+  service_name               = "admin"
+  dns_name                   = "admin.lastingpowerofattorney"
+  environment_name           = var.environment_name
+  create_block_email_records = true
 
   providers = {
     aws.us-east-1  = aws.us-east-1

--- a/terraform/environment/region/modules/dns/main.tf
+++ b/terraform/environment/region/modules/dns/main.tf
@@ -26,6 +26,43 @@ resource "aws_route53_record" "this" {
   provider       = aws.management
 }
 
+resource "aws_route53_record" "spf" {
+  count   = var.create_block_email_records ? 1 : 0
+  zone_id = var.zone_id
+  name    = var.dns_name
+  type    = "TXT"
+  ttl     = 300
+
+  records = [
+    "v=spf1 -all",
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  provider = aws.management
+}
+
+
+resource "aws_route53_record" "dmarc" {
+  count   = var.create_block_email_records ? 1 : 0
+  zone_id = var.zone_id
+  name    = "_dmarc.${var.dns_name}"
+  type    = "TXT"
+  ttl     = 300
+
+  records = [
+    "v=DMARC1; p=reject; sp=reject; fo=1; rua=mailto:dmarc-rua@dmarc.service.gov.uk; ruf=mailto:dmarc-ruf@dmarc.service.gov.uk",
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  provider = aws.management
+}
+
 resource "aws_route53_health_check" "this" {
   count             = var.create_health_check ? 1 : 0
   fqdn              = aws_route53_record.this.fqdn

--- a/terraform/environment/region/modules/dns/variables.tf
+++ b/terraform/environment/region/modules/dns/variables.tf
@@ -55,3 +55,9 @@ variable "current_region" {
   type        = string
   default     = "eu-west-1"
 }
+
+variable "create_block_email_records" {
+  description = "Create the SPF and DMARC records to block all emails from being sent from this domain."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
# Purpose

Update Terraform DNS module with SPF/DMARC records. Block emails being sent from Use / View domains.

Fixes UML-3281

## Approach

Add a boolean input var to DNS module and create SPF / DMARC records blocking all emails from being sent if the variable is set to true.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
