### PR TITLE
Remove account creation routes under one login

### DIFF
--- a/service-front/app/features/actor-privacy-notice.feature
+++ b/service-front/app/features/actor-privacy-notice.feature
@@ -4,9 +4,16 @@ Feature: View privacy notice from the terms of use page
   I want to check the privacy notice
   So that I can understand how my private data will be handled by the service
 
-  @ui
+  @ui @ff:allow_gov_one_login:false
   Scenario: user wants to see the privacy notice
     Given I am on the create account page
+    When I request to see the actor terms of use
+    And I request to see the actor privacy notice
+    Then I can see the actor privacy notice
+
+  @ui @ff:allow_gov_one_login:true
+  Scenario: user wants to see the privacy notice
+    Given I am on the one login page
     When I request to see the actor terms of use
     And I request to see the actor privacy notice
     Then I can see the actor privacy notice

--- a/service-front/app/features/actor-terms-of-use.feature
+++ b/service-front/app/features/actor-terms-of-use.feature
@@ -4,9 +4,15 @@ Feature: View terms of use from create account page
   I want to check the terms of use
   So that I can be be sure of my rights and responsibilities for using the service
 
-  @ui
+  @ui @ff:allow_gov_one_login:false
   Scenario: The user can access the terms of use from the create account page
     Given I am on the create account page
+    When I request to see the actor terms of use
+    Then I can see the actor terms of use
+
+  @ui @ff:allow_gov_one_login:true
+  Scenario: The user can access the terms of use from the one login page
+    Given I am on the one login page
     When I request to see the actor terms of use
     Then I can see the actor terms of use
 

--- a/service-front/app/features/common-language.feature
+++ b/service-front/app/features/common-language.feature
@@ -23,7 +23,7 @@ Feature: The application supports Welsh as a language
     And I request to view the content in english
     Then I should be on the home page of the service
 
-  @ui @welsh
+  @ui @welsh @ff:allow_gov_one_login:false
   Scenario: Users can expect to receive notification emails in the language they are viewing
     Given I prefix a url with the welsh language code
       And I am not a user of the lpa application

--- a/service-front/app/features/context/UI/AccountContext.php
+++ b/service-front/app/features/context/UI/AccountContext.php
@@ -1801,7 +1801,11 @@ class AccountContext implements Context
      */
     public function iRequestToSeeTheActorTermsOfUse(): void
     {
-        $this->ui->clickLink('terms of use');
+        if (($this->base->container->get(FeatureEnabled::class))('allow_gov_one_login')) {
+            $this->ui->clickLink('terms of the Use a lasting power of attorney service.');
+        } else {
+            $this->ui->clickLink('terms of use');
+        }
     }
 
     /**

--- a/service-front/app/src/Actor/src/Handler/CheckLpaHandler.php
+++ b/service-front/app/src/Actor/src/Handler/CheckLpaHandler.php
@@ -242,6 +242,7 @@ class CheckLpaHandler extends AbstractHandler implements CsrfGuardAware, UserAwa
                     $this->logger->notice(
                         'Account with Id {id} added LPA of type {lpaType} to their account',
                         [
+                            'id'         => $this->identity,
                             'event_code' => $lpaType === 'health and welfare'
                                 ? EventCodes::ADDED_LPA_TYPE_HW
                                 : EventCodes::ADDED_LPA_TYPE_PFA,


### PR DESCRIPTION
# Purpose

Remove routes responsible for logging of PII as they're not used under One Login anyway.

Fixes UML-3251

## Approach

Using conditional routing middleware.

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
