### PR TITLE
Fix forward overly long certificate domain name.

### DIFF
--- a/terraform/account/region/certificate.tf
+++ b/terraform/account/region/certificate.tf
@@ -216,7 +216,7 @@ resource "aws_acm_certificate_validation" "certificate_validation_mock_onelogin"
 }
 
 resource "aws_acm_certificate" "certificate_mock_onelogin" {
-  domain_name       = "${local.dev_wildcard}mock-onelogin.lastingpowerofattorney.opg.service.justice.gov.uk"
+  domain_name       = "${local.dev_wildcard}mol.lastingpowerofattorney.opg.service.justice.gov.uk"
   validation_method = "DNS"
 
   provider = aws.region


### PR DESCRIPTION
# Purpose

The host given for the mock one login certificate exceeded AWS' 64 character maximum in length. Changed the name to fix.

Fixes UML-3180

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* The product team have tested these changes
