### PR TITLE
UML-3427 updated renovate config to split PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -108,9 +108,9 @@
       "matchManagers": ["composer"],
       "matchPackageNames": ["aws/aws-sdk-php"],
       "schedule": [
-        "after 6am and before 9am on Monday"
+        "after 6am and before 9am every weekday"
       ],
-      "limit": 2,
+      "limit": 1,
       "automerge": false
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -107,10 +107,7 @@
       "matchUpdateTypes": ["minor", "patch"],
       "matchManagers": ["composer"],
       "matchPackageNames": ["aws/aws-sdk-php"],
-      "schedule": [
-        "after 6am and before 9am every weekday"
-      ],
-      "limit": 1,
+      "extends": ["schedule:monthly"],
       "automerge": false
     },
     {
@@ -158,8 +155,7 @@
         "Renovate"
     ],
     "prCreation": "immediate",
-    "rangeStrategy": "pin",
-    "prPriority": 1
+    "rangeStrategy": "pin"
   },
   "branchConcurrentLimit": 5,
   "prConcurrentLimit": 1,
@@ -175,7 +171,6 @@
     "rangeStrategy": "pin",
     "commitMessagePrefix": "[SECURITY]",
     "branchTopic": "{{{datasource}}}-{{{depName}}}-vulnerability",
-    "prCreation": "immediate",
-    "prPriority": 5
+    "prCreation": "immediate"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -69,7 +69,7 @@
       "labels": ["Dependencies", "Renovate", "Docker"],
       "groupName": "Docker Updates",
       "matchUpdateTypes": ["minor", "patch"],
-      "matchManagers": ["dockerfile", "docker-compose", "composer"],
+      "matchManagers": ["dockerfile", "docker-compose"],
       "automerge": false
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,9 @@
       ]
     },
     {
+      "description": [
+        "Github Actions: bundle all updates together"
+      ],
       "groupName": "GitHub Actions",
       "matchPackagePatterns": [
         "actions/*"
@@ -55,6 +58,97 @@
       "schedule": [
         "after 6am and before 9am on Monday"
       ],
+      "stabilityDays": 3,
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": [
+        "Docker: group all updates together"
+      ],
+      "labels": ["Dependencies", "Renovate", "Docker"],
+      "groupName": "Docker Updates",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchManagers": ["dockerfile", "docker-compose", "composer"],
+      "automerge": false
+    },
+    {
+      "description": [
+        "Golang: group all updates together"
+      ],
+      "labels": ["Dependencies", "Renovate", "Golang"],
+      "groupName": "Golang Updates",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchManagers": ["gomod"],
+      "automerge": false
+    },
+    {
+      "description": [
+        "npm minor and patch updates (stable for 3 days)",
+        "These might be automerged once we're comfortable with Renovate"
+      ],
+      "automerge": false,
+      "groupName": "minor and patch updates (npm)",
+      "groupSlug": "all-minor-patch-updates-npm",
+      "labels": ["Dependencies", "Renovate", "nodejs"],
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchFiles": [
+        "package.json",
+        "service-front/package.json"
+      ],
+      "prCreation": "immediate",
+      "prPriority": 4,
+      "stabilityDays": 3
+    },
+    {
+      "description": ["AWS SDK"],
+      "labels": ["Renovate", "AWS SDK"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchManagers": ["composer"],
+      "matchPackageNames": ["aws/aws-sdk-php"],
+      "schedule": [
+        "after 6am and before 9am on Monday"
+      ],
+      "limit": 2,
+      "automerge": false
+    },
+    {
+      "description": [
+        "front composer minor and patch updates (PHP 8.2, stable for 3 days)",
+        "These might be automerged once we're comfortable with Renovate"
+      ],
+      "automerge": false,
+      "groupName": "front minor and patch updates (PHP 8.2)",
+      "groupSlug": "front-minor-patch-updates-php82",
+      "labels": ["Dependencies", "Renovate", "PHP 8.2"],
+      "matchManagers": ["composer"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "excludePackageNames": ["php"],
+      "matchFiles": [
+        "service-front/composer.json"
+      ],
+      "prCreation": "immediate",
+      "prPriority": 4,
+      "stabilityDays": 3
+    },
+    {
+      "description": [
+        "api composer minor and patch updates (PHP 8.2, stable for 3 days)",
+        "These might be automerged once we're comfortable with Renovate"
+      ],
+      "automerge": false,
+      "groupName": "api minor and patch updates (PHP 8.2)",
+      "groupSlug": "api-minor-patch-updates-php82",
+      "labels": ["Dependencies", "Renovate", "PHP 8.2"],
+      "matchManagers": ["composer"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "excludePackageNames": ["php"],
+      "matchFiles": [
+        "service-api/composer.json"
+      ],
+      "prCreation": "immediate",
+      "prPriority": 4,
       "stabilityDays": 3
     }
   ],


### PR DESCRIPTION
# Purpose

_Update renovate config to be more manageable on UMLPA_

## Approach

_updated config to split renovate PRs_

## Learning

_renovate docs - https://docs.renovatebot.com/configuration-options/_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
