### PR TITLE
Uml 2982 system message view

### DIFF
--- a/service-front/app/features/context/UI/ViewerContext.php
+++ b/service-front/app/features/context/UI/ViewerContext.php
@@ -21,6 +21,7 @@ use Psr\Http\Message\RequestInterface;
  * @property $lpaStoredCode
  * @property $lpaViewedBy
  * @property $imageCollectionStatus
+ * @property $systemMessageData
  */
 class ViewerContext implements Context
 {
@@ -28,6 +29,8 @@ class ViewerContext implements Context
     use ViewerContextTrait;
 
     private const LPA_SERVICE_GET_LPA_BY_CODE = 'LpaService::getLpaByCode';
+
+    private const SYSTEM_MESSAGE_SERVICE_GET_MESSAGES   = 'SystemMessageService::getMessages';
 
     /**
      * @Then /^a PDF is downloaded$/
@@ -51,7 +54,34 @@ class ViewerContext implements Context
      */
     public function iAccessTheViewerService()
     {
+        $this->apiFixtures->append(
+            ContextUtilities::newResponse(
+                StatusCodeInterface::STATUS_OK,
+                json_encode($this->systemMessageData ?? []),
+                self::SYSTEM_MESSAGE_SERVICE_GET_MESSAGES
+            )
+        );
+
         $this->ui->visit('/home');
+    }
+
+    /**
+     * @Given /^A system message is set$/
+     */
+    public function aSystemMessageIsSet()
+    {
+        $this->systemMessageData = [
+            'view/en' => 'System Message View English',
+            'view/cy' => 'System Message View Welsh',
+        ];
+    }
+
+    /**
+     * @Given /^A system message is not set$/
+     */
+    public function aSystemMessageIsNotSet()
+    {
+        $this->systemMessageData = [];
     }
 
     /**
@@ -238,6 +268,22 @@ class ViewerContext implements Context
         $this->ui->assertPageNotContainsText(
             'Cancelled on'
         );
+    }
+
+    /**
+     * @Then /^I can see the message (.*)$/
+     */
+    public function iCanSeeTheMessage($message): void
+    {
+        $this->ui->assertPageContainsText($message);
+    }
+
+    /**
+     * @Then /^I cannot see the message (.*)$/
+     */
+    public function iCanNotSeeTheMessage($message): void
+    {
+        $this->ui->assertPageNotContainsText($message);
     }
 
     /**

--- a/service-front/app/features/context/UI/ViewerContext.php
+++ b/service-front/app/features/context/UI/ViewerContext.php
@@ -387,7 +387,7 @@ class ViewerContext implements Context
         $this->ui->pressButton('Download this LPA summary');
 
         //Full lpa fetch assertions
-        $request = $this->base->mockClientHistoryContainer[2]['request'];
+        $request = $this->base->mockClientHistoryContainer[3]['request'];
         $params  = json_decode($request->getBody()->getContents(), true);
 
         Assert::assertIsArray($params);

--- a/service-front/app/features/view-lpa-using-sharecode.feature
+++ b/service-front/app/features/view-lpa-using-sharecode.feature
@@ -142,3 +142,15 @@ Feature: View an LPA via sharecode
     And I waited too long to enter the share code
     And I give a valid LPA share code when my session is timed out
     Then I have an error message informing me to try again.
+
+  @ui
+  Scenario: As a viewer I am shown the system message if it is set
+    Given A system message is set
+    When I access the viewer service
+    Then I can see the message System Message View English
+
+  @ui
+  Scenario: As a viewer I am not shown the system message if it is not set
+    Given A system message is not set
+    When I access the viewer service
+    Then I cannot see the message System Message View English

--- a/service-front/app/src/Viewer/src/Handler/EnterCodeHandler.php
+++ b/service-front/app/src/Viewer/src/Handler/EnterCodeHandler.php
@@ -8,15 +8,27 @@ use Common\Handler\AbstractHandler;
 use Common\Handler\CsrfGuardAware;
 use Common\Handler\Traits\CsrfGuard;
 use Common\Handler\Traits\Session as SessionTrait;
+use Common\Service\SystemMessage\SystemMessageService;
 use Laminas\Diactoros\Response\HtmlResponse;
+use Mezzio\Helper\UrlHelper;
+use Mezzio\Template\TemplateRendererInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
 use Viewer\Form\ShareCode;
 
 class EnterCodeHandler extends AbstractHandler implements CsrfGuardAware
 {
     use CsrfGuard;
     use SessionTrait;
+
+    public function __construct(
+        TemplateRendererInterface $renderer,
+        UrlHelper $urlHelper,
+        private SystemMessageService $systemMessageService,
+    ) {
+        parent::__construct($renderer, $urlHelper);
+    }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
@@ -37,8 +49,12 @@ class EnterCodeHandler extends AbstractHandler implements CsrfGuardAware
             }
         }
 
+        $systemMessages = $this->systemMessageService->getMessages();
+
         return new HtmlResponse($this->renderer->render('viewer::enter-code', [
-            'form' => $form,
+            'form'       => $form,
+            'en_message' => $systemMessages['view/en'] ?? null,
+            'cy_message' => $systemMessages['view/cy'] ?? null,
         ]));
     }
 }

--- a/service-front/app/src/Viewer/templates/viewer/partials/service-message.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/partials/service-message.html.twig
@@ -9,7 +9,7 @@ you have to use english to do it.
 {# {% set cy_message = 'Add your Welsh message here' %} #}
 {# {% set cy_additional = 'Add your Welsh additional text here' %} #}
 
-{% if en_message is defined %}
+{% if en_message is defined and en_message != null %}
     <div class="govuk-notification-banner govuk-notification-banner--pagetop" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
         <div class="govuk-notification-banner__header">
             <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">

--- a/service-front/app/test/ViewerTest/Handler/EnterCodeHandlerTest.php
+++ b/service-front/app/test/ViewerTest/Handler/EnterCodeHandlerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ViewerTest\Handler;
+
+use Common\Service\SystemMessage\SystemMessageService;
+use Mezzio\Csrf\CsrfGuardInterface;
+use Mezzio\Csrf\CsrfMiddleware;
+use Mezzio\Session\SessionInterface;
+use PHPUnit\Framework\Exception;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Viewer\Handler\EnterCodeHandler;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Laminas\Diactoros\Response\HtmlResponse;
+use Mezzio\Helper\UrlHelper;
+use Mezzio\Template\TemplateRendererInterface;
+
+class EnterCodeHandlerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @throws Exception
+     */
+    public function testGetRequest()
+    {
+        $rendererProphecy      = $this->prophesize(TemplateRendererInterface::class);
+        $urlHelperProphecy     = $this->prophesize(UrlHelper::class);
+        $systemMessageProphecy = $this->prophesize(SystemMessageService::class);
+        $csrfGuardProphecy     = $this->prophesize(CsrfGuardInterface::class);
+        $sessionProphecy       = $this->prophesize(SessionInterface::class);
+
+        $rendererProphecy->render('viewer::enter-code', Argument::any())
+            ->willReturn('');
+
+        $systemMessageProphecy->getMessages()->willReturn([]);
+
+        //  Set up the handler
+        $handler = new EnterCodeHandler($rendererProphecy->reveal(), $urlHelperProphecy->reveal(), $systemMessageProphecy->reveal());
+
+        $requestProphecy = $this->prophesize(ServerRequestInterface::class);
+
+        $requestProphecy->getMethod()->willReturn('GET');
+        $requestProphecy->getAttribute('session')->willReturn($sessionProphecy->reveal());
+        $requestProphecy->getAttribute(CsrfMiddleware::GUARD_ATTRIBUTE)->willReturn($csrfGuardProphecy->reveal());
+
+        $response = $handler->handle($requestProphecy->reveal());
+
+        $this->assertInstanceOf(HtmlResponse::class, $response);
+    }
+}


### PR DESCRIPTION
# Purpose
Given there is a system message in the data store for view
When i log into view
Then I will see a banner on the landing page (example attached)

AC
Show message in appropriate language on landing page

Fixes UML-2982

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
