### PR TITLE
Add cloudwatch data protection for app logs

### DIFF
--- a/terraform/environment/region/cloudwatch_data_protection.tf
+++ b/terraform/environment/region/cloudwatch_data_protection.tf
@@ -1,31 +1,31 @@
 resource "aws_cloudwatch_log_data_protection_policy" "production_application_logs" {
-  
+
   log_group_name = "${var.environment_name}_application_logs"
 
   policy_document = jsonencode({
     Name    = "data_protection_${var.environment_name}_application_logs"
     Version = "2021-06-01"
 
-    "Statement": [
+    "Statement" : [
       {
-        "Sid": "audit-policy",
-        "DataIdentifier": [
+        "Sid" : "audit-policy",
+        "DataIdentifier" : [
           "arn:aws:dataprotection::aws:data-identifier/EmailAddress"
         ],
-        "Operation": {
-          "Audit": {
-            "FindingsDestination": {}
+        "Operation" : {
+          "Audit" : {
+            "FindingsDestination" : {}
           }
         }
       },
       {
-        "Sid": "redact-policy",
-        "DataIdentifier": [
+        "Sid" : "redact-policy",
+        "DataIdentifier" : [
           "arn:aws:dataprotection::aws:data-identifier/EmailAddress"
         ],
-        "Operation": {
-          "Deidentify": {
-            "MaskConfig": {}
+        "Operation" : {
+          "Deidentify" : {
+            "MaskConfig" : {}
           }
         }
       }

--- a/terraform/environment/region/cloudwatch_data_protection.tf
+++ b/terraform/environment/region/cloudwatch_data_protection.tf
@@ -1,4 +1,4 @@
-resource "aws_cloudwatch_log_data_protection_policy" "production_application_logs" {
+resource "aws_cloudwatch_log_data_protection_policy" "application_logs" {
 
   log_group_name = "${var.environment_name}_application_logs"
 

--- a/terraform/environment/region/cloudwatch_data_protection.tf
+++ b/terraform/environment/region/cloudwatch_data_protection.tf
@@ -1,0 +1,34 @@
+resource "aws_cloudwatch_log_data_protection_policy" "production_application_logs" {
+  
+  log_group_name = "${var.environment_name}_application_logs"
+
+  policy_document = jsonencode({
+    Name    = "data_protection_${var.environment_name}_application_logs"
+    Version = "2021-06-01"
+
+    "Statement": [
+      {
+        "Sid": "audit-policy",
+        "DataIdentifier": [
+          "arn:aws:dataprotection::aws:data-identifier/EmailAddress"
+        ],
+        "Operation": {
+          "Audit": {
+            "FindingsDestination": {}
+          }
+        }
+      },
+      {
+        "Sid": "redact-policy",
+        "DataIdentifier": [
+          "arn:aws:dataprotection::aws:data-identifier/EmailAddress"
+        ],
+        "Operation": {
+          "Deidentify": {
+            "MaskConfig": {}
+          }
+        }
+      }
+    ]
+  })
+}

--- a/tests/smoke/context/OneLoginImplementation.php
+++ b/tests/smoke/context/OneLoginImplementation.php
@@ -8,4 +8,5 @@ enum OneLoginImplementation
 {
     case Mock;
     case Integration;
+    case Production;
 }


### PR DESCRIPTION
# Purpose

Adds a data protection policy for use, which masks email address in our cloudwatch logs

Fixes UML-3251

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
