### PR TITLE
Add trim operation to return of parameter store

### DIFF
--- a/service-api/app/src/App/src/Service/SystemMessage/SystemMessage.php
+++ b/service-api/app/src/App/src/Service/SystemMessage/SystemMessage.php
@@ -44,7 +44,7 @@ class SystemMessage
         $nameToValueMap = [];
 
         foreach ($parameters as $parameter) {
-            $nameToValueMap[$this->stripPrefix($parameter['Name'])] = $parameter['Value'];
+            $nameToValueMap[$this->stripPrefix($parameter['Name'])] = trim($parameter['Value']);
         }
 
         return $nameToValueMap;

--- a/service-api/app/test/AppTest/Service/SystemMessage/SystemMessageFactoryTest.php
+++ b/service-api/app/test/AppTest/Service/SystemMessage/SystemMessageFactoryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Service\SystemMessage;
+namespace AppTest\Service\SystemMessage;
 
 use App\Service\SystemMessage\SystemMessage;
 use App\Service\SystemMessage\SystemMessageFactory;


### PR DESCRIPTION
# Purpose

_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

Fixes UML-2982, UML-3410, UML-2981

## Learning

Parameter store values must contain something, in this case we chose a single whitespace character to show that it was empty but the code failed to account for that.

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
