### PR TITLE
uml-3286 Ensure same version of PDF service is deployed through pipeline

### DIFF
--- a/docker-compose.dependencies.yml
+++ b/docker-compose.dependencies.yml
@@ -96,7 +96,7 @@ services:
   # PDF Generator
   service-pdf:
     container_name: service-pdf
-    image: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/pdf_service:latest
+    image: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/pdf_service:v1.355.2
     ports:
       - 9004:80
 

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -50,7 +50,7 @@
       "load_balancer_deletion_protection_enabled": false,
       "notify_key_secret_name": "notify-api-key",
       "associate_alb_with_waf_web_acl_enabled": false,
-      "pdf_container_version": "latest",
+      "pdf_container_version": "v1.355.2",
       "deploy_opentelemetry_sidecar": false,
       "fargate_spot": true,
       "application_flags": {
@@ -147,7 +147,7 @@
       "load_balancer_deletion_protection_enabled": false,
       "notify_key_secret_name": "notify-api-key-demo",
       "associate_alb_with_waf_web_acl_enabled": true,
-      "pdf_container_version": "latest",
+      "pdf_container_version": "v1.355.2",
       "deploy_opentelemetry_sidecar": false,
       "fargate_spot": false,
       "application_flags": {
@@ -244,7 +244,7 @@
       "load_balancer_deletion_protection_enabled": false,
       "notify_key_secret_name": "notify-api-key-demo",
       "associate_alb_with_waf_web_acl_enabled": false,
-      "pdf_container_version": "latest",
+      "pdf_container_version": "v1.355.2",
       "deploy_opentelemetry_sidecar": false,
       "fargate_spot": false,
       "application_flags": {
@@ -341,7 +341,7 @@
       "load_balancer_deletion_protection_enabled": true,
       "notify_key_secret_name": "notify-api-key",
       "associate_alb_with_waf_web_acl_enabled": true,
-      "pdf_container_version": "latest",
+      "pdf_container_version": "v1.355.2",
       "deploy_opentelemetry_sidecar": false,
       "fargate_spot": false,
       "application_flags": {
@@ -438,7 +438,7 @@
       "load_balancer_deletion_protection_enabled": true,
       "notify_key_secret_name": "notify-api-key",
       "associate_alb_with_waf_web_acl_enabled": true,
-      "pdf_container_version": "latest",
+      "pdf_container_version": "v1.355.2",
       "deploy_opentelemetry_sidecar": false,
       "fargate_spot": false,
       "application_flags": {


### PR DESCRIPTION
# Purpose

When deploying an environment, Use an LPA always [deploys the latest version](https://github.com/ministryofjustice/opg-use-an-lpa/blob/494b5e13fe6ec3830edebb3c77cab39c9c19b8b0/terraform/environment/terraform.tfvars.json#L313) of the PDF service. This could lead to releasing untested code, as the PDF service may update between deployments. For example, the following timeline could occur:

Preproduction deploys the latest version of the PDF service, v10.0.0

Preproduction runs smoke tests to check the deployment, ensuring v10.0.0 works

The PDF service updates to v11.0.0

Production deploys the now-latest version of the PDF service, v11.0.0

PDF generation now breaks in production, even though the pipeline passed to this point

Instead, the deployment pipeline should ensure that the same version of the PDF service is deployed to each environment.

This could be done by tracking the version deployed during deployment, or by hard-coding the version into Terraform to be updated by Renovate or similar.

Acceptance criteria: 

pin to latest version
Fixes UML-3286

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added tests to prove my work

