### PR TITLE
Update path to live workflow

### DIFF
--- a/.github/workflows/path-to-live.yml
+++ b/.github/workflows/path-to-live.yml
@@ -33,12 +33,25 @@ jobs:
     outputs:
       short_sha:  ${{ steps.variables.outputs.short_sha }}
       semver_tag: ${{ steps.semver_tag.outputs.created_tag }}
+      specific_path: ${{ steps.variables.outputs.path }}
     steps:
+      - name: get changed docs files in any folder
+        id: changed-files-docs
+        uses: tj-actions/changed-files@41ce994be96a740b53ae11ecbf86d1619a7bd640
+        with:
+          files: |
+            **/*.md
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # pin@v3
       - name: extract variables for workflow
         id: variables
         run: |
           echo "short_sha=$(echo ${GITHUB_SHA:0:7})" >> $GITHUB_OUTPUT
+          if [[ ${{ steps.changed-files-docs.outputs.only_changed }} = "true" ]]
+          then
+            echo "path=$(echo docs)" >> $GITHUB_OUTPUT
+          else
+            echo "path=$(echo all)" >> $GITHUB_OUTPUT
+          fi
 
       - name: Bump version and push tag
         uses: ministryofjustice/opg-github-actions/.github/actions/semver-tag@v3.0.8
@@ -48,6 +61,17 @@ jobs:
           default_bump: minor
           prerelease: false
 
+  update_documentation:
+    name: update documentation
+    runs-on: ubuntu-latest
+    needs:
+      - workflow_variables
+    steps:
+      - name: only update documentation
+        run: echo 'Only docs have changed - skipping rest of pipeline'
+    if: |
+      needs.workflow_variables.outputs.specific_path == 'docs'
+
   terraform_lint:
     name: lint terraform code
     uses: ./.github/workflows/_lint-terraform.yml
@@ -56,18 +80,30 @@ jobs:
     with:
       workspace: development
     secrets: inherit
+    if: |
+      always() &&
+      needs.workflow_variables.result == 'success' &&
+      needs.workflow_variables.outputs.specific_path != 'docs'
 
   node_test:
     name: test node dependencies
     uses: ./.github/workflows/_node-test.yml
     needs:
       - workflow_variables
+    if: |
+      always() &&
+      needs.workflow_variables.result == 'success' &&
+      needs.workflow_variables.outputs.specific_path == 'all'
 
   node_build:
     name: build node dependencies
     uses: ./.github/workflows/_node-build.yml
     needs:
       - workflow_variables
+    if: |
+      always() &&
+      needs.workflow_variables.result == 'success' &&
+      needs.workflow_variables.outputs.specific_path == 'all'
 
   docker_build_scan_push:
     name: build, test, scan and push
@@ -82,6 +118,12 @@ jobs:
       push_to_ecr: true
       specific_path: all
     secrets: inherit
+    if: |
+      always() &&
+      needs.workflow_variables.outputs.specific_path != 'docs' &&
+      (needs.node_test.result == 'success' || needs.node_test.result == 'skipped') &&
+      (needs.node_build.result == 'success' || needs.node_build.result == 'skipped') &&
+      needs.workflow_variables.result == 'success'
 
   code_coverage:
     name: upload to code coverage

--- a/.github/workflows/path-to-live.yml
+++ b/.github/workflows/path-to-live.yml
@@ -60,6 +60,8 @@ jobs:
           with_v: true
           default_bump: minor
           prerelease: false
+        if: |
+          ${{ steps.changed-files-docs.outputs.path }} != "docs"
 
   update_documentation:
     name: update documentation


### PR DESCRIPTION
# Purpose

Updates the workflow, so that if only docs are changed, the whole workflow does not need to run.

This logic matches what we currently have in the pr workflow

Fixes UML-3704

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
* [ ] I have added tests to prove my work
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
