### PR TITLE
uml-3400-logged in redirects to dashboard

### DIFF
--- a/service-front/app/features/actor-one-login.feature
+++ b/service-front/app/features/actor-one-login.feature
@@ -51,6 +51,13 @@ Feature: Authenticate One Login
     Then I see the LPA dashboard with any LPAs that are in the account
 
   @ui @ff:allow_gov_one_login:true
+  Scenario: I am redirected to the dashboard when I am signed in and visit the homepage
+    Given I have logged in to one login in English
+    When I have an email address that matches a local account
+    When I visit the homepage
+    Then I am redirected to the LPA dashboard page
+
+  @ui @ff:allow_gov_one_login:true
   Scenario: I am redirected to an empty dashboard when local account does not exist
     Given I have logged in to one login in English
     When I have an email address that does not match a local account

--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -371,8 +371,6 @@ class AccountContext implements Context
      */
     public function iVisitTheHomepage(): void
     {
-        $this->iDoFollowRedirects();
-
         $this->ui->visit('/home');
     }
 

--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -367,6 +367,24 @@ class AccountContext implements Context
     }
 
     /**
+     * @When /^I visit the homepage$/
+     */
+    public function iVisitTheHomepage(): void
+    {
+        $this->iDoFollowRedirects();
+
+        $this->ui->visit('/home');
+    }
+
+    /**
+     * @Then /^I am redirected to the LPA dashboard page$/
+     */
+    public function iAmRedirectedToTheDashboardPage(): void
+    {
+        $this->ui->assertPageAddress('/lpa/dashboard');
+    }
+
+    /**
      * @Given /^I am signed in$/
      */
     public function iAmSignedIn(): void


### PR DESCRIPTION
# Purpose

Currently, when logged in, accessing the /home path will show the button to login via One Login. This is potentially not desirable as it may give the impression that a user is not logged in when they are.

The /home url should automatically direct to /lpa/dashboard when you are logged in to remove this potential confusion.

AC
Add behat UI test to ensure the redirect occurs as intended.

Fixes UML-3400

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
