### PR TITLE
UML-972 Rename Terraform resources from Actor to Use

### DIFF
--- a/.github/workflows/_run-behat-tests.yml
+++ b/.github/workflows/_run-behat-tests.yml
@@ -72,7 +72,7 @@ jobs:
       - name: run behat test suite
         run: |
           viewer_fqdn=$(cat ./terraform/environment/cluster_config.json | jq .viewer_fqdn | xargs)
-          actor_fqdn=$(cat ./terraform/environment/cluster_config.json | jq .actor_fqdn | xargs)
+          use_fqdn=$(cat ./terraform/environment/cluster_config.json | jq .use_fqdn | xargs)
           public_facing_view_fqdn=$(cat ./terraform/environment/cluster_config.json | jq .public_facing_view_fqdn | xargs)
           public_facing_use_fqdn=$(cat ./terraform/environment/cluster_config.json | jq .public_facing_use_fqdn | xargs)
 
@@ -82,7 +82,7 @@ jobs:
           BEHAT_VIEWER_URL=https://$public_facing_view_fqdn \
             BEHAT_ACTOR_URL=https://$public_facing_use_fqdn \
             BEHAT_OLD_VIEWER_URL=https://$viewer_fqdn \
-            BEHAT_OLD_ACTOR_URL=https://$actor_fqdn \
+            BEHAT_OLD_ACTOR_URL=https://$use_fqdn \
             vendor/bin/behat
 
       - name: archive failed test screenshots

--- a/.github/workflows/_seed-database.yml
+++ b/.github/workflows/_seed-database.yml
@@ -43,7 +43,7 @@ jobs:
           fi
           export DYNAMODB_TABLE_ACTOR_CODES=$(cat ./terraform/environment/cluster_config.json | jq .actor_lpa_codes_table | xargs)
           export DYNAMODB_TABLE_VIEWER_CODES=$(cat ./terraform/environment/cluster_config.json | jq .viewer_codes_table | xargs)
-          export DYNAMODB_TABLE_ACTOR_USERS=$(cat ./terraform/environment/cluster_config.json | jq .actor_users_table | xargs)
+          export DYNAMODB_TABLE_USE_USERS=$(cat ./terraform/environment/cluster_config.json | jq .use_users_table | xargs)
           export DYNAMODB_TABLE_USER_LPA_ACTOR_MAP=$(cat ./terraform/environment/cluster_config.json | jq .user_lpa_actor_map | xargs)
           export DYNAMODB_TABLE_STATS=$(cat ./terraform/environment/cluster_config.json | jq .stats_table | xargs)
           python service-api/seeding/dynamodb.py

--- a/.github/workflows/_seed-database.yml
+++ b/.github/workflows/_seed-database.yml
@@ -43,7 +43,7 @@ jobs:
           fi
           export DYNAMODB_TABLE_ACTOR_CODES=$(cat ./terraform/environment/cluster_config.json | jq .actor_lpa_codes_table | xargs)
           export DYNAMODB_TABLE_VIEWER_CODES=$(cat ./terraform/environment/cluster_config.json | jq .viewer_codes_table | xargs)
-          export DYNAMODB_TABLE_USE_USERS=$(cat ./terraform/environment/cluster_config.json | jq .use_users_table | xargs)
+          export DYNAMODB_TABLE_ACTOR_USERS=$(cat ./terraform/environment/cluster_config.json | jq .use_users_table | xargs)
           export DYNAMODB_TABLE_USER_LPA_ACTOR_MAP=$(cat ./terraform/environment/cluster_config.json | jq .user_lpa_actor_map | xargs)
           export DYNAMODB_TABLE_STATS=$(cat ./terraform/environment/cluster_config.json | jq .stats_table | xargs)
           python service-api/seeding/dynamodb.py

--- a/.github/workflows/path-to-live.yml
+++ b/.github/workflows/path-to-live.yml
@@ -210,11 +210,11 @@ jobs:
         run: |
           viewer_fqdn=$(cat ./terraform/environment/cluster_config.json | jq .public_facing_view_fqdn | xargs)
           viewer_response=$(curl --write-out %{http_code} --silent --output /dev/null https://$viewer_fqdn/healthcheck)
-          [[ $viewer_response == 200 ]] || (echo "Error with viewer health check. HTTP status: ${viewer_response}" && exit 1)
+          [[ $viewer_response == 200 ]] || (echo "Error with Viewer health check. HTTP status: ${viewer_response}" && exit 1)
 
-          actor_fqdn=$(cat ./terraform/environment/cluster_config.json | jq .public_facing_use_fqdn | xargs)
-          actor_response=$(curl --write-out %{http_code} --silent --output /dev/null https://$actor_fqdn/healthcheck)
-          [[ $actor_response == 200 ]] || (echo "Error with actor health check. HTTP status: ${actor_response}" && exit 1)
+          use_fqdn=$(cat ./terraform/environment/cluster_config.json | jq .public_facing_use_fqdn | xargs)
+          use_response=$(curl --write-out %{http_code} --silent --output /dev/null https://$use_fqdn/healthcheck)
+          [[ $use_response == 200 ]] || (echo "Error with Use health check. HTTP status: ${use_response}" && exit 1)
 
   slack_notify:
     name: notify of result

--- a/scripts/pipeline/set_environment_variables/set_slack_message_values.sh
+++ b/scripts/pipeline/set_environment_variables/set_slack_message_values.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo 'export VIEW_DOMAIN="$(jq -r .viewer_fqdn /tmp/cluster_config.json)"'
-echo 'export USE_DOMAIN="$(jq -r .actor_fqdn /tmp/cluster_config.json)"'
+echo 'export USE_DOMAIN="$(jq -r .use_fqdn /tmp/cluster_config.json)"'
 echo 'export PUBLIC_FACING_VIEW_DOMAIN="$(jq -r .public_facing_view_fqdn /tmp/cluster_config.json)"'
 echo 'export PUBLIC_FACING_USE_DOMAIN="$(jq -r .public_facing_use_fqdn /tmp/cluster_config.json)"'
 echo 'export COMMIT_MESSAGE="$(git log -1 --pretty=%B)"'

--- a/terraform/environment/backup_plan.tf
+++ b/terraform/environment/backup_plan.tf
@@ -45,8 +45,8 @@ resource "aws_backup_selection" "main" {
   plan_id      = aws_backup_plan.main[0].id
 
   resources = [
-    aws_dynamodb_table.actor_codes_table.arn,
-    aws_dynamodb_table.actor_users_table.arn,
+    aws_dynamodb_table.use_codes_table.arn,
+    aws_dynamodb_table.use_users_table.arn,
     aws_dynamodb_table.viewer_codes_table.arn,
     aws_dynamodb_table.viewer_activity_table.arn,
     aws_dynamodb_table.user_lpa_actor_map.arn,

--- a/terraform/environment/config_file.tf
+++ b/terraform/environment/config_file.tf
@@ -8,14 +8,14 @@ locals {
   active_region = [for k, v in local.environment.regions : k if v["is_active"] == true][0]
 
   cluster_config = {
-    actor_users_table                        = aws_dynamodb_table.actor_users_table.name
+    use_users_table                          = aws_dynamodb_table.use_users_table.name
     cluster_name                             = local.active_region == "eu-west-1" ? module.eu_west_1[0].ecs_cluster.name : module.eu_west_2[0].ecs_cluster.name
     account_id                               = local.environment.account_id
-    actor_lpa_codes_table                    = aws_dynamodb_table.actor_codes_table.name
+    use_lpa_codes_table                      = aws_dynamodb_table.use_codes_table.name
     viewer_codes_table                       = aws_dynamodb_table.viewer_codes_table.name
     user_lpa_actor_map                       = aws_dynamodb_table.user_lpa_actor_map.name
     stats_table                              = aws_dynamodb_table.stats_table.name
-    actor_fqdn                               = local.active_region == "eu-west-1" ? module.eu_west_1[0].route53_fqdns.actor : module.eu_west_2[0].route53_fqdns.actor
+    use_fqdn                                 = local.active_region == "eu-west-1" ? module.eu_west_1[0].route53_fqdns.use : module.eu_west_2[0].route53_fqdns.use
     viewer_fqdn                              = local.active_region == "eu-west-1" ? module.eu_west_1[0].route53_fqdns.viewer : module.eu_west_2[0].route53_fqdns.viewer
     admin_fqdn                               = local.active_region == "eu-west-1" ? module.eu_west_1[0].route53_fqdns.admin : module.eu_west_2[0].route53_fqdns.admin
     public_facing_use_fqdn                   = local.active_region == "eu-west-1" ? module.eu_west_1[0].route53_fqdns.public_facing_use : module.eu_west_2[0].route53_fqdns.public_facing_use

--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -1,4 +1,4 @@
-resource "aws_dynamodb_table" "actor_codes_table" {
+resource "aws_dynamodb_table" "use_codes_table" {
   name             = "${local.environment_name}-${local.environment.dynamodb_tables.actor_codes.name}"
   billing_mode     = "PAY_PER_REQUEST"
   hash_key         = "ActorCode"
@@ -78,7 +78,7 @@ resource "aws_dynamodb_table" "stats_table" {
   provider = aws.eu_west_1
 }
 
-resource "aws_dynamodb_table" "actor_users_table" {
+resource "aws_dynamodb_table" "use_users_table" {
   name             = "${local.environment_name}-${local.environment.dynamodb_tables.actor_users.name}"
   billing_mode     = "PAY_PER_REQUEST"
   hash_key         = "Id"

--- a/terraform/environment/modules/iam/iam_ecs_task_roles.tf
+++ b/terraform/environment/modules/iam/iam_ecs_task_roles.tf
@@ -26,8 +26,8 @@ resource "aws_iam_role" "use_task_role" {
 }
 
 moved {
-  from = "aws_iam_role.use_task_role"
-  to   = "aws_iam_role.actor_task_role"
+  from = aws_iam_role.actor_task_role
+  to   = aws_iam_role.use_task_role
 }
 
 resource "aws_iam_role" "viewer_task_role" {

--- a/terraform/environment/modules/iam/iam_ecs_task_roles.tf
+++ b/terraform/environment/modules/iam/iam_ecs_task_roles.tf
@@ -20,9 +20,14 @@ resource "aws_iam_role" "api_task_role" {
   assume_role_policy = data.aws_iam_policy_document.task_role_assume_policy.json
 }
 
-resource "aws_iam_role" "actor_task_role" {
+resource "aws_iam_role" "use_task_role" {
   name               = "${var.environment_name}-actor-task-role"
   assume_role_policy = data.aws_iam_policy_document.task_role_assume_policy.json
+}
+
+moved {
+  from = "aws_iam_role.use_task_role"
+  to   = "aws_iam_role.actor_task_role"
 }
 
 resource "aws_iam_role" "viewer_task_role" {

--- a/terraform/environment/modules/iam/outputs.tf
+++ b/terraform/environment/modules/iam/outputs.tf
@@ -3,7 +3,7 @@ output "ecs_task_roles" {
   value = {
     admin_task_role  = aws_iam_role.admin_task_role
     api_task_role    = aws_iam_role.api_task_role
-    actor_task_role  = aws_iam_role.actor_task_role
+    use_task_role  = aws_iam_role.use_task_role
     viewer_task_role = aws_iam_role.viewer_task_role
     pdf_task_role    = aws_iam_role.pdf_task_role
   }

--- a/terraform/environment/modules/iam/outputs.tf
+++ b/terraform/environment/modules/iam/outputs.tf
@@ -3,7 +3,7 @@ output "ecs_task_roles" {
   value = {
     admin_task_role  = aws_iam_role.admin_task_role
     api_task_role    = aws_iam_role.api_task_role
-    use_task_role  = aws_iam_role.use_task_role
+    use_task_role    = aws_iam_role.use_task_role
     viewer_task_role = aws_iam_role.viewer_task_role
     pdf_task_role    = aws_iam_role.pdf_task_role
   }

--- a/terraform/environment/refactor.tf
+++ b/terraform/environment/refactor.tf
@@ -179,8 +179,8 @@ moved {
 }
 
 moved {
-  from = aws_lb.actor
-  to   = module.eu_west_1.aws_lb.actor
+  from = aws_lb.use
+  to   = module.eu_west_1.aws_lb.use
 }
 
 moved {

--- a/terraform/environment/refactor_actor.tf
+++ b/terraform/environment/refactor_actor.tf
@@ -1,0 +1,142 @@
+# These resources were renamed from 'actor' to 'use' as part of ticket UML-972
+
+
+moved {
+  from = module.eu_west_1[0].aws_lb.actor
+  to   = module.eu_west_1[0].aws_lb.use
+}
+
+moved {
+  from = module.eu_west_1[0].aws_lb_listener.actor_loadbalancer
+  to   = module.eu_west_1[0].aws_lb_listener.use_loadbalancer
+}
+
+moved {
+  from = module.eu_west_1[0].aws_lb_listener_certificate.actor_live_service_certificate
+  to   = module.eu_west_1[0].aws_lb_listener_certificate.use_live_service_certificate
+}
+
+moved {
+  from = module.eu_west_1[0].aws_lb_listener_rule.actor_maintenance
+  to   = module.eu_west_1[0].aws_lb_listener_rule.use_maintenance
+}
+
+moved {
+  from = module.eu_west_1[0].aws_lb_listener_rule.actor_maintenance_welsh
+  to   = module.eu_west_1[0].aws_lb_listener_rule.use_maintenance_welsh
+}
+
+moved {
+  from = module.eu_west_1[0].aws_lb_target_group.actor
+  to   = module.eu_west_1[0].aws_lb_target_group.use
+}
+
+moved {
+  from = module.eu_west_1[0].aws_security_group.actor_loadbalancer
+  to   = module.eu_west_1[0].aws_security_group.use_loadbalancer
+}
+
+moved {
+  from = module.eu_west_1[0].aws_security_group.actor_loadbalancer_route53
+  to   = module.eu_west_1[0].aws_security_group.use_loadbalancer_route53
+}
+
+moved {
+  from = module.eu_west_1[0].aws_security_group_rule.actor_ingress
+  to   = module.eu_west_1[0].aws_security_group_rule.use_ingress
+}
+
+moved {
+  from = module.eu_west_1[0].aws_security_group_rule.actor_ingress_http
+  to   = module.eu_west_1[0].aws_security_group_rule.use_ingress_http
+}
+
+moved {
+  from = module.eu_west_1[0].aws_security_group_rule.actor_ingress_route53_healthchecks
+  to   = module.eu_west_1[0].aws_security_group_rule.use_ingress_route53_healthchecks
+}
+
+moved {
+  from = module.eu_west_1[0].aws_security_group_rule.actor_egress
+  to   = module.eu_west_1[0].aws_security_group_rule.use_egress
+}
+
+moved {
+  from = module.eu_west_1[0].aws_shield_application_layer_automatic_response.actor[0]
+  to   = module.eu_west_1[0].aws_shield_application_layer_automatic_response.use[0]
+}
+
+moved {
+  from = module.eu_west_1[0].aws_ssm_parameter.actor_maintenance_switch
+  to   = module.eu_west_1[0].aws_ssm_parameter.use_maintenance_switch
+}
+
+moved {
+  from = module.eu_west_1[0].aws_wafv2_web_acl_association.actor[0]
+  to   = module.eu_west_1[0].aws_wafv2_web_acl_association.use[0]
+}
+
+moved {
+  from = module.eu_west_1[0].aws_lb_listener.actor_loadbalancer_http_redirect
+  to   = module.eu_west_1[0].aws_lb_listener.use_loadbalancer_http_redirect
+}
+
+moved {
+  from = module.eu_west_1[0].aws_lb_listener_certificate.actor_loadbalancer_live_service_certificate
+  to   = module.eu_west_1[0].aws_lb_listener_certificate.use_loadbalancer_live_service_certificate
+}
+
+moved {
+  from = module.eu_west_1[0].aws_security_group_rule.actor_loadbalancer_egress
+  to   = module.eu_west_1[0].aws_security_group_rule.use_loadbalancer_egress
+}
+
+moved {
+  from = module.eu_west_1[0].aws_security_group_rule.actor_loadbalancer_ingress
+  to   = module.eu_west_1[0].aws_security_group_rule.use_loadbalancer_ingress
+}
+
+moved {
+  from = module.eu_west_1[0].aws_security_group_rule.actor_loadbalancer_ingress_http
+  to   = module.eu_west_1[0].aws_security_group_rule.use_loadbalancer_ingress_http
+}
+
+moved {
+  from = module.eu_west_1[0].aws_security_group_rule.actor_loadbalancer_ingress_route53_healthchecks
+  to   = module.eu_west_1[0].aws_security_group_rule.use_loadbalancer_ingress_route53_healthchecks
+}
+
+moved {
+  from = module.eu_west_1[0].aws_security_group_rule.api_ecs_service_actor_ingress
+  to   = module.eu_west_1[0].aws_security_group_rule.api_ecs_service_use_ingress
+}
+
+moved {
+  from = module.eu_west_1[0].aws_security_group.actor_loadbalancer
+  to   = module.eu_west_1[0].aws_security_group.use_loadbalancer
+}
+
+moved {
+  from = module.eu_west_1[0].aws_security_group_rule.actor_ecs_service_ingress
+  to   = module.eu_west_1[0].aws_security_group_rule.use_ecs_service_ingress
+}
+
+moved {
+  from = module.eu_west_1[0].aws_ecs_task_definition.actor
+  to   = module.eu_west_1[0].aws_ecs_task_definition.use
+}
+
+moved {
+  from = module.eu_west_1[0].aws_iam_role_policy.actor_permissions_role
+  to   = module.eu_west_1[0].aws_iam_role_policy.use_permissions_role
+}
+
+moved {
+  from = aws_dynamodb_table.actor_users_table
+  to   = aws_dynamodb_table.use_users_table
+}
+
+moved {
+  from = aws_dynamodb_table.actor_codes_table
+  to   = aws_dynamodb_table.use_codes_table
+}

--- a/terraform/environment/region.tf
+++ b/terraform/environment/region.tf
@@ -46,9 +46,9 @@ module "eu_west_1" {
   }
 
   dynamodb_tables = {
-    "actor_codes_table"     = aws_dynamodb_table.actor_codes_table
+    "use_codes_table"       = aws_dynamodb_table.use_codes_table
     "stats_table"           = aws_dynamodb_table.stats_table
-    "actor_users_table"     = aws_dynamodb_table.actor_users_table
+    "use_users_table"       = aws_dynamodb_table.use_users_table
     "viewer_codes_table"    = aws_dynamodb_table.viewer_codes_table
     "viewer_activity_table" = aws_dynamodb_table.viewer_activity_table
     "user_lpa_actor_map"    = aws_dynamodb_table.user_lpa_actor_map
@@ -123,9 +123,9 @@ module "eu_west_2" {
   }
 
   dynamodb_tables = {
-    "actor_codes_table"     = aws_dynamodb_table.actor_codes_table
+    "use_codes_table"       = aws_dynamodb_table.use_codes_table
     "stats_table"           = aws_dynamodb_table.stats_table
-    "actor_users_table"     = aws_dynamodb_table.actor_users_table
+    "use_users_table"       = aws_dynamodb_table.use_users_table
     "viewer_codes_table"    = aws_dynamodb_table.viewer_codes_table
     "viewer_activity_table" = aws_dynamodb_table.viewer_activity_table
     "user_lpa_actor_map"    = aws_dynamodb_table.user_lpa_actor_map

--- a/terraform/environment/region/actor_ecs.tf
+++ b/terraform/environment/region/actor_ecs.tf
@@ -44,8 +44,8 @@ resource "aws_ecs_service" "use" {
 }
 
 moved {
-  from = "aws_ecs_service.actor"
-  to   = "aws_ecs_service.use"
+  from = aws_ecs_service.actor
+  to   = aws_ecs_service.use
 }
 //----------------------------------
 // The service's Security Groups
@@ -62,8 +62,8 @@ resource "aws_security_group" "use_ecs_service" {
 }
 
 moved {
-  from = "aws_security_group.actor_ecs_service"
-  to   = "aws_security_group.use_ecs_service"
+  from = aws_security_group.actor_ecs_service
+  to   = aws_security_group.use_ecs_service
 }
 
 // 80 in from the ELB
@@ -83,8 +83,8 @@ resource "aws_security_group_rule" "use_ecs_service_ingress" {
 }
 
 moved {
-  from = "aws_security_group_rule.actor_ecs_service_ingress"
-  to   = "aws_security_group_rule.use_ecs_service_ingress"
+  from = aws_security_group_rule.actor_ecs_service_ingress
+  to   = aws_security_group_rule.use_ecs_service_ingress
 }
 
 // Anything out
@@ -104,8 +104,8 @@ resource "aws_security_group_rule" "use_ecs_service_egress" {
 }
 
 moved {
-  from = "aws_security_group_rule.actor_ecs_service_egress"
-  to   = "aws_security_group_rule.use_ecs_service_egress"
+  from = aws_security_group_rule.actor_ecs_service_egress
+  to   = aws_security_group_rule.use_ecs_service_egress
 }
 
 resource "aws_security_group_rule" "use_ecs_service_elasticache_ingress" {
@@ -124,8 +124,8 @@ resource "aws_security_group_rule" "use_ecs_service_elasticache_ingress" {
 }
 
 moved {
-  from = "aws_security_group_rule.actor_ecs_service_elasticache_ingress"
-  to   = "aws_security_group_rule.use_ecs_service_elasticache_ingress"
+  from = aws_security_group_rule.actor_ecs_service_elasticache_ingress
+  to   = aws_security_group_rule.use_ecs_service_elasticache_ingress
 }
 
 //--------------------------------------
@@ -144,24 +144,15 @@ resource "aws_ecs_task_definition" "use" {
   provider = aws.region
 }
 
-moved {
-  from = "aws_ecs_task_definition.actor"
-  to   = "aws_ecs_task_definition.use"
-}
 //----------------
 // Permissions
 
 resource "aws_iam_role_policy" "use_permissions_role" {
-  name   = "${var.environment_name}-${local.policy_region_prefix}-UseApplicationPermissions"
+  name   = "${var.environment_name}-${local.policy_region_prefix}-ActorApplicationPermissions"
   policy = data.aws_iam_policy_document.use_permissions_role.json
   role   = var.ecs_task_roles.use_task_role.id
 
   provider = aws.region
-}
-
-moved {
-  from = "aws_iam_role_policy.actor_permissions_role"
-  to   = "aws_iam_role_policy.use_permissions_role"   
 }
 
 /*

--- a/terraform/environment/region/actor_ecs.tf
+++ b/terraform/environment/region/actor_ecs.tf
@@ -1,21 +1,21 @@
 //----------------------------------
 // Actor ECS Service level config
 
-resource "aws_ecs_service" "actor" {
+resource "aws_ecs_service" "use" {
   name             = "actor-service"
   cluster          = aws_ecs_cluster.use_an_lpa.id
-  task_definition  = aws_ecs_task_definition.actor.arn
+  task_definition  = aws_ecs_task_definition.use.arn
   desired_count    = local.use_desired_count
   platform_version = "1.4.0"
 
   network_configuration {
-    security_groups  = [aws_security_group.actor_ecs_service.id]
+    security_groups  = [aws_security_group.use_ecs_service.id]
     subnets          = data.aws_subnets.private.ids
     assign_public_ip = false
   }
 
   load_balancer {
-    target_group_arn = aws_lb_target_group.actor.arn
+    target_group_arn = aws_lb_target_group.use.arn
     container_name   = "web"
     container_port   = 80
   }
@@ -43,10 +43,14 @@ resource "aws_ecs_service" "actor" {
   provider = aws.region
 }
 
+moved {
+  from = "aws_ecs_service.actor"
+  to   = "aws_ecs_service.use"
+}
 //----------------------------------
 // The service's Security Groups
 
-resource "aws_security_group" "actor_ecs_service" {
+resource "aws_security_group" "use_ecs_service" {
   name_prefix = "${var.environment_name}-actor-ecs-service"
   description = "Use service security group"
   vpc_id      = data.aws_vpc.default.id
@@ -57,15 +61,20 @@ resource "aws_security_group" "actor_ecs_service" {
   provider = aws.region
 }
 
+moved {
+  from = "aws_security_group.actor_ecs_service"
+  to   = "aws_security_group.use_ecs_service"
+}
+
 // 80 in from the ELB
-resource "aws_security_group_rule" "actor_ecs_service_ingress" {
+resource "aws_security_group_rule" "use_ecs_service_ingress" {
   description              = "Allow Port 80 ingress from the application load balancer"
   type                     = "ingress"
   from_port                = 80
   to_port                  = 80
   protocol                 = "tcp"
-  security_group_id        = aws_security_group.actor_ecs_service.id
-  source_security_group_id = aws_security_group.actor_loadbalancer.id
+  security_group_id        = aws_security_group.use_ecs_service.id
+  source_security_group_id = aws_security_group.use_loadbalancer.id
   lifecycle {
     create_before_destroy = true
   }
@@ -73,15 +82,20 @@ resource "aws_security_group_rule" "actor_ecs_service_ingress" {
   provider = aws.region
 }
 
+moved {
+  from = "aws_security_group_rule.actor_ecs_service_ingress"
+  to   = "aws_security_group_rule.use_ecs_service_ingress"
+}
+
 // Anything out
-resource "aws_security_group_rule" "actor_ecs_service_egress" {
+resource "aws_security_group_rule" "use_ecs_service_egress" {
   description       = "Allow any egress from Use service"
   type              = "egress"
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:aws-vpc-no-public-egress-sgr - open egress for ECR access
-  security_group_id = aws_security_group.actor_ecs_service.id
+  security_group_id = aws_security_group.use_ecs_service.id
   lifecycle {
     create_before_destroy = true
   }
@@ -89,14 +103,19 @@ resource "aws_security_group_rule" "actor_ecs_service_egress" {
   provider = aws.region
 }
 
-resource "aws_security_group_rule" "actor_ecs_service_elasticache_ingress" {
+moved {
+  from = "aws_security_group_rule.actor_ecs_service_egress"
+  to   = "aws_security_group_rule.use_ecs_service_egress"
+}
+
+resource "aws_security_group_rule" "use_ecs_service_elasticache_ingress" {
   description              = "Allow elasticache ingress for Use service"
   type                     = "ingress"
   from_port                = 0
   to_port                  = 6379
   protocol                 = "tcp"
   security_group_id        = data.aws_security_group.brute_force_cache_service.id
-  source_security_group_id = aws_security_group.actor_ecs_service.id
+  source_security_group_id = aws_security_group.use_ecs_service.id
   lifecycle {
     create_before_destroy = true
   }
@@ -104,37 +123,51 @@ resource "aws_security_group_rule" "actor_ecs_service_elasticache_ingress" {
   provider = aws.region
 }
 
+moved {
+  from = "aws_security_group_rule.actor_ecs_service_elasticache_ingress"
+  to   = "aws_security_group_rule.use_ecs_service_elasticache_ingress"
+}
+
 //--------------------------------------
 // Actor ECS Service Task level config
 
-resource "aws_ecs_task_definition" "actor" {
+resource "aws_ecs_task_definition" "use" {
   family                   = "${var.environment_name}-actor"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   cpu                      = 512
   memory                   = 1024
   container_definitions    = "[${local.actor_web}, ${local.actor_app} ${var.feature_flags.deploy_opentelemetry_sidecar ? ", ${local.actor_aws_otel_collector}" : ""}]"
-  task_role_arn            = var.ecs_task_roles.actor_task_role.arn
+  task_role_arn            = var.ecs_task_roles.use_task_role.arn
   execution_role_arn       = var.ecs_execution_role.arn
 
   provider = aws.region
 }
 
+moved {
+  from = "aws_ecs_task_definition.actor"
+  to   = "aws_ecs_task_definition.use"
+}
 //----------------
 // Permissions
 
-resource "aws_iam_role_policy" "actor_permissions_role" {
-  name   = "${var.environment_name}-${local.policy_region_prefix}-ActorApplicationPermissions"
-  policy = data.aws_iam_policy_document.actor_permissions_role.json
-  role   = var.ecs_task_roles.actor_task_role.id
+resource "aws_iam_role_policy" "use_permissions_role" {
+  name   = "${var.environment_name}-${local.policy_region_prefix}-UseApplicationPermissions"
+  policy = data.aws_iam_policy_document.use_permissions_role.json
+  role   = var.ecs_task_roles.use_task_role.id
 
   provider = aws.region
+}
+
+moved {
+  from = "aws_iam_role_policy.actor_permissions_role"
+  to   = "aws_iam_role_policy.use_permissions_role"   
 }
 
 /*
   Defines permissions that the application running within the task has.
 */
-data "aws_iam_policy_document" "actor_permissions_role" {
+data "aws_iam_policy_document" "use_permissions_role" {
   statement {
     sid    = "${local.policy_region_prefix}XRayAccess"
     effect = "Allow"

--- a/terraform/environment/region/admin_ecs.tf
+++ b/terraform/environment/region/admin_ecs.tf
@@ -165,8 +165,8 @@ data "aws_iam_policy_document" "admin_permissions_role" {
     ]
 
     resources = [
-      local.dynamodb_tables_arns.actor_users_table_arn,
-      "${local.dynamodb_tables_arns.actor_users_table_arn}/index/*",
+      local.dynamodb_tables_arns.use_users_table_arn,
+      "${local.dynamodb_tables_arns.use_users_table_arn}/index/*",
       local.dynamodb_tables_arns.viewer_codes_table_arn,
       "${local.dynamodb_tables_arns.viewer_codes_table_arn}/index/*",
       local.dynamodb_tables_arns.viewer_activity_table_arn,

--- a/terraform/environment/region/api_ecs.tf
+++ b/terraform/environment/region/api_ecs.tf
@@ -106,14 +106,14 @@ resource "aws_security_group_rule" "api_ecs_service_viewer_ingress" {
 //----------------------------------
 // 80 in from Actor ECS service
 
-resource "aws_security_group_rule" "api_ecs_service_actor_ingress" {
+resource "aws_security_group_rule" "api_ecs_service_use_ingress" {
   description              = "Allow Port 80 ingress from the Use service"
   type                     = "ingress"
   from_port                = 80
   to_port                  = 80
   protocol                 = "tcp"
   security_group_id        = aws_security_group.api_ecs_service.id
-  source_security_group_id = aws_security_group.actor_ecs_service.id
+  source_security_group_id = aws_security_group.use_ecs_service.id
   lifecycle {
     create_before_destroy = true
   }
@@ -211,10 +211,10 @@ data "aws_iam_policy_document" "api_permissions_role" {
     ]
 
     resources = [
-      local.dynamodb_tables_arns.actor_codes_table_arn,
-      "${local.dynamodb_tables_arns.actor_codes_table_arn}/index/*",
-      local.dynamodb_tables_arns.actor_users_table_arn,
-      "${local.dynamodb_tables_arns.actor_users_table_arn}/index/*",
+      local.dynamodb_tables_arns.use_codes_table_arn,
+      "${local.dynamodb_tables_arns.use_codes_table_arn}/index/*",
+      local.dynamodb_tables_arns.use_users_table_arn,
+      "${local.dynamodb_tables_arns.use_users_table_arn}/index/*",
       local.dynamodb_tables_arns.viewer_codes_table_arn,
       "${local.dynamodb_tables_arns.viewer_codes_table_arn}/index/*",
       local.dynamodb_tables_arns.viewer_activity_table_arn,
@@ -433,11 +433,11 @@ locals {
       environment = [
         {
           name  = "DYNAMODB_TABLE_ACTOR_CODES",
-          value = var.dynamodb_tables.actor_codes_table.name
+          value = var.dynamodb_tables.use_codes_table.name
         },
         {
           name  = "DYNAMODB_TABLE_ACTOR_USERS",
-          value = var.dynamodb_tables.actor_users_table.name
+          value = var.dynamodb_tables.use_users_table.name
         },
         {
           name  = "DYNAMODB_TABLE_VIEWER_CODES",

--- a/terraform/environment/region/autoscaling.tf
+++ b/terraform/environment/region/autoscaling.tf
@@ -17,7 +17,7 @@ module "use_ecs_autoscaling" {
   source                           = "./modules/ecs_autoscaling"
   environment                      = var.environment_name
   aws_ecs_cluster_name             = aws_ecs_cluster.use_an_lpa.name
-  aws_ecs_service_name             = aws_ecs_service.actor.name
+  aws_ecs_service_name             = aws_ecs_service.use.name
   ecs_autoscaling_service_role_arn = data.aws_iam_role.ecs_autoscaling_service_role.arn
   ecs_task_autoscaling_minimum     = local.use_desired_count
   ecs_task_autoscaling_maximum     = var.autoscaling.use.maximum

--- a/terraform/environment/region/cloudwatch_alarms.tf
+++ b/terraform/environment/region/cloudwatch_alarms.tf
@@ -30,7 +30,7 @@ resource "aws_cloudwatch_metric_alarm" "actor_5xx_errors" {
   comparison_operator = "GreaterThanThreshold"
   datapoints_to_alarm = 2
   dimensions = {
-    "LoadBalancer" = trimprefix(split(":", aws_lb.actor.arn)[5], "loadbalancer/")
+    "LoadBalancer" = trimprefix(split(":", aws_lb.use.arn)[5], "loadbalancer/")
   }
   evaluation_periods        = 2
   insufficient_data_actions = []
@@ -94,7 +94,7 @@ resource "aws_cloudwatch_metric_alarm" "actor_ddos_attack_external" {
   treat_missing_data  = "notBreaching"
   alarm_actions       = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
   dimensions = {
-    ResourceArn = aws_lb.actor.arn
+    ResourceArn = aws_lb.use.arn
   }
 
   provider = aws.region

--- a/terraform/environment/region/dns.tf
+++ b/terraform/environment/region/dns.tf
@@ -67,7 +67,7 @@ module "public_facing_use_lasting_power_of_attorney" {
   current_region             = data.aws_region.current.name
   zone_id                    = data.aws_route53_zone.live_service_use_lasting_power_of_attorney.zone_id
   dns_name                   = data.aws_route53_zone.live_service_use_lasting_power_of_attorney.name
-  loadbalancer               = aws_lb.actor
+  loadbalancer               = aws_lb.use
   environment_name           = var.environment_name
   create_block_email_records = true
 
@@ -84,7 +84,7 @@ module "actor_use_my_lpa" {
   is_active_region           = local.is_active_region
   current_region             = data.aws_region.current.name
   zone_id                    = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
-  loadbalancer               = aws_lb.actor
+  loadbalancer               = aws_lb.use
   dns_name                   = "use.lastingpowerofattorney"
   service_name               = "actor"
   create_alarm               = true

--- a/terraform/environment/region/locals.tf
+++ b/terraform/environment/region/locals.tf
@@ -16,9 +16,9 @@ locals {
   # Replace the region in the ARN of the DynamoDB tables with the region of the current stack as the tables are created in the primary region
   # and replicated to the secondary region. This allows use to grant access to the tables in the secondary region for applications running in the secondary region.
   dynamodb_tables_arns = {
-    actor_codes_table_arn     = replace(var.dynamodb_tables.actor_codes_table.arn, local.primary_region, data.aws_region.current.name)
+    use_codes_table_arn       = replace(var.dynamodb_tables.use_codes_table.arn, local.primary_region, data.aws_region.current.name)
     stats_table_arn           = replace(var.dynamodb_tables.stats_table.arn, local.primary_region, data.aws_region.current.name)
-    actor_users_table_arn     = replace(var.dynamodb_tables.actor_users_table.arn, local.primary_region, data.aws_region.current.name)
+    use_users_table_arn       = replace(var.dynamodb_tables.use_users_table.arn, local.primary_region, data.aws_region.current.name)
     viewer_codes_table_arn    = replace(var.dynamodb_tables.viewer_codes_table.arn, local.primary_region, data.aws_region.current.name)
     viewer_activity_table_arn = replace(var.dynamodb_tables.viewer_activity_table.arn, local.primary_region, data.aws_region.current.name)
     user_lpa_actor_map_arn    = replace(var.dynamodb_tables.user_lpa_actor_map.arn, local.primary_region, data.aws_region.current.name)
@@ -28,7 +28,7 @@ locals {
     public_facing_view = local.is_active_region ? module.public_facing_view_lasting_power_of_attorney.fqdn : ""
     public_facing_use  = local.is_active_region ? module.public_facing_use_lasting_power_of_attorney.fqdn : ""
     admin              = local.is_active_region ? module.admin_use_my_lpa.fqdn : ""
-    actor              = local.is_active_region ? module.actor_use_my_lpa.fqdn : ""
+    use                = local.is_active_region ? module.actor_use_my_lpa.fqdn : ""
     viewer             = local.is_active_region ? module.viewer_use_my_lpa.fqdn : ""
   }
 

--- a/terraform/environment/region/outputs.tf
+++ b/terraform/environment/region/outputs.tf
@@ -6,7 +6,7 @@ output "ecs_cluster" {
 output "ecs_services" {
   description = "Objects containing the ECS services"
   value = {
-    actor  = aws_ecs_service.actor
+    actor  = aws_ecs_service.use
     admin  = aws_ecs_service.admin
     api    = aws_ecs_service.api
     pdf    = aws_ecs_service.pdf
@@ -17,7 +17,7 @@ output "ecs_services" {
 output "albs" {
   description = "Objects containing the ALBs"
   value = {
-    actor  = aws_lb.actor
+    actor  = aws_lb.use
     admin  = aws_lb.admin
     viewer = aws_lb.viewer
   }
@@ -26,7 +26,7 @@ output "albs" {
 output "security_group_names" {
   description = "Security group names"
   value = {
-    actor_loadbalancer  = aws_security_group.actor_loadbalancer.name
+    actor_loadbalancer  = aws_security_group.use_loadbalancer.name
     viewer_loadbalancer = aws_security_group.viewer_loadbalancer.name
   }
 }
@@ -37,7 +37,7 @@ output "route53_fqdns" {
     public_facing_view = local.route53_fqdns.public_facing_view
     public_facing_use  = local.route53_fqdns.public_facing_use
     admin              = local.route53_fqdns.admin
-    actor              = local.route53_fqdns.actor
+    use                = local.route53_fqdns.use
     viewer             = local.route53_fqdns.viewer
   }
 }

--- a/terraform/environment/region/viewer_load_balancer.tf
+++ b/terraform/environment/region/viewer_load_balancer.tf
@@ -147,7 +147,7 @@ resource "aws_ssm_parameter" "viewer_maintenance_switch" {
   value           = "false"
   description     = "values of either 'true' or 'false' only"
   allowed_pattern = "^(true|false)"
-  overwrite       = true
+
   lifecycle {
     ignore_changes = [value]
   }

--- a/terraform/environment/region/waf.tf
+++ b/terraform/environment/region/waf.tf
@@ -5,9 +5,9 @@ data "aws_wafv2_web_acl" "main" {
   provider = aws.region
 }
 
-resource "aws_wafv2_web_acl_association" "actor" {
+resource "aws_wafv2_web_acl_association" "use" {
   count        = var.associate_alb_with_waf_web_acl_enabled ? 1 : 0
-  resource_arn = aws_lb.actor.arn
+  resource_arn = aws_lb.use.arn
   web_acl_arn  = data.aws_wafv2_web_acl.main.arn
 
   provider = aws.region


### PR DESCRIPTION
# Purpose

Rename the Terraform resources to be consistent with the service name

Fixes UML-972

## Approach

Rename the Terraform resources but do not change the AWS names as many AWS resources cannot be renamed and would result in resources (such as loadbalancers) being recreated. This would be far too disruptive for the gain. Use moved blocks for all renamed objects.

## Learning


## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
