### PR TITLE
Uml 3251 revert dp policy

### DIFF
--- a/terraform/environment/region/cloudwatch_data_protection_policy.tf
+++ b/terraform/environment/region/cloudwatch_data_protection_policy.tf
@@ -36,7 +36,7 @@ resource "aws_cloudwatch_log_data_protection_policy" "application_logs" {
       "CustomDataIdentifier" : [
         {
           "Name" : "HTTPGetEmailAddress",
-          "Regex" : "/create-account-success?email=[a-zA-Z0-9._-]+%40[a-zA-Z0-9.-]+.[a-zA-Z]{2,63}&resend=true"
+          "Regex" : "/create-account-success?email=[a-zA-z0-9_+-]+%40[a-zA-z0-9]+.[a-zA-Z]{2,4}&resend=true"
         }
       ]
     }

--- a/terraform/environment/region/cloudwatch_data_protection_policy.tf
+++ b/terraform/environment/region/cloudwatch_data_protection_policy.tf
@@ -10,8 +10,7 @@ resource "aws_cloudwatch_log_data_protection_policy" "application_logs" {
       {
         "Sid" : "audit-policy",
         "DataIdentifier" : [
-          "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
-          "HTTPGetEmailAddress"
+          "arn:aws:dataprotection::aws:data-identifier/EmailAddress"
         ],
         "Operation" : {
           "Audit" : {
@@ -22,8 +21,7 @@ resource "aws_cloudwatch_log_data_protection_policy" "application_logs" {
       {
         "Sid" : "redact-policy",
         "DataIdentifier" : [
-          "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
-          "HTTPGetEmailAddress"
+          "arn:aws:dataprotection::aws:data-identifier/EmailAddress"
         ],
         "Operation" : {
           "Deidentify" : {
@@ -31,14 +29,6 @@ resource "aws_cloudwatch_log_data_protection_policy" "application_logs" {
           }
         }
       }
-    ],
-    "Configuration" : {
-      "CustomDataIdentifier" : [
-        {
-          "Name" : "HTTPGetEmailAddress",
-          "Regex" : "/create-account-success?email=[a-zA-z0-9._+-]+%40[a-zA-z0-9]+.[a-zA-Z]{2,4}&resend=true"
-        }
-      ]
-    }
+    ]
   })
 }

--- a/terraform/environment/region/cloudwatch_data_protection_policy.tf
+++ b/terraform/environment/region/cloudwatch_data_protection_policy.tf
@@ -36,7 +36,7 @@ resource "aws_cloudwatch_log_data_protection_policy" "application_logs" {
       "CustomDataIdentifier" : [
         {
           "Name" : "HTTPGetEmailAddress",
-          "Regex" : "/create-account-success?email=[a-zA-z0-9_+-]+%40[a-zA-z0-9]+.[a-zA-Z]{2,4}&resend=true"
+          "Regex" : "/create-account-success?email=[a-zA-z0-9._+-]+%40[a-zA-z0-9]+.[a-zA-Z]{2,4}&resend=true"
         }
       ]
     }


### PR DESCRIPTION
# Purpose

Reverting the data protection policies back to the default, including the email address identifier

Fixes UML-3251

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
