### PR TITLE
UML-3426: stop task desired count reset on deploy

### DIFF
--- a/terraform/environment/region/api_ecs.tf
+++ b/terraform/environment/region/api_ecs.tf
@@ -37,6 +37,9 @@ resource "aws_ecs_service" "api" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [
+      desired_count
+    ]
   }
 
   provider = aws.region

--- a/terraform/environment/region/pdf_ecs.tf
+++ b/terraform/environment/region/pdf_ecs.tf
@@ -36,6 +36,9 @@ resource "aws_ecs_service" "pdf" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [
+      desired_count
+    ]
   }
 
   provider = aws.region

--- a/terraform/environment/region/use_ecs.tf
+++ b/terraform/environment/region/use_ecs.tf
@@ -38,6 +38,9 @@ resource "aws_ecs_service" "use" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [
+      desired_count
+    ]
   }
 
   provider = aws.region

--- a/terraform/environment/region/viewer_ecs.tf
+++ b/terraform/environment/region/viewer_ecs.tf
@@ -38,6 +38,9 @@ resource "aws_ecs_service" "viewer" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [
+      desired_count
+    ]
   }
 
   provider = aws.region


### PR DESCRIPTION
# Purpose

Currently, every deploy we do resets the `desired_count` of our ECS tasks to the default, whether or not there's increased load on the service.

Fixes UML-3426

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
