### PR TITLE
UML-3227: Count IP Reputation matches #minor

### DIFF
--- a/terraform/account/region/waf.tf
+++ b/terraform/account/region/waf.tf
@@ -8,8 +8,30 @@ resource "aws_wafv2_web_acl" "main" {
   }
 
   rule {
-    name     = "AWS-AWSManagedRulesPHPRuleSet"
+    name     = "AWS-AWSManagedRulesAmazonIpReputationList"
     priority = 0
+
+    override_action {
+      count {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAmazonIpReputationList"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWS-AWSManagedRulesAmazonIpReputationList"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesPHPRuleSet"
+    priority = 1
 
     override_action {
       none {}
@@ -30,7 +52,7 @@ resource "aws_wafv2_web_acl" "main" {
   }
   rule {
     name     = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
-    priority = 1
+    priority = 2
 
     override_action {
       none {}
@@ -51,7 +73,7 @@ resource "aws_wafv2_web_acl" "main" {
   }
   rule {
     name     = "AWS-AWSManagedRulesCommonRuleSet"
-    priority = 2
+    priority = 3
 
     override_action {
       none {}
@@ -79,6 +101,7 @@ resource "aws_wafv2_web_acl" "main" {
       sampled_requests_enabled   = true
     }
   }
+
   visibility_config {
     cloudwatch_metrics_enabled = true
     metric_name                = "${var.account_name}-web-acl"


### PR DESCRIPTION
# Purpose

Allows AWS WAF to `Count` connections that are found in the AWS IP Reputation List (including known bad bots, DDoS actors, and reconnaissance)

Fixes UML-3327

## Approach

Before we start blocking traffic, we should first assess how these rules will affect our traffic. Therefore, we will set the `Count` parameter until we have a fuller picture, and then later on we will begin to block these requests.

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
