### PR TITLE
UML-2547 Fix Web ACL in secondary region

### DIFF
--- a/terraform/environment/region/waf.tf
+++ b/terraform/environment/region/waf.tf
@@ -1,16 +1,22 @@
 data "aws_wafv2_web_acl" "main" {
   name  = "${var.account_name}-web-acl"
   scope = "REGIONAL"
+
+  provider = aws.region
 }
 
 resource "aws_wafv2_web_acl_association" "actor" {
   count        = var.associate_alb_with_waf_web_acl_enabled ? 1 : 0
   resource_arn = aws_lb.actor.arn
   web_acl_arn  = data.aws_wafv2_web_acl.main.arn
+
+  provider = aws.region
 }
 
 resource "aws_wafv2_web_acl_association" "viewer" {
   count        = var.associate_alb_with_waf_web_acl_enabled ? 1 : 0
   resource_arn = aws_lb.viewer.arn
   web_acl_arn  = data.aws_wafv2_web_acl.main.arn
+
+  provider = aws.region
 }


### PR DESCRIPTION
# Purpose

Fix the Web ACL creation in secondary region.

Fixes UML-2547

## Approach

Explicitly use aws.region provider when doing data lookup for ACL.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
