### PR TITLE
UML-3351 later version of changed-files, remove potentially misleading pin

### DIFF
--- a/.github/workflows/pull-request-path.yml
+++ b/.github/workflows/pull-request-path.yml
@@ -37,24 +37,24 @@ jobs:
       short_sha:  ${{ steps.variables.outputs.short_sha }}
       specific_path: ${{ steps.variables.outputs.path }}
     steps:
-      - uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017 # pin@v3
+      - uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017 
         with:
           fetch-depth: 2
       - name: get changed files in the admin folder
         id: changed-files-admin
-        uses: tj-actions/changed-files@0f319d742554833419bdc95d68ecb50ccebcd39d
+        uses: tj-actions/changed-files@77af4bed286740ef1a6387dc4e4e4dec39f96054
         with:
           files: |
             service-admin/**
       - name: get changed files in the terraform folder
         id: changed-files-terraform
-        uses: tj-actions/changed-files@0f319d742554833419bdc95d68ecb50ccebcd39d
+        uses: tj-actions/changed-files@77af4bed286740ef1a6387dc4e4e4dec39f96054
         with:
           files: |
             terraform/**
       - name: get changed docs files in any folder
         id: changed-files-docs
-        uses: tj-actions/changed-files@0f319d742554833419bdc95d68ecb50ccebcd39d
+        uses: tj-actions/changed-files@77af4bed286740ef1a6387dc4e4e4dec39f96054
         with:
           files: |
             **/*.md

--- a/.github/workflows/workflow-deploy-ref-to-env.yml
+++ b/.github/workflows/workflow-deploy-ref-to-env.yml
@@ -53,20 +53,20 @@ jobs:
       short_sha:  ${{ steps.variables.outputs.short_sha }}
       specific_path: ${{ steps.variables.outputs.path }}
     steps:
-      - uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017 # pin@v4
+      - uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017 
         with:
           fetch-depth: 2
           ref: ${{ inputs.git_ref }}
 
       - name: get changed files in the admin folder
         id: changed-files-admin
-        uses: tj-actions/changed-files@0f319d742554833419bdc95d68ecb50ccebcd39d
+        uses: tj-actions/changed-files@77af4bed286740ef1a6387dc4e4e4dec39f96054
         with:
           files: |
             service-admin/**
       - name: get changed files in the terraform folder
         id: changed-files-terraform
-        uses: tj-actions/changed-files@0f319d742554833419bdc95d68ecb50ccebcd39d
+        uses: tj-actions/changed-files@77af4bed286740ef1a6387dc4e4e4dec39f96054
         with:
           files: |
             terraform/**


### PR DESCRIPTION

# Purpose

_later version of changed-files to non-vulnerable version, remove potentially misleading pin comments because renovate will update version without updating the pin command_


## Approach

_Update workflows_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
