### PR TITLE
Add additional output to one login error states including event codes.

### DIFF
--- a/service-front/app/src/Common/src/Service/Log/EventCodes.php
+++ b/service-front/app/src/Common/src/Service/Log/EventCodes.php
@@ -81,6 +81,16 @@ class EventCodes
     public const ADD_LPA_SUCCESS = 'ADD_LPA_SUCCESS';
 
     /**
+     * GOVUK One Login is returning that an error has occurred
+     */
+    public const AUTH_ONELOGIN_ERROR = 'AUTH_ONELOGIN_ERROR';
+
+    /**
+     * GOVUK One Login is returning that it is unavailable
+     */
+    public const AUTH_ONELOGIN_NOT_AVAILABLE = 'AUTH_ONELOGIN_NOT_AVAILABLE';
+
+    /**
      * Lpa summary has been downloaded
      */
     public const DOWNLOAD_SUMMARY = 'DOWNLOAD_SUMMARY';

--- a/terraform/environment/region/cloudwatch_metrics.tf
+++ b/terraform/environment/region/cloudwatch_metrics.tf
@@ -49,6 +49,8 @@ locals {
     "event_code.ACTIVATION_KEY_REQUEST_REPLACEMENT_ATTORNEY",
     "event_code.AUTH_ONELOGIN_ACCOUNT_MIGRATED",
     "event_code.AUTH_ONELOGIN_ACCOUNT_CREATED",
+    "event_code.AUTH_ONELOGIN_ERROR",
+    "event_code.AUTH_ONELOGIN_NOT_AVAILABLE",
   ]
 }
 


### PR DESCRIPTION
# Purpose

Ensures our logging around One Login failures is robust and that we're attaching event codes to things. Additionally 

## Approach

Add error code to logged output. New event_codes and associated metrics in cloudwatch.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* The product team have tested these changes
