### PR TITLE
Add type coersion to SiriusPerson getters

### DIFF
--- a/service-api/app/src/App/src/Service/Lpa/SiriusPerson.php
+++ b/service-api/app/src/App/src/Service/Lpa/SiriusPerson.php
@@ -22,7 +22,7 @@ class SiriusPerson implements TrustCorporationStatusInterface, ArrayAccess, Iter
 
     public function getSystemStatus(): bool
     {
-        return $this->person['systemStatus'];
+        return (bool)$this->person['systemStatus'];
     }
 
     public function getUid(): string
@@ -32,7 +32,7 @@ class SiriusPerson implements TrustCorporationStatusInterface, ArrayAccess, Iter
 
     public function getCompanyName(): string
     {
-        return $this->person['companyName'];
+        return (string)$this->person['companyName'];
     }
 
     public function offsetExists(mixed $offset): bool

--- a/service-api/app/test/AppTest/Service/Lpa/SiriusPersonTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/SiriusPersonTest.php
@@ -85,4 +85,20 @@ class SiriusPersonTest extends TestCase
             json_encode($sut),
         );
     }
+
+    #[Test]
+    public function it_typecasts_on_getters(): void
+    {
+        $sut = new SiriusPerson(
+            [
+                'uId' => 700000000000,
+                'systemStatus' => 1,
+                'companyName' => null,
+            ]
+        );
+
+        $this->assertSame('700000000000', $sut->getUid());
+        $this->assertSame(true, $sut->getSystemStatus());
+        $this->assertSame('', $sut->getCompanyName());
+    }
 }


### PR DESCRIPTION
# Purpose

To ensure that the returned value matches the type specified in the method definition.

Fixes UML-3657 #patch

## Approach

Used PHP's [inline type casting](https://www.php.net/manual/en/language.types.type-juggling.php#language.types.typecasting)

## Learning

Check the logs first 😄 Though running locally was useful to ensure it would fix the underlying issue

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [x] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
