### PR TITLE
Utilise nginx to strip out the problematic SameSite cookie setting if the UserAgent is broken.

### DIFF
--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -46,6 +46,13 @@ map $upstream_http_x_csp_nonce $CSP_nonce {
     default   "nonce-ApplicationFailedToGenerateNonce";
 }
 
+# UML-3581 - regex to pull out all the problematic UserAgents in the logs. It's not by any means exhaustive but
+# absolutely covers all the ones impacted by webkit's none === strict problem.
+map $http_user_agent $samesite_strip {
+    "~*(iPhone; CPU iPhone OS 1[0-3]|iPad; CPU OS 1[0-2]|iPod touch; CPU iPhone OS 1[0-3]|Macintosh; Intel Mac OS X.*Version\x2F1[0-3].*Safari|Macintosh;.*Mac OS X 10_14.* AppleWebKit.*Version\x2F1[0-3].*Safari|CrOS.*Chrome\/[1-6][0-6]\.|\(Windows NT 10\.0; Win64; x64\) AppleWebKit\/537\.36 \(KHTML, like Gecko\) Chrome\/128.0.0.0 Safari\/537\.36)" nosamesite;
+    default off;
+}
+
 server {
     listen        80 default_server;
     server_name   _;
@@ -116,17 +123,10 @@ server {
         root   /usr/share/nginx/html;
     }
 
-    # pass the PHP scripts to FastCGI upstream server
+    # pass the PHP scripts to FastCGI upstream server whilst stripping out problematic cookie settings
     location ~ \.php$ {
-        fastcgi_split_path_info ^(.+\.php)(/.*)$;
-
-        include fastcgi_params;
-        fastcgi_param HTTP_X_AMZN_TRACE_ID $trace_id;
-        fastcgi_param SCRIPT_FILENAME      /app/public$fastcgi_script_name;
-
-        fastcgi_hide_header X-Csp-Nonce;
-
-        fastcgi_pass @php;
+        proxy_cookie_flags __Host-session $samesite_strip;
+        proxy_pass http://127.0.0.1:8000$request_uri;
     }
 
     # deny access to .htaccess files, if Apache's document root
@@ -137,9 +137,31 @@ server {
 
     # Comply with https://ministryofjustice.github.io/security-guidance/contact/implement-security-txt/#implementing-securitytxt
     rewrite ^/.well-known/security.txt$ https://security-guidance.service.justice.gov.uk/.well-known/security.txt permanent;
+}
 
-    # UML-3504 - Issue with email containing wrong url
-    rewrite ^/your-details$ {{ getv "/web/domain" "http://localhost" }}/settings redirect;
+# we need to define our PHP process as a new server as we're not able to access proxy_* commands
+# unless we access the resource view a proxy_pass command. Consequently we hide our fastcgi_pass in here.
+server {
+    listen      8000 default_server;
+    server_name _;
+
+    access_log off;
+
+    location / {
+        try_files $uri /index.php$is_args$args;
+    }
+
+    location ~ \.php {
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+
+        include fastcgi_params;
+        fastcgi_param HTTP_X_AMZN_TRACE_ID $trace_id;
+        fastcgi_param SCRIPT_FILENAME      /app/public$fastcgi_script_name;
+
+        fastcgi_hide_header X-Csp-Nonce;
+
+        fastcgi_pass @php;
+    }
 }
 
 # this block is needed, along with the /_csp location defined above, to allow the

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -126,6 +126,7 @@ server {
     # pass the PHP scripts to FastCGI upstream server whilst stripping out problematic cookie settings
     location ~ \.php$ {
         proxy_cookie_flags __Host-session $samesite_strip;
+        proxy_set_header Host $host;
         proxy_pass http://127.0.0.1:8000$request_uri;
     }
 


### PR DESCRIPTION
# Purpose

Fixes logins being broken on old devices or browsers.

Fixes UML-3581

## Approach

Fix that skirts around the problem by just making our broken devices special cases. Uses nginx configuration to take all the complexity away from the app.

The problem we have is that modern versions of Chrome set a default SameSite cookie setting of "Lax" which doesn't work for us, so we set it to "None" which does. But this breaks all sorts of old iOS and MacOS Safari browsers as they don't understand "None" and assume you meant "Strict", which definitely doesn't work for us.

So the trick here is to have our app continue to assume you're all modern and set a "None" value, but then utilise an Nginx configuration to strip the SameSite configuration option from any cookies that pass through it. The Regex used is derived from the webkit bug page linked below with some additions based on what we're seeing in our logs. 

## Learning

https://caniuse.com/?search=samesite
https://bugs.webkit.org/show_bug.cgi?id=198181

## Checklist

* [x] I have performed a self-review of my own code
* I have added relevant logging with appropriate levels to my code
* [New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* I have added tests to prove my work
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* The product team have tested these changes
