### PR TITLE
Ensure smoke tests work with production one login

### DIFF
--- a/tests/smoke/context/OneLoginImplementation.php
+++ b/tests/smoke/context/OneLoginImplementation.php
@@ -8,4 +8,5 @@ enum OneLoginImplementation
 {
     case Mock;
     case Integration;
+    case Production;
 }


### PR DESCRIPTION
# Purpose
Currently the smoke tests do not function if the production one login environment is configured... which we need to do in our pre-production environment.

## Approach

Extra checks around what page we're on and what would be the appropriate step to take.

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* The product team have tested these changes
