### PR TITLE
UML-3684: prevent failed PR workflow from passing checks

### DIFF
--- a/.github/workflows/pull-request-path.yml
+++ b/.github/workflows/pull-request-path.yml
@@ -293,10 +293,10 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - ecr_scan_results
-      - slack_notify
       - workflow_variables
       - update_documentation
       - docker_build_scan_push
+      - run_behat_suite
     steps:
       - uses: actions/checkout@v4
 
@@ -331,17 +331,16 @@ jobs:
 
       - name: workflow has ended without issue
         run: |
-          if [[ ${{ needs.workflow_variables.outputs.specific_path }} = 'docs' ]]
-          then
-            echo 'Ending docs workflow'
-          else
+          if ${{ contains(needs.run_behat_suite.result, 'success') && contains(needs.ecr_scan_results.result, 'success') }}; then
             echo "${{ needs.workflow_variables.outputs.safe_branch_name }} PR environment tested, built and deployed"
             echo "Tag Used: ${{ needs.workflow_variables.outputs.safe_branch_name }}-${{ needs.workflow_variables.outputs.short_sha }}"
             echo "URL: https://${{ needs.workflow_variables.outputs.workspace_name }}.use-lasting-power-of-attorney.service.gov.uk"
+            exit 0
+          elif [[ ${{ needs.workflow_variables.outputs.specific_path }} = 'docs' ]]; then
+            echo 'Ending docs workflow'
+          else
+            echo "Previous jobs in pipeline failed."
+            exit 1
           fi
-    if: |
-      always() &&
-      ((needs.ecr_scan_results.result == 'success' || needs.ecr_scan_results.result == 'skipped') &&
-      needs.slack_notify.result == 'success' &&
-      needs.workflow_variables.result == 'success') ||
-      needs.update_documentation.result == 'success'
+
+    if: always()


### PR DESCRIPTION
# Purpose

Prevents a skipped `end_of_workflow` from reporting as 'Success', which allowed us to merge in failed pipelines

Fixes UML-3684

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
