### PR TITLE
Revert download and upload-artifact version upgrade

### DIFF
--- a/.github/workflows/_build-and-push.yml
+++ b/.github/workflows/_build-and-push.yml
@@ -198,7 +198,7 @@ jobs:
           (inputs.specific_path == 'all' || inputs.specific_path == matrix.svc_prefix)
 
       - name: archive test results
-        uses: actions/upload-artifact@ef09cdac3e2d3e60d8ccadda691f4f1cec5035cb # pin@v3.1.0
+        uses: actions/upload-artifact@v3 # pin@v3.1.0
         with:
           name: service-${{ matrix.svc_prefix }}
           path: build/service-${{ matrix.svc_prefix }}

--- a/.github/workflows/_build-and-push.yml
+++ b/.github/workflows/_build-and-push.yml
@@ -107,7 +107,7 @@ jobs:
           (inputs.specific_path == 'all' || inputs.specific_path == matrix.svc_prefix)
 
       - name: download artifact
-        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
+        uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         with:
           name: ${{ matrix.artifact_to_dl }}
           path: service-${{ matrix.svc_prefix }}/web/dist

--- a/.github/workflows/_build-and-push.yml
+++ b/.github/workflows/_build-and-push.yml
@@ -198,7 +198,7 @@ jobs:
           (inputs.specific_path == 'all' || inputs.specific_path == matrix.svc_prefix)
 
       - name: archive test results
-        uses: actions/upload-artifact@v3 # pin@v3.1.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # pin@v3.1.0
         with:
           name: service-${{ matrix.svc_prefix }}
           path: build/service-${{ matrix.svc_prefix }}

--- a/.github/workflows/_codecov.yml
+++ b/.github/workflows/_codecov.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@8410ad0602e1e429cee44a835ae9f77f654a6694 # pin@v3
       - name: download artifact for front tests
         id: download-artifact-front-tests
-        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
+        uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         continue-on-error: true
         with:
           name: service-front
@@ -26,7 +26,7 @@ jobs:
         if: inputs.specific_path == 'all'
       - name: download artifact for api tests
         id: download-artifact-api-tests
-        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
+        uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         continue-on-error: true
         with:
           name: service-api
@@ -34,7 +34,7 @@ jobs:
         if: inputs.specific_path == 'all'
       - name: download artifact for admin tests
         id: download-artifact-admin-tests
-        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
+        uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         continue-on-error: true
         with:
           name: service-admin

--- a/.github/workflows/_node-build.yml
+++ b/.github/workflows/_node-build.yml
@@ -33,7 +33,7 @@ jobs:
           cd service-front/web/
           npm run build
       - name: archive dist
-        uses: actions/upload-artifact@v3 # pin@v3.1.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # pin@v3.1.0
         with:
           name: dist-web
           path: service-front/web/dist/

--- a/.github/workflows/_node-build.yml
+++ b/.github/workflows/_node-build.yml
@@ -33,7 +33,7 @@ jobs:
           cd service-front/web/
           npm run build
       - name: archive dist
-        uses: actions/upload-artifact@ef09cdac3e2d3e60d8ccadda691f4f1cec5035cb # pin@v3.1.0
+        uses: actions/upload-artifact@v3 # pin@v3.1.0
         with:
           name: dist-web
           path: service-front/web/dist/

--- a/.github/workflows/_run-behat-tests.yml
+++ b/.github/workflows/_run-behat-tests.yml
@@ -86,7 +86,7 @@ jobs:
             vendor/bin/behat
 
       - name: archive failed test screenshots
-        uses: actions/upload-artifact@v3 # pin@v3.1.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # pin@v3.1.0
         with:
           name: behat-screenshots
           path: tests/smoke/failed_step_screenshots

--- a/.github/workflows/_run-behat-tests.yml
+++ b/.github/workflows/_run-behat-tests.yml
@@ -45,7 +45,7 @@ jobs:
         working-directory: tests/smoke
 
       - name: download cluster_config
-        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
+        uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         with:
           name: environment_config_file
           path: terraform/environment

--- a/.github/workflows/_run-behat-tests.yml
+++ b/.github/workflows/_run-behat-tests.yml
@@ -86,7 +86,7 @@ jobs:
             vendor/bin/behat
 
       - name: archive failed test screenshots
-        uses: actions/upload-artifact@ef09cdac3e2d3e60d8ccadda691f4f1cec5035cb # pin@v3.1.0
+        uses: actions/upload-artifact@v3 # pin@v3.1.0
         with:
           name: behat-screenshots
           path: tests/smoke/failed_step_screenshots

--- a/.github/workflows/_run-terraform.yml
+++ b/.github/workflows/_run-terraform.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: upload environment cluster config file
         if: inputs.terraform_path == 'environment'
-        uses: actions/upload-artifact@ef09cdac3e2d3e60d8ccadda691f4f1cec5035cb # pin@v3.1.0
+        uses: actions/upload-artifact@v3 # pin@v3.1.0
         with:
           name: environment_config_file
           path: terraform/environment/cluster_config.json

--- a/.github/workflows/_run-terraform.yml
+++ b/.github/workflows/_run-terraform.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: upload environment cluster config file
         if: inputs.terraform_path == 'environment'
-        uses: actions/upload-artifact@v3 # pin@v3.1.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # pin@v3.1.0
         with:
           name: environment_config_file
           path: terraform/environment/cluster_config.json

--- a/.github/workflows/_seed-database.yml
+++ b/.github/workflows/_seed-database.yml
@@ -19,7 +19,7 @@ jobs:
           role-session-name: OPGUseAnLPASeedGithubAction
 
       - name: download cluster_config
-        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
+        uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         with:
           name: environment_config_file
           path: terraform/environment

--- a/.github/workflows/_slack-notification.yml
+++ b/.github/workflows/_slack-notification.yml
@@ -36,7 +36,7 @@ jobs:
         run: pip install -r scripts/pipeline/requirements.txt
 
       - name: download cluster_config
-        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
+        uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         with:
           name: environment_config_file
           path: /tmp

--- a/.github/workflows/path-to-live.yml
+++ b/.github/workflows/path-to-live.yml
@@ -92,17 +92,17 @@ jobs:
     steps:
       - uses: actions/checkout@8410ad0602e1e429cee44a835ae9f77f654a6694 # pin@v3
       - name: download artifact for front tests
-        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
+        uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         with:
           name: service-front
           path: service-front
       - name: download artifact for api tests
-        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
+        uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         with:
           name: service-api
           path: service-api
       - name: download artifact for api tests
-        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
+        uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         with:
           name: service-admin
           path: service-admin
@@ -202,7 +202,7 @@ jobs:
         with:
           fetch-depth: '0'
       - name: download cluster_config
-        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
+        uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         with:
           name: environment_config_file
           path: terraform/environment


### PR DESCRIPTION
# Purpose

Revert upgrade to upload-artifact to fix Path to Live issues

Unticketed work

## Approach

Roll back due to https://github.com/actions/upload-artifact/issues/478

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
