### PR TITLE
UML-3271 Password reset form need to 410

### DIFF
--- a/service-front/app/config/autoload/dependencies.global.php
+++ b/service-front/app/config/autoload/dependencies.global.php
@@ -21,7 +21,6 @@ return [
         // Use 'factories' for services provided by callbacks/factory classes.
         'factories' => [
             // Fully\Qualified\ClassName::class => Fully\Qualified\FactoryName::class,
-            \Common\Middleware\ErrorHandling\GoneHandler::class => \Common\Middleware\ErrorHandling\GoneHandlerFactory::class
         ],
     ],
 ];

--- a/service-front/app/config/autoload/dependencies.global.php
+++ b/service-front/app/config/autoload/dependencies.global.php
@@ -21,6 +21,7 @@ return [
         // Use 'factories' for services provided by callbacks/factory classes.
         'factories' => [
             // Fully\Qualified\ClassName::class => Fully\Qualified\FactoryName::class,
+            \Common\Middleware\ErrorHandling\GoneHandler::class => \Common\Middleware\ErrorHandling\GoneHandlerFactory::class
         ],
     ],
 ];

--- a/service-front/app/config/autoload/dependencies.global.php
+++ b/service-front/app/config/autoload/dependencies.global.php
@@ -20,7 +20,6 @@ return [
         ],
         // Use 'factories' for services provided by callbacks/factory classes.
         'factories' => [
-            \Common\Middleware\ErrorHandling\GoneHandler::class => \Common\Middleware\ErrorHandling\GoneHandlerFactory::class
             // Fully\Qualified\ClassName::class => Fully\Qualified\FactoryName::class,
         ],
     ],

--- a/service-front/app/config/autoload/dependencies.global.php
+++ b/service-front/app/config/autoload/dependencies.global.php
@@ -20,6 +20,7 @@ return [
         ],
         // Use 'factories' for services provided by callbacks/factory classes.
         'factories' => [
+            \Common\Middleware\ErrorHandling\GoneHandler::class => \Common\Middleware\ErrorHandling\GoneHandlerFactory::class
             // Fully\Qualified\ClassName::class => Fully\Qualified\FactoryName::class,
         ],
     ],

--- a/service-front/app/config/pipeline.php
+++ b/service-front/app/config/pipeline.php
@@ -106,6 +106,8 @@ return function (Application $app, MiddlewareFactory $factory, ContainerInterfac
     // Register the dispatch middleware in the middleware pipeline
     $app->pipe(DispatchMiddleware::class);
 
+    $app->pipe(\Common\Middleware\ErrorHandling\GoneHandler::class);
+
     // At this point, if no Response is returned by any middleware, the
     // NotFoundHandler kicks in; alternately, you can provide other fallback
     // middleware to execute.

--- a/service-front/app/config/routes.php
+++ b/service-front/app/config/routes.php
@@ -67,6 +67,9 @@ $actorRoutes = function (Application $app, MiddlewareFactory $factory, Container
 
     $defaultNotFoundPage = Actor\Handler\LpaDashboardHandler::class;
 
+    $config = $container->get("config");
+    $feature_flags = $config["feature_flags"];
+
     $app->route('/home', [
         new ConditionalRoutingMiddleware(
             $container,
@@ -131,21 +134,25 @@ $actorRoutes = function (Application $app, MiddlewareFactory $factory, Container
     );
 
     // User management
-    $app->route(
-        '/reset-password',
-        Actor\Handler\PasswordResetRequestPageHandler::class,
-        ['GET', 'POST'],
-        'password-reset'
-    );
-    $app->route(
-        '/reset-password/{token}',
-        Actor\Handler\PasswordResetPageHandler::class,
-        ['GET', 'POST'],
-        'password-reset-token'
-    );
-    $app->get('/verify-new-email/{token}', [
-        Actor\Handler\CompleteChangeEmailHandler::class,
-    ], 'verify-new-email');
+    if (!$feature_flags[$ALLOW_GOV_ONE_LOGIN]) {
+        $app->route(
+            '/reset-password',
+            Actor\Handler\PasswordResetRequestPageHandler::class,
+            ['GET', 'POST'],
+            'password-reset'
+        );
+
+        $app->route(
+            '/reset-password/{token}',
+            Actor\Handler\PasswordResetPageHandler::class,
+            ['GET', 'POST'],
+            'password-reset-token'
+        );
+
+        $app->get('/verify-new-email/{token}', [
+            Actor\Handler\CompleteChangeEmailHandler::class,
+        ],        'verify-new-email');
+    }
 
     // User deletion
     $app->get('/confirm-delete-account', [

--- a/service-front/app/features/bootstrap/behat.config.php
+++ b/service-front/app/features/bootstrap/behat.config.php
@@ -18,9 +18,10 @@ return [
     'debug'                        => false,
     'dependencies'                 => [
         'factories' => [
-            Client::class                 => TestClientFactory::class,
-            Sdk::class                    => SdkFactory::class,
-            ErrorResponseGenerator::class => ErrorResponseGeneratorFactory::class,
+            Client::class                                       => TestClientFactory::class,
+            Sdk::class                                          => SdkFactory::class,
+            ErrorResponseGenerator::class                       => ErrorResponseGeneratorFactory::class,
+            \Common\Middleware\ErrorHandling\GoneHandler::class => \Common\Middleware\ErrorHandling\GoneHandlerFactory::class
         ],
     ],
     'api'                          => [

--- a/service-front/app/src/Common/src/ConfigProvider.php
+++ b/service-front/app/src/Common/src/ConfigProvider.php
@@ -110,6 +110,7 @@ class ConfigProvider
                 SessionMiddleware::class                   => SessionMiddlewareFactory::class,
                 SessionExpiryMiddleware::class             => SessionExpiryMiddlewareFactory::class,
                 Middleware\I18n\SetLocaleMiddleware::class => Middleware\I18n\SetLocaleMiddlewareFactory::class,
+                Common\Middleware\ErrorHandling\GoneHandler::class => \Common\Middleware\ErrorHandling\GoneHandlerFactory::class,
 
                 // Auth
                 UserInterface::class => Entity\UserFactory::class,

--- a/service-front/app/src/Common/src/ConfigProvider.php
+++ b/service-front/app/src/Common/src/ConfigProvider.php
@@ -110,7 +110,7 @@ class ConfigProvider
                 SessionMiddleware::class                   => SessionMiddlewareFactory::class,
                 SessionExpiryMiddleware::class             => SessionExpiryMiddlewareFactory::class,
                 Middleware\I18n\SetLocaleMiddleware::class => Middleware\I18n\SetLocaleMiddlewareFactory::class,
-                Common\Middleware\ErrorHandling\GoneHandler::class => \Common\Middleware\ErrorHandling\GoneHandlerFactory::class,
+                Middleware\ErrorHandling\GoneHandler::class => Middleware\ErrorHandling\GoneHandlerFactory::class,
 
                 // Auth
                 UserInterface::class => Entity\UserFactory::class,

--- a/service-front/app/src/Common/src/Middleware/ErrorHandling/GoneHandler.php
+++ b/service-front/app/src/Common/src/Middleware/ErrorHandling/GoneHandler.php
@@ -30,8 +30,12 @@ class GoneHandler implements MiddlewareInterface
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        if (in_array($request->getUri()->getPath(), $this->goneUris)) {
-            return $this->generateTemplatedResponse($this->renderer);
+        $uriPath = $request->getUri()->getPath();
+
+        foreach ($this->goneUris as $goneUri) {
+            if (str_starts_with($uriPath, $goneUri)) {
+                return $this->generateTemplatedResponse($this->renderer);
+            }
         }
 
         return $handler->handle($request);

--- a/service-front/app/src/Common/src/Middleware/ErrorHandling/GoneHandler.php
+++ b/service-front/app/src/Common/src/Middleware/ErrorHandling/GoneHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Middleware\ErrorHandling;
+
+use Fig\Http\Message\StatusCodeInterface;
+use Mezzio\Template\TemplateRendererInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class GoneHandler implements MiddlewareInterface
+{
+    /**
+     * @var string[] List of URIs that are gone.
+     */
+    private array $goneUris = [
+        '/reset-password',
+        '/verify-new-email',
+    ];
+
+    public function __construct(
+        private ResponseFactoryInterface $responseFactory,
+        private TemplateRendererInterface $renderer,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if (in_array($request->getUri()->getPath(), $this->goneUris)) {
+            return $this->generateTemplatedResponse($this->renderer);
+        }
+
+        return $handler->handle($request);
+    }
+
+    private function generateTemplatedResponse(TemplateRendererInterface $renderer): ResponseInterface
+    {
+        $response = $this->responseFactory->createResponse()->withStatus(StatusCodeInterface::STATUS_GONE);
+        $response->getBody()->write($renderer->render('error::410'));
+
+        return $response;
+    }
+}

--- a/service-front/app/src/Common/src/Middleware/ErrorHandling/GoneHandler.php
+++ b/service-front/app/src/Common/src/Middleware/ErrorHandling/GoneHandler.php
@@ -20,6 +20,9 @@ class GoneHandler implements MiddlewareInterface
     private array $goneUris = [
         '/reset-password',
         '/verify-new-email',
+        '/create-account',
+        '/create-account-success',
+        '/activate-account',
     ];
 
     public function __construct(

--- a/service-front/app/src/Common/src/Middleware/ErrorHandling/GoneHandlerFactory.php
+++ b/service-front/app/src/Common/src/Middleware/ErrorHandling/GoneHandlerFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Middleware\ErrorHandling;
+
+use Mezzio\Container\Psr17ResponseFactoryTrait;
+use Mezzio\Template\TemplateRendererInterface;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+/**
+ * Factory for the GoneHandler.
+ */
+class GoneHandlerFactory
+{
+    use Psr17ResponseFactoryTrait;
+
+    /**
+     * Invokes the creation of a GoneHandler.
+     *
+     * @param ContainerInterface $container The container interface.
+     * @return GoneHandler Returns an instance of GoneHandler.
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
+     */
+    public function __invoke(ContainerInterface $container): GoneHandler
+    {
+        $renderer        = $container->get(TemplateRendererInterface::class);
+        $responseFactory = $this->detectResponseFactory($container);
+
+        return new GoneHandler($responseFactory, $renderer);
+    }
+}

--- a/service-front/app/src/Common/templates/error/410.html.twig
+++ b/service-front/app/src/Common/templates/error/410.html.twig
@@ -9,7 +9,7 @@
                 <div class="govuk-grid-column-two-thirds">
                     <h1 class="govuk-heading-xl">{% trans %}Gone{% endtrans %}</h1>
                     <p class="govuk-body">
-                        {% trans %}This page is no longer available and has been moved permanently.{% endtrans %}
+                        {% trans %}This page is no longer available and has been removed permanently.{% endtrans %}
                     </p>
                     <p class="govuk-body">
                         {% trans %}If you entered a web address, check it's correct.{% endtrans %}

--- a/service-front/app/src/Common/templates/error/410.html.twig
+++ b/service-front/app/src/Common/templates/error/410.html.twig
@@ -1,0 +1,31 @@
+{% extends '@layout/default.html.twig' %}
+
+{% block html_title %}{% trans %}Gone{% endtrans %} - {{ parent() }} {% endblock %}
+
+{% block content %}
+    <div class="govuk-width-container">
+        <main class="govuk-main-wrapper">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds">
+                    <h1 class="govuk-heading-xl">{% trans %}Gone{% endtrans %}</h1>
+                    <p class="govuk-body">
+                        {% trans %}This page is no longer available and has been moved permanently.{% endtrans %}
+                    </p>
+                    <p class="govuk-body">
+                        {% trans %}If you entered a web address, check it's correct.{% endtrans %}
+                    </p>
+                    <p class="govuk-body">
+                        {% trans %}
+                            You can <a class="govuk-link" href="https://www.gov.uk/">return to GOV.UK</a> or start again.
+                        {% endtrans %}
+                    </p><br>
+                    <p class="govuk-body">
+                        {%trans with {'%link%': path('home')} %}
+                            <a href="%link%" draggable="false" class="govuk-button">Start again</a>
+                        {% endtrans %}
+                    </p>
+                </div>
+            </div>
+        </main>
+    </div>
+{% endblock %}

--- a/service-front/app/test/CommonTest/Middleware/ErrorHandling/GoneHandlerFactoryTest.php
+++ b/service-front/app/test/CommonTest/Middleware/ErrorHandling/GoneHandlerFactoryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommonTest\Middleware\ErrorHandling;
+
+use Common\Middleware\ErrorHandling\GoneHandler;
+use Common\Middleware\ErrorHandling\GoneHandlerFactory;
+use Mezzio\Template\TemplateRendererInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class GoneHandlerFactoryTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testFactoryReturnsGoneHandlerInstance(): void
+    {
+        $container        = $this->prophesize(ContainerInterface::class);
+        $templateRenderer = $this->prophesize(TemplateRendererInterface::class);
+        $responseFactory  = $this->prophesize(ResponseFactoryInterface::class);
+
+        $responseMock = $this->prophesize(ResponseInterface::class)->reveal();
+        $responseFactory->createResponse(410)->willReturn($responseMock);
+
+        $container->get(TemplateRendererInterface::class)->willReturn($templateRenderer->reveal());
+        $container->get(ResponseFactoryInterface::class)->willReturn($responseFactory->reveal());
+        $container->has(ResponseFactoryInterface::class)->willReturn(true);
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn([]);
+
+        $factory = new GoneHandlerFactory();
+
+        $goneHandler = $factory($container->reveal());
+
+        $this->assertInstanceOf(GoneHandler::class, $goneHandler);
+    }
+}

--- a/service-front/app/test/CommonTest/Middleware/ErrorHandling/GoneHandlerTest.php
+++ b/service-front/app/test/CommonTest/Middleware/ErrorHandling/GoneHandlerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommonTest\Middleware\ErrorHandling;
+
+use Common\Middleware\ErrorHandling\GoneHandler;
+use Fig\Http\Message\StatusCodeInterface;
+use Mezzio\Template\TemplateRendererInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class GoneHandlerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testReturnsGoneResponseForGoneUris(): void
+    {
+        $rendererProphecy        = $this->prophesize(TemplateRendererInterface::class);
+        $responseProphecy        = $this->prophesize(ResponseInterface::class);
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+
+        $rendererProphecy->render('error::410')->willReturn('Gone');
+
+        $responseProphecy->getBody()->willReturn(new class {
+            public function write($content)
+            {
+            }
+        });
+        $responseProphecy->withStatus(StatusCodeInterface::STATUS_GONE)->willReturn($responseProphecy->reveal());
+        $responseFactoryProphecy->createResponse()->willReturn($responseProphecy->reveal());
+
+        $goneHandler = new GoneHandler(
+            $responseFactoryProphecy->reveal(),
+            $rendererProphecy->reveal()
+        );
+
+        $requestProphecy = $this->prophesize(ServerRequestInterface::class);
+        $requestProphecy->getUri()->willReturn(new class {
+            public function getPath()
+            {
+                return '/reset-password';
+            }
+        });
+
+        $handlerProphecy = $this->prophesize(RequestHandlerInterface::class);
+
+        $response = $goneHandler->process($requestProphecy->reveal(), $handlerProphecy->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertSame($responseProphecy->reveal(), $response);
+    }
+
+    public function testReturnsGoneStatusForSpecifiedRoutes()
+    {
+        $templateRendererProphecy = $this->prophesize(TemplateRendererInterface::class);
+        $responseProphecy         = $this->prophesize(ResponseInterface::class);
+        $streamProphecy           = $this->prophesize(StreamInterface::class);
+
+        $streamProphecy->write('Page gone')->shouldBeCalled();
+        $responseProphecy->getBody()->willReturn($streamProphecy->reveal());
+        $responseProphecy->withStatus(410)->willReturn($responseProphecy->reveal());
+
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $responseFactoryProphecy->createResponse()->willReturn($responseProphecy->reveal());
+
+        $goneHandler = new GoneHandler($responseFactoryProphecy->reveal(), $templateRendererProphecy->reveal());
+
+        $requestProphecy = $this->prophesize(ServerRequestInterface::class);
+        $handlerProphecy = $this->prophesize(RequestHandlerInterface::class);
+
+        $templateRendererProphecy->render('error::410')->willReturn('Page gone');
+
+        $requestProphecy->getUri()->willReturn(new class {
+            public function getPath()
+            {
+                return '/reset-password';
+            }
+        });
+
+        $responseProphecy->withStatus(StatusCodeInterface::STATUS_GONE)->shouldBeCalledTimes(1);
+        $templateRendererProphecy->render('error::410')->shouldBeCalledTimes(1);
+
+        $result = $goneHandler->process($requestProphecy->reveal(), $handlerProphecy->reveal());
+
+        $this->assertSame($responseProphecy->reveal(), $result);
+    }
+
+    public function testPassesControlToNextMiddlewareForOtherUris(): void
+    {
+        $rendererProphecy        = $this->prophesize(TemplateRendererInterface::class);
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+
+        $goneHandler = new GoneHandler(
+            $responseFactoryProphecy->reveal(),
+            $rendererProphecy->reveal()
+        );
+
+        $requestProphecy = $this->prophesize(ServerRequestInterface::class);
+        $requestProphecy->getUri()->willReturn(new class {
+            public function getPath()
+            {
+                return '/some-other-uri';
+            }
+        });
+
+        $nextResponseProphecy = $this->prophesize(ResponseInterface::class);
+        $handlerProphecy      = $this->prophesize(RequestHandlerInterface::class);
+        $handlerProphecy->handle($requestProphecy->reveal())->willReturn($nextResponseProphecy->reveal());
+
+        $response = $goneHandler->process($requestProphecy->reveal(), $handlerProphecy->reveal());
+
+        $this->assertSame($nextResponseProphecy->reveal(), $response);
+    }
+}


### PR DESCRIPTION
# Purpose

Password reset form needs to be 410

AC:

Following URLs need to 410

`/reset-password` 

`/verify-new-email`

content taken from 404 page

behind feature flag `ALLOW_GOV_ONE_LOGIN`

Fixes [UML-3271](https://opgtransform.atlassian.net/jira/software/c/projects/LPA/boards/149?selectedIssue=UML-3273)

## Approach

## Checklist

* [x] I have performed a self-review of my own code
* ~[ ] I have added relevant logging with appropriate levels to my code~
* ~[ ] New event_codes have been documented on the [wiki page]~~(https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
*~ [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant~
* [x] I have added tests to prove my work
* [x] I have added welsh translation tags and updated translation files
* ~[ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~[ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* [x] The product team have tested these changes


[UML-3271]: https://opgtransform.atlassian.net/browse/UML-3271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ