### PR TITLE
UML-2547 Fix attempt to create DNS records in secondary region

### DIFF
--- a/terraform/environment/region/modules/dns/main.tf
+++ b/terraform/environment/region/modules/dns/main.tf
@@ -1,6 +1,7 @@
 locals {
   create_alarm = var.create_alarm && var.create_health_check && var.is_active_region
   route_weight = var.is_active_region ? 100 : 0
+  create_block_email_records = var.create_block_email_records && var.is_active_region
 }
 
 resource "aws_route53_record" "this" {
@@ -27,7 +28,7 @@ resource "aws_route53_record" "this" {
 }
 
 resource "aws_route53_record" "spf" {
-  count   = var.create_block_email_records ? 1 : 0
+  count   = local.create_block_email_records ? 1 : 0
   zone_id = var.zone_id
   name    = "${var.dns_namespace_env}${var.dns_name}"
   type    = "TXT"
@@ -46,7 +47,7 @@ resource "aws_route53_record" "spf" {
 
 
 resource "aws_route53_record" "dmarc" {
-  count   = var.create_block_email_records ? 1 : 0
+  count   = local.create_block_email_records ? 1 : 0
   zone_id = var.zone_id
   name    = "_dmarc.${var.dns_namespace_env}${var.dns_name}"
   type    = "TXT"

--- a/terraform/environment/region/modules/dns/main.tf
+++ b/terraform/environment/region/modules/dns/main.tf
@@ -1,6 +1,6 @@
 locals {
-  create_alarm = var.create_alarm && var.create_health_check && var.is_active_region
-  route_weight = var.is_active_region ? 100 : 0
+  create_alarm               = var.create_alarm && var.create_health_check && var.is_active_region
+  route_weight               = var.is_active_region ? 100 : 0
   create_block_email_records = var.create_block_email_records && var.is_active_region
 }
 


### PR DESCRIPTION
# Purpose

Do not attempt to create DMARC and SPF records in the secondary region as they cannot exist twice.

Fixes UML-2547

## Approach

Add a check to the DNS module to ensure that we are in the active region before attempting to create the DNS records.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
