### PR TITLE
UML-3359 Add default value for gov_uk_onelogin_client_id

### DIFF
--- a/terraform/account/secretsmanager.tf
+++ b/terraform/account/secretsmanager.tf
@@ -46,6 +46,7 @@ resource "aws_secretsmanager_secret_version" "gov_uk_onelogin_client_id" {
     ignore_changes = [
       secret_string,
     ]
+  }
 }
 
 

--- a/terraform/account/secretsmanager.tf
+++ b/terraform/account/secretsmanager.tf
@@ -38,6 +38,17 @@ resource "aws_secretsmanager_secret" "gov_uk_onelogin_client_id" {
   }
 }
 
+resource "aws_secretsmanager_secret_version" "gov_uk_onelogin_client_id" {
+  secret_id     = aws_secretsmanager_secret.gov_uk_onelogin_client_id.id
+  secret_string = "DEFAULT"
+
+  lifecycle {
+    ignore_changes = [
+      secret_string,
+    ]
+}
+
+
 resource "aws_secretsmanager_secret" "notify_api_key" {
   name       = "notify-api-key"
   kms_key_id = module.secrets_manager_mrk.key_id


### PR DESCRIPTION
# Purpose

Unblock pipeline by adding a secret value to gov_uk_onelogin_client_id if it doesn't already exist.

Fixes UML-3359

## Approach

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
