### PR TITLE
UML-3092: Use max CPU rather than average for autoscaling

### DIFF
--- a/terraform/environment/region/modules/ecs_autoscaling/main.tf
+++ b/terraform/environment/region/modules/ecs_autoscaling/main.tf
@@ -77,7 +77,7 @@ resource "aws_cloudwatch_metric_alarm" "scale_up" {
       metric_name = "CPUUtilization"
       namespace   = "AWS/ECS"
       period      = "60"
-      stat        = "Average"
+      stat        = "Maximum"
 
       dimensions = {
         ServiceName = var.aws_ecs_service_name
@@ -145,7 +145,7 @@ resource "aws_cloudwatch_metric_alarm" "scale_down" {
       metric_name = "CPUUtilization"
       namespace   = "AWS/ECS"
       period      = "60"
-      stat        = "Average"
+      stat        = "Maximum"
 
       dimensions = {
         ServiceName = var.aws_ecs_service_name


### PR DESCRIPTION
# Purpose

Use Max CPU rather than average for autoscaling to allow faster autoscaling.

Fixes UML-3092

## Approach

Change metric from Average to Max


## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
