### PR TITLE
Build confd as a part of the Dockerfiles so that we get ARCH specific versions

### DIFF
--- a/service-api/docker/web/Dockerfile
+++ b/service-api/docker/web/Dockerfile
@@ -1,3 +1,12 @@
+FROM golang:1.23-alpine AS confd_builder
+
+RUN apk add --no-cache make git && \
+    cd / && \
+    git clone https://github.com/kelseyhightower/confd.git build && \
+    cd build && \
+    git checkout 919444eb && \
+    make build
+
 FROM nginxinc/nginx-unprivileged:stable-alpine
 USER root
 
@@ -5,15 +14,8 @@ RUN apk upgrade && \
   apk update curl
 
 # Add Confd to configure nginx on start
-ENV CONFD_VERSION="0.16.0"
-
-RUN wget -q -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64" \
-  && chmod +x /usr/local/bin/confd
-
-# Add Waitforit to wait on app starting
-ENV WAITFORIT_VERSION="v2.4.1"
-RUN wget -q -O /usr/local/bin/waitforit https://github.com/maxcnunes/waitforit/releases/download/$WAITFORIT_VERSION/waitforit-linux_amd64 \
-  && chmod +x /usr/local/bin/waitforit
+COPY --from=confd_builder /build/bin/confd /usr/local/bin/confd
+RUN chmod +x /usr/local/bin/confd
 
 COPY service-api/docker/web/etc /etc
 

--- a/service-front/docker/web/Dockerfile
+++ b/service-front/docker/web/Dockerfile
@@ -1,3 +1,12 @@
+FROM golang:1.23-alpine AS confd_builder
+
+RUN apk add --no-cache make git && \
+    cd / && \
+    git clone https://github.com/kelseyhightower/confd.git build && \
+    cd build && \
+    git checkout 919444eb && \
+    make build
+
 FROM nginxinc/nginx-unprivileged:stable-alpine
 USER root
 
@@ -5,14 +14,8 @@ RUN apk upgrade && \
   apk update curl
 
 # Add Confd to configure nginx on start
-ENV CONFD_VERSION="0.16.0"
-RUN wget -q -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64" \
-  && chmod +x /usr/local/bin/confd
-
-# Add Waitforit to wait on app starting
-ENV WAITFORIT_VERSION="v2.4.1"
-RUN wget -q -O /usr/local/bin/waitforit https://github.com/maxcnunes/waitforit/releases/download/$WAITFORIT_VERSION/waitforit-linux_amd64 \
-  && chmod +x /usr/local/bin/waitforit
+COPY --from=confd_builder /build/bin/confd /usr/local/bin/confd
+RUN chmod +x /usr/local/bin/confd
 
 COPY service-front/docker/web/etc /etc
 COPY service-front/docker/web/web /web


### PR DESCRIPTION
# Purpose

Every time docker updates it seems to re-enable the Rosetta setting on my mac which causes the web images to fail to run since confd was built with unsupported processor instructions. The fix for that is to build your own confd. 

## Approach

Build confd in multistage image instead of downloading the github release (which is super old at this point anyway). Additionally remove the waitforit download as thats not even used anymore.

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
