### PR TITLE
Uml 3439 enable opcache

### DIFF
--- a/service-api/app/config/autoload/mezzio.global.php
+++ b/service-api/app/config/autoload/mezzio.global.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Elie\PHPDI\Config\ConfigInterface;
 use Laminas\ConfigAggregator\ConfigAggregator;
 
 return [
@@ -9,7 +10,8 @@ return [
     // directive, to disable configuration caching. Toggling development mode
     // will also disable it by default; clear the configuration cache using
     // `composer clear-config-cache`.
-    ConfigAggregator::ENABLE_CACHE => true,
+    ConfigAggregator::ENABLE_CACHE           => true,
+    ConfigInterface::ENABLE_CACHE_DEFINITION => true,
 
     // Enable debugging; typically used to provide debugging information within templates.
     'debug' => false,

--- a/service-api/app/config/development.config.php.dist
+++ b/service-api/app/config/development.config.php.dist
@@ -21,10 +21,12 @@
  */
 
 declare(strict_types=1);
-
+ 
+use Elie\PHPDI\Config\ConfigInterface;
 use Laminas\ConfigAggregator\ConfigAggregator;
 
 return [
-    'debug' => true,
-    ConfigAggregator::ENABLE_CACHE => false,
+    'debug'                                  => true,
+    ConfigAggregator::ENABLE_CACHE           => false,
+    ConfigInterface::ENABLE_CACHE_DEFINITION => true,
 ];

--- a/service-api/app/config/development.config.php.dist
+++ b/service-api/app/config/development.config.php.dist
@@ -28,5 +28,5 @@ use Laminas\ConfigAggregator\ConfigAggregator;
 return [
     'debug'                                  => true,
     ConfigAggregator::ENABLE_CACHE           => false,
-    ConfigInterface::ENABLE_CACHE_DEFINITION => true,
+    ConfigInterface::ENABLE_CACHE_DEFINITION => false,
 ];

--- a/service-api/app/features/bootstrap/config.php
+++ b/service-api/app/features/bootstrap/config.php
@@ -2,34 +2,38 @@
 
 declare(strict_types=1);
 
+use App\Service\Log\RequestTracingLogProcessorFactory;
+use Aws\Sdk;
+use BehatTest\Common\Service\Aws\SdkFactory;
+use BehatTest\GuzzleHttp\TestClientFactory as TestGuzzleClientFactory;
+use BehatTest\Http\Adapter\Guzzle6\TestClientFactory;
+use Elie\PHPDI\Config\ConfigInterface;
+use GuzzleHttp\Client as GuzzleClient;
+use Http\Adapter\Guzzle6\Client;
 use Laminas\ConfigAggregator\ConfigAggregator;
 
 return [
-    'debug' => true,
-    ConfigAggregator::ENABLE_CACHE => false,
-
-    'dependencies' => [
+    'debug'                                  => true,
+    ConfigAggregator::ENABLE_CACHE           => false,
+    ConfigInterface::ENABLE_CACHE_DEFINITION => false,
+    'dependencies'                           => [
         'factories' => [
-            Http\Adapter\Guzzle6\Client::class => BehatTest\Http\Adapter\Guzzle6\TestClientFactory::class,
-            GuzzleHttp\Client::class => BehatTest\GuzzleHttp\TestClientFactory::class,
-
-            Aws\Sdk::class => BehatTest\Common\Service\Aws\SdkFactory::class,
+            Client::class       => TestClientFactory::class,
+            GuzzleClient::class => TestGuzzleClientFactory::class,
+            Sdk::class          => SdkFactory::class,
         ],
     ],
-
-    'aws' => [
-        'region' => getenv('AWS_REGION') ?: 'eu-west-1',
-        'version' => 'latest',
-
+    'aws'                                    => [
+        'region'   => getenv('AWS_REGION') ?: 'eu-west-1',
+        'version'  => 'latest',
         'DynamoDb' => [
             'endpoint' => 'https://dynamodb',
         ],
     ],
-
-    'monolog' => [
-        'handlers' => [
+    'monolog'                                => [
+        'handlers'   => [
             'default' => [ // default configuration in normal operation
-                'type' => 'test',
+                'type'       => 'test',
                 'processors' => [
                     'psrLogProcessor',
                     'requestTracingProcessor',
@@ -37,45 +41,41 @@ return [
             ],
         ],
         'processors' => [
-            'psrLogProcessor' => [
-                'type' => 'psrLogMessage',
+            'psrLogProcessor'         => [
+                'type'    => 'psrLogMessage',
                 'options' => [], // No options
             ],
             'requestTracingProcessor' => [
-                'type' => \App\Service\Log\RequestTracingLogProcessorFactory::class,
+                'type'    => RequestTracingLogProcessorFactory::class,
                 'options' => [], // No options
             ],
         ],
     ],
-
-    'repositories' => [
+    'repositories'                           => [
         'dynamodb' => [
-            'actor-codes-table' => 'actor-codes',
-            'actor-users-table' => 'actor-users',
-            'viewer-codes-table' => 'viewer-codes',
+            'actor-codes-table'     => 'actor-codes',
+            'actor-users-table'     => 'actor-users',
+            'viewer-codes-table'    => 'viewer-codes',
             'viewer-activity-table' => 'viewer-activity',
-            'user-lpa-actor-map' => 'user-actor-lpa-map',
+            'user-lpa-actor-map'    => 'user-actor-lpa-map',
         ],
     ],
-
-    'sirius_api' => [
+    'sirius_api'                             => [
         'endpoint' => 'http://api-gateway-pact-mock',
     ],
-
-    'codes_api' => [
-        'endpoint' => 'http://lpa-codes-pact-mock',
+    'codes_api'                              => [
+        'endpoint'          => 'http://lpa-codes-pact-mock',
         'static_auth_token' => getenv('LPA_CODES_STATIC_AUTH_TOKEN') ?: null,
     ],
-
-    'iap_images_api' => [
+    'iap_images_api'                         => [
         'endpoint' => 'http://iap-images-mock',
     ],
-
-    'one_login'      => [
+    'one_login'                              => [
         'client_id'       => 'client-id',
         'discovery_url'   => 'http://one-login-mock/.well-known/openid-configuration',
         'identity_issuer' => 'http://identity.one-login-mock/',
     ],
-
-    'feature_flags' => [],
+    'feature_flags'                          => [
+        'allow_gov_one_login' => true,
+    ],
 ];

--- a/service-api/app/features/bootstrap/container.acceptance.php
+++ b/service-api/app/features/bootstrap/container.acceptance.php
@@ -12,7 +12,7 @@ $aggregator = new ConfigAggregator(
         new PhpFileProvider(realpath(__DIR__) . '/../../config/config.php'),
 
         // Load development config if it exists
-        new PhpFileProvider(realpath(__DIR__) . '/config.php')
+        new PhpFileProvider(realpath(__DIR__) . '/config.php'),
     ]
 );
 

--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -9,7 +9,7 @@ ENV OPG_PHP_POOL_CHILDREN_MAX="25"
 
 RUN set -xe \
   && apk add --update --no-cache fcgi \
-  && install-php-extensions apcu gmp \
+  && install-php-extensions apcu gmp opcache \
   && rm /usr/bin/install-php-extensions
 
 COPY service-api/docker/app/app-php.ini /usr/local/etc/php/conf.d/

--- a/service-api/docker/app/app-php.development.ini
+++ b/service-api/docker/app/app-php.development.ini
@@ -2,3 +2,8 @@ log_errors = On
 expose_php = On
 display_errors = stderr
 error_reporting = E_ALL
+
+opcache.memory_consumption=128
+opcache.interned_strings_buffer=8
+opcache.max_accelerated_files=4000
+opcache.revalidate_freq=0

--- a/service-api/docker/app/app-php.ini
+++ b/service-api/docker/app/app-php.ini
@@ -1,3 +1,8 @@
 log_errors = On
 expose_php = Off
 display_errors = Off
+
+opcache.memory_consumption=128
+opcache.interned_strings_buffer=8
+opcache.max_accelerated_files=4000
+opcache.validate_timestamps=false

--- a/service-front/app/config/autoload/mezzio.global.php
+++ b/service-front/app/config/autoload/mezzio.global.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Elie\PHPDI\Config\ConfigInterface;
 use Laminas\ConfigAggregator\ConfigAggregator;
 
 return [
@@ -9,7 +10,8 @@ return [
     // directive, to disable configuration caching. Toggling development mode
     // will also disable it by default; clear the configuration cache using
     // `composer clear-config-cache`.
-    ConfigAggregator::ENABLE_CACHE => true,
+    ConfigAggregator::ENABLE_CACHE           => true,
+    ConfigInterface::ENABLE_CACHE_DEFINITION => true,
 
     // Enable debugging; typically used to provide debugging information within templates.
     'debug'  => false,

--- a/service-front/app/config/development.config.php.dist
+++ b/service-front/app/config/development.config.php.dist
@@ -1,6 +1,5 @@
 <?php
-
-/**
+ /**
  * File required to allow enablement of development mode.
  *
  * For use with the laminas-development-mode tool.
@@ -22,10 +21,12 @@
  */
 
 declare(strict_types=1);
-
+ 
+use Elie\PHPDI\Config\ConfigInterface;
 use Laminas\ConfigAggregator\ConfigAggregator;
-
+ 
 return [
-    'debug'                        => true,
-    ConfigAggregator::ENABLE_CACHE => false,
+    'debug'                                  => true,
+    ConfigAggregator::ENABLE_CACHE           => false,
+    ConfigInterface::ENABLE_CACHE_DEFINITION => true,
 ];

--- a/service-front/app/config/development.config.php.dist
+++ b/service-front/app/config/development.config.php.dist
@@ -28,5 +28,5 @@ use Laminas\ConfigAggregator\ConfigAggregator;
 return [
     'debug'                                  => true,
     ConfigAggregator::ENABLE_CACHE           => false,
-    ConfigInterface::ENABLE_CACHE_DEFINITION => true,
+    ConfigInterface::ENABLE_CACHE_DEFINITION => false,
 ];

--- a/service-front/app/features/bootstrap/behat.config.php
+++ b/service-front/app/features/bootstrap/behat.config.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 use Aws\Sdk;
 use BehatTest\Common\Service\Aws\SdkFactory;
 use BehatTest\Http\Adapter\Guzzle6\TestClientFactory;
+use Common\Middleware\ErrorHandling\GoneHandler;
+use Common\Middleware\ErrorHandling\GoneHandlerFactory;
 use Common\Service\Log\RequestTracingLogProcessorFactory;
+use Elie\PHPDI\Config\ConfigInterface;
 use Http\Adapter\Guzzle6\Client;
 use Laminas\Cache\Storage\Adapter\Memory;
 use Laminas\ConfigAggregator\ConfigAggregator;
@@ -14,37 +17,38 @@ use Mezzio\Container\ErrorResponseGeneratorFactory;
 use Mezzio\Middleware\ErrorResponseGenerator;
 
 return [
-    ConfigAggregator::ENABLE_CACHE => false,
-    'debug'                        => false,
-    'dependencies'                 => [
+    ConfigAggregator::ENABLE_CACHE           => false,
+    ConfigInterface::ENABLE_CACHE_DEFINITION => false,
+    'debug'                                  => false,
+    'dependencies'                           => [
         'factories' => [
-            Client::class                                       => TestClientFactory::class,
-            Sdk::class                                          => SdkFactory::class,
-            ErrorResponseGenerator::class                       => ErrorResponseGeneratorFactory::class,
-            \Common\Middleware\ErrorHandling\GoneHandler::class => \Common\Middleware\ErrorHandling\GoneHandlerFactory::class
+            Client::class                 => TestClientFactory::class,
+            Sdk::class                    => SdkFactory::class,
+            ErrorResponseGenerator::class => ErrorResponseGeneratorFactory::class,
+            GoneHandler::class            => GoneHandlerFactory::class,
         ],
     ],
-    'api'                          => [
+    'api'                                    => [
         'uri' => 'http://localhost',
     ],
-    'pdf'                          => [
+    'pdf'                                    => [
         'uri' => 'http://pdf-service',
     ],
-    'aws'                          => [
+    'aws'                                    => [
         //'debug'   => true,
     ],
-    'feature_flags'                => [
+    'feature_flags'                          => [
         'delete_lpa_feature'                                         => true,
         'dont_send_lpas_registered_after_sep_2019_to_cleansing_team' => true,
         'instructions_and_preferences'                               => true,
         'allow_gov_one_login'                                        => true,
     ],
-    'notify'                       => [
+    'notify'                                 => [
         'api' => [
             'key' => 'not_a_real_key-22996155-4e04-42d0-8d1a-d1d3998e2149-be30242e-049d-4039-b43e-14aa8a6a76a4',
         ],
     ],
-    'monolog'                      => [
+    'monolog'                                => [
         'handlers'   => [
             'default' => [ // default configuration in normal operation
                 'type'       => 'test',
@@ -65,14 +69,14 @@ return [
             ],
         ],
     ],
-    'session'                      => [
+    'session'                                => [
         'key'           => [
             // KMS alias to use for data key generation.
             'alias' => 'alias/viewer-sessions-cmk-alias',
         ],
         'cookie_secure' => true,
     ],
-    'ratelimits'                   => [
+    'ratelimits'                             => [
         'viewer_code_failure' => [
             'type'    => 'keyed',
             'storage' => [
@@ -125,8 +129,8 @@ return [
             ],
         ],
     ],
-    'twig'                         => [
+    'twig'                                   => [
         'strict_variables' => true,
     ],
-    'whoops'                       => new MergeRemoveKey(),
+    'whoops'                                 => new MergeRemoveKey(),
 ];

--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -9,7 +9,7 @@ COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr
 
 RUN set -xe \
   && apk add --update --no-cache icu gettext fcgi \
-  && install-php-extensions apcu redis-^5 intl gettext \
+  && install-php-extensions apcu redis-^5 intl gettext opcache \
   && rm /usr/bin/install-php-extensions
 
 COPY service-front/docker/app/app-php.ini /usr/local/etc/php/conf.d/

--- a/service-front/docker/app/app-php-development.ini
+++ b/service-front/docker/app/app-php-development.ini
@@ -1,4 +1,10 @@
 log_errors = On
-expose_php = Off
+expose_php = On
 display_errors = stderr
 error_reporting = E_ALL
+
+opcache.memory_consumption=128
+opcache.interned_strings_buffer=8
+opcache.max_accelerated_files=4000
+opcache.revalidate_freq=0
+

--- a/service-front/docker/app/app-php.ini
+++ b/service-front/docker/app/app-php.ini
@@ -1,3 +1,8 @@
 log_errors = On
 expose_php = Off
 display_errors = Off
+
+opcache.memory_consumption=128
+opcache.interned_strings_buffer=8
+opcache.max_accelerated_files=4000
+opcache.validate_timestamps=false


### PR DESCRIPTION
# Purpose

Enables opcache in PHP to improve application resource usage and speed. Also enable the DI container cache.

Fixes UML-3439

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [x] The product team have tested these changes
