### PR TITLE
Update Data Protection Policy with HTTPGetEmailAddress Identifier

### DIFF
--- a/terraform/environment/region/cloudwatch_data_protection_policy.tf
+++ b/terraform/environment/region/cloudwatch_data_protection_policy.tf
@@ -6,11 +6,12 @@ resource "aws_cloudwatch_log_data_protection_policy" "application_logs" {
     Name    = "data_protection_${var.environment_name}_application_logs"
     Version = "2021-06-01"
 
-    "Statement" : [
+        "Statement" : [
       {
         "Sid" : "audit-policy",
         "DataIdentifier" : [
-          "arn:aws:dataprotection::aws:data-identifier/EmailAddress"
+          "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+          "HTTPGetEmailAddress"
         ],
         "Operation" : {
           "Audit" : {
@@ -21,7 +22,8 @@ resource "aws_cloudwatch_log_data_protection_policy" "application_logs" {
       {
         "Sid" : "redact-policy",
         "DataIdentifier" : [
-          "arn:aws:dataprotection::aws:data-identifier/EmailAddress"
+          "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+          "HTTPGetEmailAddress"
         ],
         "Operation" : {
           "Deidentify" : {
@@ -29,6 +31,14 @@ resource "aws_cloudwatch_log_data_protection_policy" "application_logs" {
           }
         }
       }
-    ]
+    ],
+    "Configuration" : {
+      "CustomDataIdentifier" : [
+        {
+          "Name" : "HTTPGetEmailAddress",
+          "Regex" : "\\/create-account-success\\?email=[\\w-\\.]+%40([\\w-]+\\.)+[\\w-]{2,4}&resend=true"
+        }
+      ]
+    }
   })
 }

--- a/terraform/environment/region/cloudwatch_data_protection_policy.tf
+++ b/terraform/environment/region/cloudwatch_data_protection_policy.tf
@@ -6,29 +6,39 @@ resource "aws_cloudwatch_log_data_protection_policy" "application_logs" {
     Name    = "data_protection_${var.environment_name}_application_logs"
     Version = "2021-06-01"
 
-    "Statement" : [
-      {
-        "Sid" : "audit-policy",
-        "DataIdentifier" : [
-          "arn:aws:dataprotection::aws:data-identifier/EmailAddress"
-        ],
-        "Operation" : {
-          "Audit" : {
-            "FindingsDestination" : {}
-          }
-        }
-      },
-      {
-        "Sid" : "redact-policy",
-        "DataIdentifier" : [
-          "arn:aws:dataprotection::aws:data-identifier/EmailAddress"
-        ],
-        "Operation" : {
-          "Deidentify" : {
-            "MaskConfig" : {}
-          }
+    "Statement": [
+    {
+      "Sid": "audit-policy",
+      "DataIdentifier": [
+        "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+        "HTTPGetEmailAddress"
+      ],
+      "Operation": {
+        "Audit": {
+          "FindingsDestination": {}
         }
       }
+    },
+    {
+      "Sid": "redact-policy",
+      "DataIdentifier": [
+        "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+        "HTTPGetEmailAddress"
+      ],
+      "Operation": {
+        "Deidentify": {
+          "MaskConfig": {}
+        }
+      }
+    }
+  ],
+  "Configuration": {
+    "CustomDataIdentifier": [
+      {
+        "Name": "HTTPGetEmailAddress",
+        "Regex": "\\/create-account-success\\?email=[\\w-\\.]+%40([\\w-]+\\.)+[\\w-]{2,4}&resend=true"
+      }
     ]
+  }
   })
 }

--- a/terraform/environment/region/cloudwatch_data_protection_policy.tf
+++ b/terraform/environment/region/cloudwatch_data_protection_policy.tf
@@ -6,7 +6,7 @@ resource "aws_cloudwatch_log_data_protection_policy" "application_logs" {
     Name    = "data_protection_${var.environment_name}_application_logs"
     Version = "2021-06-01"
 
-        "Statement" : [
+    "Statement" : [
       {
         "Sid" : "audit-policy",
         "DataIdentifier" : [

--- a/terraform/environment/region/cloudwatch_data_protection_policy.tf
+++ b/terraform/environment/region/cloudwatch_data_protection_policy.tf
@@ -6,39 +6,29 @@ resource "aws_cloudwatch_log_data_protection_policy" "application_logs" {
     Name    = "data_protection_${var.environment_name}_application_logs"
     Version = "2021-06-01"
 
-    "Statement": [
-    {
-      "Sid": "audit-policy",
-      "DataIdentifier": [
-        "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
-        "HTTPGetEmailAddress"
-      ],
-      "Operation": {
-        "Audit": {
-          "FindingsDestination": {}
-        }
-      }
-    },
-    {
-      "Sid": "redact-policy",
-      "DataIdentifier": [
-        "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
-        "HTTPGetEmailAddress"
-      ],
-      "Operation": {
-        "Deidentify": {
-          "MaskConfig": {}
-        }
-      }
-    }
-  ],
-  "Configuration": {
-    "CustomDataIdentifier": [
+    "Statement" : [
       {
-        "Name": "HTTPGetEmailAddress",
-        "Regex": "\\/create-account-success\\?email=[\\w-\\.]+%40([\\w-]+\\.)+[\\w-]{2,4}&resend=true"
+        "Sid" : "audit-policy",
+        "DataIdentifier" : [
+          "arn:aws:dataprotection::aws:data-identifier/EmailAddress"
+        ],
+        "Operation" : {
+          "Audit" : {
+            "FindingsDestination" : {}
+          }
+        }
+      },
+      {
+        "Sid" : "redact-policy",
+        "DataIdentifier" : [
+          "arn:aws:dataprotection::aws:data-identifier/EmailAddress"
+        ],
+        "Operation" : {
+          "Deidentify" : {
+            "MaskConfig" : {}
+          }
+        }
       }
     ]
-  }
   })
 }


### PR DESCRIPTION
# Purpose

Update Data Protection Policy with HTTPGetEmailAddress Identifier. This adds regex for email address's with a `%40` in place of `@`

Fixes UML-3251

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
