### PR TITLE
Add redirect url for your-details to go to settings

### DIFF
--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -137,6 +137,9 @@ server {
 
     # Comply with https://ministryofjustice.github.io/security-guidance/contact/implement-security-txt/#implementing-securitytxt
     rewrite ^/.well-known/security.txt$ https://security-guidance.service.justice.gov.uk/.well-known/security.txt permanent;
+
+    # UML-3504 - Issue with email containing wrong url
+    rewrite ^/your-details$ {{ getv "/web/domain" "http://localhost" }}/settings redirect;
 }
 
 # this block is needed, along with the /_csp location defined above, to allow the


### PR DESCRIPTION
# Purpose
Adds a temporary redirect into the nginx configuration to point our incorrect email urls users to the right place.

Fixes UML-3504

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
