### PR TITLE
UML-3699: update PR workflow docs only path

### DIFF
--- a/.github/workflows/pull-request-path.yml
+++ b/.github/workflows/pull-request-path.yml
@@ -152,6 +152,7 @@ jobs:
     secrets: inherit
     if: |
       always() &&
+      needs.workflow_variables.outputs.specific_path != 'docs' &&
       (needs.node_test.result == 'success' || needs.node_test.result == 'skipped') &&
       (needs.node_build.result == 'success' || needs.node_build.result == 'skipped') &&
       needs.workflow_variables.result == 'success'


### PR DESCRIPTION
# Purpose

Prevents docker build step when a docs only update is happening

Fixes UML-3699

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
