### PR TITLE
UML-1911 Add SrcAccount condition for resource policies

### DIFF
--- a/terraform/account/backup_role.tf
+++ b/terraform/account/backup_role.tf
@@ -20,6 +20,12 @@ data "aws_iam_policy_document" "aws_backup_assume_policy" {
       identifiers = ["backup.amazonaws.com"]
       type        = "Service"
     }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
   }
 }
 

--- a/terraform/account/kms.tf
+++ b/terraform/account/kms.tf
@@ -98,6 +98,12 @@ data "aws_iam_policy_document" "cloudwatch_kms" {
         "events.amazonaws.com"
       ]
     }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
   }
 
   statement {

--- a/terraform/account/modules/dynamodb_cloudtrail/cloudtrail.tf
+++ b/terraform/account/modules/dynamodb_cloudtrail/cloudtrail.tf
@@ -38,6 +38,12 @@ data "aws_iam_policy_document" "cloudtrail_role_assume_role_policy" {
       type        = "Service"
       identifiers = ["cloudtrail.amazonaws.com"]
     }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
   }
 }
 

--- a/terraform/account/modules/dynamodb_cloudtrail/kms.tf
+++ b/terraform/account/modules/dynamodb_cloudtrail/kms.tf
@@ -73,6 +73,12 @@ data "aws_iam_policy_document" "cloudtrail_s3_key" {
       type        = "Service"
       identifiers = ["cloudtrail.amazonaws.com"]
     }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
   }
 }
 
@@ -123,6 +129,12 @@ data "aws_iam_policy_document" "cloudtrail_log_group_key" {
         "logs.${data.aws_region.current.name}.amazonaws.com",
         "events.amazonaws.com"
       ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
     }
   }
 

--- a/terraform/account/modules/dynamodb_cloudtrail/s3.tf
+++ b/terraform/account/modules/dynamodb_cloudtrail/s3.tf
@@ -64,6 +64,11 @@ data "aws_iam_policy_document" "cloudtrail" {
       identifiers = ["cloudtrail.amazonaws.com"]
       type        = "Service"
     }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
     resources = [aws_s3_bucket.cloudtrail.arn]
   }
 
@@ -81,6 +86,11 @@ data "aws_iam_policy_document" "cloudtrail" {
       values   = ["bucket-owner-full-control"]
       variable = "s3:x-amz-acl"
     }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
   }
 
   statement {
@@ -90,6 +100,11 @@ data "aws_iam_policy_document" "cloudtrail" {
     principals {
       identifiers = ["cloudtrail.amazonaws.com"]
       type        = "Service"
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
     }
     resources = [aws_s3_bucket.cloudtrail.arn]
   }

--- a/terraform/account/region/cloudwatch.tf
+++ b/terraform/account/region/cloudwatch.tf
@@ -68,6 +68,11 @@ data "aws_iam_policy_document" "cloudwatch_kms" {
         "events.amazonaws.com"
       ]
     }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
   }
 
   statement {

--- a/terraform/account/region/modules/lambda_function/iam.tf
+++ b/terraform/account/region/modules/lambda_function/iam.tf
@@ -11,6 +11,12 @@ data "aws_iam_policy_document" "lambda_assume" {
       type        = "Service"
       identifiers = ["lambda.amazonaws.com"]
     }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
   }
 }
 

--- a/terraform/account/region/pagerduty.tf
+++ b/terraform/account/region/pagerduty.tf
@@ -28,6 +28,11 @@ data "aws_iam_policy_document" "pagerduty_sns_kms" {
       identifiers = ["cloudwatch.amazonaws.com"]
       type        = "Service"
     }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
   }
   statement {
     sid       = "Enable Root account permissions on Key"

--- a/terraform/account/region/s3_lb_access_logs.tf
+++ b/terraform/account/region/s3_lb_access_logs.tf
@@ -76,6 +76,11 @@ data "aws_iam_policy_document" "access_log" {
       identifiers = [data.aws_elb_service_account.main.id]
       type        = "AWS"
     }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
   }
 
   statement {
@@ -95,6 +100,11 @@ data "aws_iam_policy_document" "access_log" {
       values   = ["bucket-owner-full-control"]
       variable = "s3:x-amz-acl"
     }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
   }
 
   statement {
@@ -107,6 +117,11 @@ data "aws_iam_policy_document" "access_log" {
     principals {
       identifiers = ["delivery.logs.amazonaws.com"]
       type        = "Service"
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
     }
   }
 

--- a/terraform/account/region/waf.tf
+++ b/terraform/account/region/waf.tf
@@ -158,6 +158,11 @@ data "aws_iam_policy_document" "waf_cloudwatch_log_encryption_kms" {
         "events.amazonaws.com"
       ]
     }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
   }
 
   statement {

--- a/terraform/account/vpc_flowlogs.tf
+++ b/terraform/account/vpc_flowlogs.tf
@@ -11,6 +11,12 @@ data "aws_iam_policy_document" "vpc_flow_logs_role_assume_role_policy" {
       type        = "Service"
       identifiers = ["vpc-flow-logs.amazonaws.com"]
     }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
   }
 }
 

--- a/terraform/environment/modules/iam/iam_ecs_execution_role.tf
+++ b/terraform/environment/modules/iam/iam_ecs_execution_role.tf
@@ -12,5 +12,11 @@ data "aws_iam_policy_document" "execution_role_assume_policy" {
       identifiers = ["ecs-tasks.amazonaws.com"]
       type        = "Service"
     }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
   }
 }

--- a/terraform/environment/modules/iam/iam_ecs_task_roles.tf
+++ b/terraform/environment/modules/iam/iam_ecs_task_roles.tf
@@ -7,6 +7,12 @@ data "aws_iam_policy_document" "task_role_assume_policy" {
       identifiers = ["ecs-tasks.amazonaws.com"]
       type        = "Service"
     }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
   }
 }
 

--- a/terraform/environment/modules/lambda/iam.tf
+++ b/terraform/environment/modules/lambda/iam.tf
@@ -14,6 +14,12 @@ data "aws_iam_policy_document" "lambda_assume" {
       type        = "Service"
       identifiers = ["lambda.amazonaws.com"]
     }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
   }
 }
 


### PR DESCRIPTION
# Purpose

Improve security posture of IAM resource policies.

Fixes UML-1911

## Approach

Add SourceAccount condition to resource policies to ensure that requests can only be made on behalf of the same AWS account

## Learning

https://www.wiz.io/blog/black-hat-2021-aws-cross-account-vulnerabilities-how-isolated-is-your-cloud-environment#

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
