### PR TITLE
UML-2547 Make eu-west-2 active for preproduction

### DIFF
--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -256,13 +256,13 @@
         "eu-west-1": {
           "enabled": true,
           "name": "eu-west-1",
-          "is_active": true,
+          "is_active": false,
           "is_primary": true
         },
         "eu-west-2": {
           "enabled": true,
           "name": "eu-west-2",
-          "is_active": false,
+          "is_active": true,
           "is_primary": false
         }
       }


### PR DESCRIPTION
# Purpose

Make eu-west-2 the active region for preproduction.

Fixes UML-2547

## Approach

Enable eu-west-2 active flag and disable eu-west-1 active flag.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
