### PR TITLE
UML-3582 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -235,6 +235,8 @@ services:
     build:
       context: .
       dockerfile: service-api/docker/seeding/Dockerfile
+    volumes:
+      - ./service-api/seeding:/app/seeding
     environment:
       AWS_ACCESS_KEY_ID: "devkey"
       AWS_SECRET_ACCESS_KEY: "secretdevkey"

--- a/service-api/seeding/dynamodb.py
+++ b/service-api/seeding/dynamodb.py
@@ -87,17 +87,20 @@ viewerCodes = [
     },
 ]
 
-for i in range(33):
-    viewerCodes.append(
-    {
-            'ViewerCode': f"P9H8A6MLD3{str(i+20)}",
-            'SiriusUid': "700000000138",
-            'Expires': nextWeek.isoformat(),
-            'Added': "2019-01-01T12:34:56.123456Z",
-            'Organisation': "Test Organisation",
-            'UserLpaActor': "806f3720-5b43-49ce-ac66-c670860bf4ee",
-            'Comment': 'Seeded data: Valid viewer code'
-    })
+# The following loop was used to test UML-3582. It can be uncommented if any further issues
+# arise and/or testing required
+
+#for i in range(33):
+#    viewerCodes.append(
+#    {
+#            'ViewerCode': f"P9H8A6MLD3{str(i+20)}",
+#            'SiriusUid': "700000000138",
+#            'Expires': nextWeek.isoformat(),
+#            'Added': "2019-01-01T12:34:56.123456Z",
+#            'Organisation': "Test Organisation",
+#            'UserLpaActor': "806f3720-5b43-49ce-ac66-c670860bf4ee",
+#            'Comment': 'Seeded data: Valid viewer code'
+#    })
 
 for i in viewerCodes:
     try:

--- a/service-api/seeding/dynamodb.py
+++ b/service-api/seeding/dynamodb.py
@@ -87,6 +87,18 @@ viewerCodes = [
     },
 ]
 
+for i in range(33):
+    viewerCodes.append(
+    {
+            'ViewerCode': f"P9H8A6MLD3{str(i+20)}",
+            'SiriusUid': "700000000138",
+            'Expires': nextWeek.isoformat(),
+            'Added': "2019-01-01T12:34:56.123456Z",
+            'Organisation': "Test Organisation",
+            'UserLpaActor': "806f3720-5b43-49ce-ac66-c670860bf4ee",
+            'Comment': 'Seeded data: Valid viewer code'
+    })
+
 for i in viewerCodes:
     try:
         viewerCodesTable.put_item(

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -148,6 +148,13 @@ server {
 
     access_log off;
 
+    proxy_busy_buffers_size   512k;
+    proxy_buffers   4 512k;
+    proxy_buffer_size   256k;
+    fastcgi_buffers 16 32k;
+    fastcgi_buffer_size 64k;
+    fastcgi_busy_buffers_size 64k;
+
     location / {
         try_files $uri /index.php$is_args$args;
     }

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -92,6 +92,11 @@ server {
     # serve noindex, nofollow meta tag on each page so that search engines do not index this domain
     add_header X-Robots-Tag "noindex, nofollow" always;
 
+    # proxy_buffer_size needs to be increased from the 4k default, to 8k, to avoid "upstream sent too big header" errors (UML-3582)
+    # This is the size of the buffer used for reading the first part of the response received from the proxied server.
+    # On a page with many forms such as Check Access Codes when we have 33+ access codes, the cookies exceed the 4k default
+    proxy_buffer_size   8k;
+
     location / {
         root    /web;
 
@@ -148,12 +153,10 @@ server {
 
     access_log off;
 
-    proxy_buffers   4 512k;
-    proxy_buffer_size   256k;
-    proxy_busy_buffers_size   512k;
-    fastcgi_buffers 16 32k;
-    fastcgi_buffer_size 64k;
-    fastcgi_busy_buffers_size 64k;
+    # fastcgi_buffer_size needs to be increased from the 4k default, to 8k, to avoid "upstream sent too big header" errors (UML-3582)
+    # This is the size of the buffer used for reading the first part of the response received from the FastCGI server.
+    # On a page with many forms such as Check Access Codes when we have 33+ access codes, the cookies exceed the 4k default
+    fastcgi_buffer_size 8k;
 
     location / {
         try_files $uri /index.php$is_args$args;

--- a/service-front/docker/web/etc/confd/templates/nginx.conf
+++ b/service-front/docker/web/etc/confd/templates/nginx.conf
@@ -148,9 +148,9 @@ server {
 
     access_log off;
 
-    proxy_busy_buffers_size   512k;
     proxy_buffers   4 512k;
     proxy_buffer_size   256k;
+    proxy_busy_buffers_size   512k;
     fastcgi_buffers 16 32k;
     fastcgi_buffer_size 64k;
     fastcgi_busy_buffers_size 64k;


### PR DESCRIPTION
# Purpose

_Fix a bug where when you get up to about 33 codes, it results in a nginx 502 error when the user clicks Check Access Codes_

Fixes UML-3582

## Approach

_locally seed with 33 codes (commented out but can be uncommented for future testing), add a volume for seeding so it picks up changes, changes to nginx.conf to increase buffer sizes to 8k_

## Learning

To avoid such "upstream sent too big header while reading response header" messages, it is necessary to increase the proxy and fastcgi buffers.  This is the size of the buffer used for reading the first part of the response. We have established that cookies exceed the 4k default when we have 33 access codes on a page. More general info at https://www.cyberciti.biz/faq/nginx-upstream-sent-too-big-header-while-reading-response-header-from-upstream/ , https://gist.github.com/magnetikonline/11312172#determine-fastcgi-response-sizes . 

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
