### PR TITLE
Ensure null bytes are not passed to bcrypt.

### DIFF
--- a/service-api/app/src/App/src/Service/User/UserService.php
+++ b/service-api/app/src/App/src/Service/User/UserService.php
@@ -94,7 +94,7 @@ class UserService
         $id = $this->generateUniqueId();
 
         // If a password is not supplied, make a random one.
-        $password = $data['password'] ?? new HiddenString(($this->byteGenerator)(32));
+        $password = $data['password'] ?? new HiddenString(bin2hex(($this->byteGenerator)(32)));
 
         //  An unactivated user account can only exist for 24 hours before it is deleted
         $activationToken = $this->getLinkToken();


### PR DESCRIPTION
# Purpose

Found an error in testing when logging in. Fixes that.

`"Bcrypt password must not contain null character on line 494 in /app/src/App/src/DataAccess/DynamoDb/ActorUsers.php"`

## Approach

Encode random bytes with bin2hex to remove null characters.

## Learning

Security change in PHP introduced in 8.3.5/8.2.18/8.1.28 means null characters are not allowed.

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* The product team have tested these changes
