### PR TITLE
UML-2981 Show system messages on use side

### DIFF
--- a/service-api/app/features/actor-dashboard.feature
+++ b/service-api/app/features/actor-dashboard.feature
@@ -33,7 +33,6 @@ Feature: The user is able to see correct information on their dashboard
     When I am on the dashboard page
     Then I cannot see the added LPA
 
-
   @integration
   Scenario: As a user I want to be able to see my other LPAs if one has errored
     Given An LPA gives an unexpected error

--- a/service-api/app/features/system-message.feature
+++ b/service-api/app/features/system-message.feature
@@ -3,7 +3,7 @@ Feature: User able to view system message
   As a user
   I want to be able to see the system message if one is set
 
-  @integration @acceptance
+  @acceptance
   Scenario: As a user I want be able to see the system message
      Given I am a user of the lpa application
      When I view a page and the system message is set

--- a/service-front/app/features/actor-dashboard.feature
+++ b/service-front/app/features/actor-dashboard.feature
@@ -54,13 +54,13 @@ Feature: The user is able to see correct information on their dashboard
     When I am on the dashboard page
     Then I am told that I have 2 LPAs in my account
 
-  @ui @integration
+  @ui
   Scenario: As a user I am shown the system message if it is set
     Given A system message is set
     When I am on the dashboard page
     Then I can see the message System Message Use English
 
-  @ui @integration
+  @ui
   Scenario: As a user I am not shown the system message if it is not set
     Given A system message is not set
     When I am on the dashboard page

--- a/service-front/app/features/actor-dashboard.feature
+++ b/service-front/app/features/actor-dashboard.feature
@@ -53,3 +53,15 @@ Feature: The user is able to see correct information on their dashboard
     Given I have added an additional LPA to my account
     When I am on the dashboard page
     Then I am told that I have 2 LPAs in my account
+
+  @ui @integration
+  Scenario: As a user I am shown the system message if it is set
+    Given A system message is set
+    When I am on the dashboard page
+    Then I can see the message System Message Use English
+
+  @ui @integration
+  Scenario: As a user I am not shown the system message if it is not set
+    Given A system message is not set
+    When I am on the dashboard page
+    Then I cannot see the message System Message Use English

--- a/service-front/app/features/context/Integration/LpaContext.php
+++ b/service-front/app/features/context/Integration/LpaContext.php
@@ -1431,8 +1431,6 @@ class LpaContext extends BaseIntegrationContext
             $this->userDob
         );
 
-
-
         Assert::assertEquals(AddLpaApiResult::ADD_LPA_SUCCESS, $response->getResponse());
     }
 

--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -48,6 +48,8 @@ class AccountContext implements Context
     private const ONE_LOGIN_SERVICE_CALLBACK           = 'OneLoginService::callback';
     private const ONE_LOGIN_SERVICE_LOGOUT             = 'OneLoginService::logout';
     private const VIEWER_CODE_SERVICE_GET_SHARE_CODES  = 'ViewerCodeService::getShareCodes';
+    private const SYSTEM_MESSAGE_SERVICE_GET_MESSAGES  = 'SystemMessageService::getMessages';
+
 
 
     /**
@@ -2271,6 +2273,14 @@ class AccountContext implements Context
                 StatusCodeInterface::STATUS_OK,
                 json_encode([]),
                 self::VIEWER_CODE_SERVICE_GET_SHARE_CODES
+            )
+        );
+
+        $this->apiFixtures->append(
+            ContextUtilities::newResponse(
+                StatusCodeInterface::STATUS_OK,
+                json_encode([]),
+                self::SYSTEM_MESSAGE_SERVICE_GET_MESSAGES
             )
         );
 

--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -1080,6 +1080,14 @@ class AccountContext implements Context
                     self::LPA_SERVICE_GET_LPAS
                 )
             );
+
+            $this->apiFixtures->append(
+                ContextUtilities::newResponse(
+                    StatusCodeInterface::STATUS_OK,
+                    json_encode([]),
+                    self::SYSTEM_MESSAGE_SERVICE_GET_MESSAGES
+                )
+            );
         } else {
             // API call for authentication
             $this->apiFixtures->append(

--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -1080,14 +1080,6 @@ class AccountContext implements Context
                     self::LPA_SERVICE_GET_LPAS
                 )
             );
-
-            $this->apiFixtures->append(
-                ContextUtilities::newResponse(
-                    StatusCodeInterface::STATUS_OK,
-                    json_encode([]),
-                    self::SYSTEM_MESSAGE_SERVICE_GET_MESSAGES
-                )
-            );
         } else {
             // API call for authentication
             $this->apiFixtures->append(

--- a/service-front/app/features/context/UI/LpaContext.php
+++ b/service-front/app/features/context/UI/LpaContext.php
@@ -22,6 +22,7 @@ use function PHPUnit\Framework\assertStringContainsString;
  * @property string $userLpaActorToken
  * @property int    $actorId
  * @property array  $lpaData
+ * @property array  $systemMessageData
  * @property string $organisation
  * @property string $accessCode
  * @property string $userFirstName
@@ -45,6 +46,8 @@ class LpaContext implements Context
     private const VIEWER_CODE_SERVICE_CANCEL_SHARE_CODE = 'ViewerCodeService::cancelShareCode';
     private const REMOVE_LPA_INVOKE                     = 'RemoveLpa::__invoke';
     private const INPSERVICE_GET_BY_ID                  = 'InstAndPrefImagesService::getImagesById';
+
+    private const SYSTEM_MESSAGE_SERVICE_GET_MESSAGES   = 'SystemMessageService::getMessages';
 
     private $dashboardLPAs;
 
@@ -400,6 +403,14 @@ class LpaContext implements Context
             }
         }
 
+        $this->apiFixtures->append(
+            ContextUtilities::newResponse(
+                StatusCodeInterface::STATUS_OK,
+                json_encode($this->systemMessageData ?? []),
+                self::SYSTEM_MESSAGE_SERVICE_GET_MESSAGES
+            )
+        );
+
         $this->ui->visit('/lpa/dashboard');
 
         $this->ui->assertResponseStatus(StatusCodeInterface::STATUS_OK);
@@ -666,6 +677,14 @@ class LpaContext implements Context
             )
         );
 
+        $this->apiFixtures->append(
+            ContextUtilities::newResponse(
+                StatusCodeInterface::STATUS_OK,
+                json_encode([]),
+                self::SYSTEM_MESSAGE_SERVICE_GET_MESSAGES
+            )
+        );
+
         $this->ui->visit('/lpa/dashboard');
 
         $this->ui->assertResponseStatus(StatusCodeInterface::STATUS_OK);
@@ -767,6 +786,14 @@ class LpaContext implements Context
             )
         );
 
+        $this->apiFixtures->append(
+            ContextUtilities::newResponse(
+                StatusCodeInterface::STATUS_OK,
+                json_encode([]),
+                self::SYSTEM_MESSAGE_SERVICE_GET_MESSAGES
+            )
+        );
+
         $this->ui->visit('/lpa/dashboard');
 
         $this->ui->assertResponseStatus(StatusCodeInterface::STATUS_OK);
@@ -795,6 +822,14 @@ class LpaContext implements Context
                 StatusCodeInterface::STATUS_OK,
                 json_encode([]),
                 self::VIEWER_CODE_SERVICE_GET_SHARE_CODES
+            )
+        );
+
+        $this->apiFixtures->append(
+            ContextUtilities::newResponse(
+                StatusCodeInterface::STATUS_OK,
+                json_encode([]),
+                self::SYSTEM_MESSAGE_SERVICE_GET_MESSAGES
             )
         );
 
@@ -839,10 +874,27 @@ class LpaContext implements Context
             )
         );
 
+        $this->apiFixtures->append(
+            ContextUtilities::newResponse(
+                StatusCodeInterface::STATUS_OK,
+                json_encode($this->systemMessageData ?? []),
+                self::SYSTEM_MESSAGE_SERVICE_GET_MESSAGES
+            )
+        );
+
         $this->ui->visit('/lpa/dashboard');
 
         $this->ui->assertPageAddress('/lpa/dashboard');
         $this->ui->assertPageContainsText($message);
+    }
+
+    /**
+     * @Then /^I cannot see the message (.*)$/
+     * <Important: This LPA has instructions or preferences>
+     */
+    public function iCanNotSeeTheMessage($message): void
+    {
+        $this->ui->assertPageNotContainsText($message);
     }
 
     /**
@@ -934,6 +986,14 @@ class LpaContext implements Context
             )
         );
 
+        $this->apiFixtures->append(
+            ContextUtilities::newResponse(
+                StatusCodeInterface::STATUS_OK,
+                json_encode([]),
+                self::SYSTEM_MESSAGE_SERVICE_GET_MESSAGES
+            )
+        );
+
         $this->ui->visit('/lpa/dashboard');
         $this->ui->assertResponseStatus(StatusCodeInterface::STATUS_OK);
 
@@ -966,6 +1026,14 @@ class LpaContext implements Context
             )
         );
 
+        $this->apiFixtures->append(
+            ContextUtilities::newResponse(
+                StatusCodeInterface::STATUS_OK,
+                json_encode([]),
+                self::SYSTEM_MESSAGE_SERVICE_GET_MESSAGES
+            )
+        );
+
         $this->ui->visit('/lpa/dashboard');
         $this->ui->assertResponseStatus(StatusCodeInterface::STATUS_OK);
 
@@ -995,6 +1063,14 @@ class LpaContext implements Context
                 StatusCodeInterface::STATUS_OK,
                 json_encode([]),
                 self::VIEWER_CODE_SERVICE_GET_SHARE_CODES
+            )
+        );
+
+        $this->apiFixtures->append(
+            ContextUtilities::newResponse(
+                StatusCodeInterface::STATUS_OK,
+                json_encode([]),
+                self::SYSTEM_MESSAGE_SERVICE_GET_MESSAGES
             )
         );
 
@@ -2709,6 +2785,14 @@ class LpaContext implements Context
             )
         );
 
+        $this->apiFixtures->append(
+            ContextUtilities::newResponse(
+                StatusCodeInterface::STATUS_OK,
+                json_encode([]),
+                self::SYSTEM_MESSAGE_SERVICE_GET_MESSAGES
+            )
+        );
+
         $this->ui->assertPageAddress('/lpa/check');
 
         $this->ui->assertPageContainsText('Is this the LPA you want to add?');
@@ -2815,6 +2899,14 @@ class LpaContext implements Context
                 StatusCodeInterface::STATUS_OK,
                 json_encode([]),
                 self::VIEWER_CODE_SERVICE_GET_SHARE_CODES
+            )
+        );
+
+        $this->apiFixtures->append(
+            ContextUtilities::newResponse(
+                StatusCodeInterface::STATUS_OK,
+                json_encode([]),
+                self::SYSTEM_MESSAGE_SERVICE_GET_MESSAGES
             )
         );
 
@@ -3082,5 +3174,26 @@ class LpaContext implements Context
     {
         $this->ui->assertPageAddress('/lpa/view-lpa');
         $this->ui->assertPageNotContainsText('Also known as');
+    }
+
+    /**
+     * @Given /^A system message is set$/
+     */
+    public function aSystemMessageIsSet(): void
+    {
+      $this->systemMessageData = [
+          'use/en'  => 'System Message Use English',
+          'use/cy'  => 'System Message Use Welsh',
+          'view/en' => 'System Message View English',
+          'view/cy' => 'System Message View Welsh'
+      ];
+    }
+
+    /**
+     * @Given /^A system message is not set$/
+     */
+    public function aSystemMessageIsNotSet(): void
+    {
+        $this->systemMessageData = [];
     }
 }

--- a/service-front/app/src/Actor/src/Handler/LpaDashboardHandler.php
+++ b/service-front/app/src/Actor/src/Handler/LpaDashboardHandler.php
@@ -9,6 +9,8 @@ use Common\Handler\Traits\User;
 use Common\Handler\UserAware;
 use Common\Service\Lpa\LpaService;
 use Common\Service\Lpa\ViewerCodeService;
+use Common\Service\SystemMessage\SystemMessageService;
+use Exception;
 use Laminas\Diactoros\Response\HtmlResponse;
 use Mezzio\Authentication\AuthenticationInterface;
 use Mezzio\Flash\FlashMessageMiddleware;
@@ -31,6 +33,7 @@ class LpaDashboardHandler extends AbstractHandler implements UserAware
         AuthenticationInterface $authenticator,
         private LpaService $lpaService,
         private ViewerCodeService $viewerCodeService,
+        private SystemMessageService $systemMessageService
     ) {
         parent::__construct($renderer, $urlHelper);
 
@@ -42,7 +45,7 @@ class LpaDashboardHandler extends AbstractHandler implements UserAware
      *
      * @param ServerRequestInterface $request
      * @return ResponseInterface
-     * @throws \Exception
+     * @throws Exception
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
@@ -67,12 +70,16 @@ class LpaDashboardHandler extends AbstractHandler implements UserAware
 
         $totalLpas = array_sum(array_map('count', $lpas->getArrayCopy()));
 
+        $systemMessages = $this->systemMessageService->getMessages();
+
         return new HtmlResponse($this->renderer->render('actor::lpa-dashboard', [
             'user'             => $user,
             'lpas'             => $lpas,
             'has_active_codes' => $hasActiveCodes,
             'flash'            => $flash,
             'total_lpas'       => $totalLpas,
+            'en_message'       => $systemMessages['use/en'] ?? null,
+            'cy_message'       => $systemMessages['use/cy'] ?? null,
         ]));
     }
 }

--- a/service-front/app/src/Actor/templates/actor/partials/service-message.html.twig
+++ b/service-front/app/src/Actor/templates/actor/partials/service-message.html.twig
@@ -9,7 +9,7 @@
 {# {% set cy_message = 'Add your Welsh message here' %} #}
 {# {% set cy_additional = 'Add your Welsh additional text here' %} #}
 
-{% if en_message is defined %}
+{% if en_message is defined and en_message != null %}
     <div class="govuk-notification-banner govuk-notification-banner--pagetop" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
         <div class="govuk-notification-banner__header">
             <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">

--- a/service-front/app/src/Common/src/ConfigProvider.php
+++ b/service-front/app/src/Common/src/ConfigProvider.php
@@ -12,6 +12,8 @@ use Aws\SecretsManager\SecretsManagerClient;
 use Common\Middleware\Session\SessionExpiryMiddleware;
 use Common\Middleware\Session\SessionExpiryMiddlewareFactory;
 use Common\Service\Cache\RedisAdapterPluginManagerDelegatorFactory;
+use Common\Service\OneLogin\SystemMessageService;
+use Common\Service\OneLogin\SystemMessageServiceFactory;
 use Gettext\Generator\GeneratorInterface;
 use Gettext\Generator\PoGenerator;
 use Gettext\Loader\LoaderInterface;
@@ -105,6 +107,7 @@ class ConfigProvider
                 KmsClient::class            => Service\Aws\KmsFactory::class,
                 SecretsManagerClient::class => Service\Aws\SecretsManagerFactory::class,
                 Client::class               => Service\ApiClient\GuzzleClientFactory::class,
+                SystemMessageService::class => SystemMessageServiceFactory::class,
 
                 // Middleware
                 SessionMiddleware::class                   => SessionMiddlewareFactory::class,

--- a/service-front/app/src/Common/src/Service/SystemMessage/SystemMessageService.php
+++ b/service-front/app/src/Common/src/Service/SystemMessage/SystemMessageService.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Service\SystemMessage;
+
+use Common\Exception\ApiException;
+use Common\Service\ApiClient\Client as ApiClient;
+
+class SystemMessageService
+{
+    public function __construct(
+        private ApiClient $apiClient,
+    ) {
+    }
+
+    /**
+     * @throws ApiException
+     */
+    public function getMessages(): array
+    {
+        return $this->apiClient->httpGet(
+            '/v1/system-message',
+        );
+    }
+}

--- a/service-front/app/src/Common/src/Service/SystemMessage/SystemMessageService.php
+++ b/service-front/app/src/Common/src/Service/SystemMessage/SystemMessageService.php
@@ -19,8 +19,12 @@ class SystemMessageService
      */
     public function getMessages(): array
     {
-        return $this->apiClient->httpGet(
-            '/v1/system-message',
-        );
+        try {
+            return $this->apiClient->httpGet(
+                '/v1/system-message',
+            );
+        } catch (ApiException $exception) {
+            return [];
+        }
     }
 }

--- a/service-front/app/src/Common/src/Service/SystemMessage/SystemMessageService.php
+++ b/service-front/app/src/Common/src/Service/SystemMessage/SystemMessageService.php
@@ -14,9 +14,6 @@ class SystemMessageService
     ) {
     }
 
-    /**
-     * @throws ApiException
-     */
     public function getMessages(): array
     {
         try {

--- a/service-front/app/src/Common/src/Service/SystemMessage/SystemMessageService.php
+++ b/service-front/app/src/Common/src/Service/SystemMessage/SystemMessageService.php
@@ -20,7 +20,7 @@ class SystemMessageService
             return $this->apiClient->httpGet(
                 '/v1/system-message',
             );
-        } catch (ApiException $exception) {
+        } catch (ApiException) {
             return [];
         }
     }

--- a/service-front/app/src/Common/src/Service/SystemMessage/SystemMessageServiceFactory.php
+++ b/service-front/app/src/Common/src/Service/SystemMessage/SystemMessageServiceFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Service\SystemMessage;
+
+use Common\Service\ApiClient\Client;
+use Psr\Container\ContainerInterface;
+
+class SystemMessageServiceFactory
+{
+    public function __invoke(ContainerInterface $container): SystemMessageService
+    {
+        return new SystemMessageService(
+            $container->get(Client::class),
+        );
+    }
+}

--- a/service-front/app/test/CommonTest/Service/SystemMessage/SystemMessageServiceFactoryTest.php
+++ b/service-front/app/test/CommonTest/Service/SystemMessage/SystemMessageServiceFactoryTest.php
@@ -32,6 +32,7 @@ class SystemMessageServiceFactoryTest extends TestCase
         $containerProphecy->get(Client::class)->willReturn($apiClientProphecy->reveal());
 
         $systemMessageServiceFactory = new SystemMessageServiceFactory();
+
         $systemMessageService = $systemMessageServiceFactory($containerProphecy->reveal());
 
         $this->assertInstanceOf(SystemMessageService::class, $systemMessageService);

--- a/service-front/app/test/CommonTest/Service/SystemMessage/SystemMessageServiceFactoryTest.php
+++ b/service-front/app/test/CommonTest/Service/SystemMessage/SystemMessageServiceFactoryTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommonTest\Service\SystemMessage;
+
+use Common\Service\ApiClient\Client;
+use Common\Service\SystemMessage\SystemMessageService;
+use Common\Service\SystemMessage\SystemMessageServiceFactory;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Exception\Prophecy\ObjectProphecyException;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Container\ContainerInterface;
+
+/**
+ * @coversDefaultClass \Common\Service\SystemMessage\SystemMessageServiceFactory
+ */
+class SystemMessageServiceFactoryTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @test
+     * @covers ::__invoke
+     * @throws ObjectProphecyException
+     */
+    public function it_will_create_an_instance(): void
+    {
+        $containerProphecy = $this->prophesize(ContainerInterface::class);
+        $apiClientProphecy = $this->prophesize(Client::class);
+
+        $containerProphecy->get(Client::class)->willReturn($apiClientProphecy->reveal());
+
+        $systemMessageServiceFactory = new SystemMessageServiceFactory();
+        $systemMessageService = $systemMessageServiceFactory($containerProphecy->reveal());
+
+        $this->assertInstanceOf(SystemMessageService::class, $systemMessageService);
+    }
+}

--- a/service-front/app/test/CommonTest/Service/SystemMessage/SystemMessageServiceTest.php
+++ b/service-front/app/test/CommonTest/Service/SystemMessage/SystemMessageServiceTest.php
@@ -7,8 +7,8 @@ namespace CommonTest\Service\SystemMessage;
 use Common\Exception\ApiException;
 use Common\Service\ApiClient\Client;
 use Common\Service\SystemMessage\SystemMessageService;
+use Exception;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Exception\Prophecy\ObjectProphecyException;
 use Prophecy\PhpUnit\ProphecyTrait;
 
 class SystemMessageServiceTest extends TestCase
@@ -17,8 +17,7 @@ class SystemMessageServiceTest extends TestCase
 
     /**
      * @test
-     * @covers ::__invoke
-     * @throws ObjectProphecyException
+     * @throws Exception
      */
     public function get_messages_calls_api(): void
     {
@@ -36,6 +35,10 @@ class SystemMessageServiceTest extends TestCase
         $this->assertEquals('Welsh', $messages['use/cy'] ?? null);
     }
 
+    /**
+     * @test
+     * @throws Exception
+     */
     public function gets_no_messages_when_api_fails(): void
     {
         $apiClientProphecy = $this->prophesize(Client::class);

--- a/service-front/app/test/CommonTest/Service/SystemMessage/SystemMessageServiceTest.php
+++ b/service-front/app/test/CommonTest/Service/SystemMessage/SystemMessageServiceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommonTest\Service\SystemMessage;
+
+use Common\Service\ApiClient\Client;
+use Common\Service\SystemMessage\SystemMessageService;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Exception\Prophecy\ObjectProphecyException;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+class SystemMessageServiceTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @test
+     * @covers ::__invoke
+     * @throws ObjectProphecyException
+     */
+    public function get_messages_calls_api(): void
+    {
+        $apiClientProphecy = $this->prophesize(Client::class);
+        $apiClientProphecy->httpGet('/v1/system-message')->shouldBeCalled()->willReturn([ 'use/en' => 'English', 'use/cy' => 'Welsh']);
+
+        $systemMessageService = new SystemMessageService($apiClientProphecy->reveal());
+
+        $messages = $systemMessageService->getMessages();
+
+        $this->assertEquals('English', $messages['use/en'] ?? null);
+        $this->assertEquals('Welsh', $messages['use/cy'] ?? null);
+    }
+}

--- a/service-front/app/test/CommonTest/Service/SystemMessage/SystemMessageServiceTest.php
+++ b/service-front/app/test/CommonTest/Service/SystemMessage/SystemMessageServiceTest.php
@@ -22,7 +22,10 @@ class SystemMessageServiceTest extends TestCase
     public function get_messages_calls_api(): void
     {
         $apiClientProphecy = $this->prophesize(Client::class);
-        $apiClientProphecy->httpGet('/v1/system-message')->shouldBeCalled()->willReturn([ 'use/en' => 'English', 'use/cy' => 'Welsh']);
+        $apiClientProphecy->httpGet('/v1/system-message')->shouldBeCalled()->willReturn([
+            'use/en' => 'English',
+            'use/cy' => 'Welsh',
+        ]);
 
         $systemMessageService = new SystemMessageService($apiClientProphecy->reveal());
 

--- a/service-front/app/test/CommonTest/Service/SystemMessage/SystemMessageServiceTest.php
+++ b/service-front/app/test/CommonTest/Service/SystemMessage/SystemMessageServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CommonTest\Service\SystemMessage;
 
+use Common\Exception\ApiException;
 use Common\Service\ApiClient\Client;
 use Common\Service\SystemMessage\SystemMessageService;
 use PHPUnit\Framework\TestCase;
@@ -33,5 +34,17 @@ class SystemMessageServiceTest extends TestCase
 
         $this->assertEquals('English', $messages['use/en'] ?? null);
         $this->assertEquals('Welsh', $messages['use/cy'] ?? null);
+    }
+
+    public function gets_no_messages_when_api_fails(): void
+    {
+        $apiClientProphecy = $this->prophesize(Client::class);
+        $apiClientProphecy->httpGet('/v1/system-message')->shouldBeCalled()->willThrow(ApiException::class);
+
+        $systemMessageService = new SystemMessageService($apiClientProphecy->reveal());
+
+        $messages = $systemMessageService->getMessages();
+
+        $this->assertEmpty($messages);
     }
 }


### PR DESCRIPTION
# Purpose

https://opgtransform.atlassian.net/browse/UML-2981

## Approach

Shows the system message on the LPA dashboard if it's set

- Adds common SystemMessageService which talks to the API to fetch messages
- Uses this in the LPA dashboard handler to obtain messages
- Uses existing system message template with messages (if set)

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
