### PR TITLE
Add debug logging of the usage of array access methods so that we can…

### DIFF
--- a/service-api/app/src/App/src/DataAccess/ApiGateway/SiriusLpas.php
+++ b/service-api/app/src/App/src/DataAccess/ApiGateway/SiriusLpas.php
@@ -141,6 +141,7 @@ class SiriusLpas extends AbstractApiClient implements LpasInterface, RequestLett
                         $results[$uid] = new Lpa(
                             new SiriusLpa(
                                 $this->sanitiser->sanitise($response),
+                                $this->logger,
                             ),
                             new DateTimeImmutable($result->getHeaderLine('Date'))
                         );

--- a/service-api/app/src/App/src/Service/Lpa/SiriusLpa.php
+++ b/service-api/app/src/App/src/Service/Lpa/SiriusLpa.php
@@ -12,6 +12,7 @@ use App\Service\Lpa\ResolveActor\SiriusHasActorTrait;
 use ArrayAccess;
 use IteratorAggregate;
 use JsonSerializable;
+use Psr\Log\LoggerInterface;
 use Traversable;
 
 /**
@@ -29,7 +30,7 @@ class SiriusLpa implements
 {
     use SiriusHasActorTrait;
 
-    public function __construct(private array $lpa)
+    public function __construct(private array $lpa, private LoggerInterface $logger)
     {
         if ($this->lpa['donor'] !== null) {
             $donorAsSiriusPerson = $this->convertToSiriusPerson($this->lpa['donor']);
@@ -68,7 +69,7 @@ class SiriusLpa implements
     {
         return $entity instanceof SiriusPerson
             ? $entity
-            : new SiriusPerson($entity);
+            : new SiriusPerson($entity, $this->logger);
     }
 
     private function getTrustCorporations(): array
@@ -78,16 +79,34 @@ class SiriusLpa implements
 
     public function offsetExists(mixed $offset): bool
     {
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+        $this->logger->debug(
+            'Use of SiriusLpa object as array (exists) in file '
+            . $trace[0]['file'] . ' on line ' . $trace[0]['line']
+        );
+
         return isset($this->lpa[$offset]);
     }
 
     public function offsetGet(mixed $offset): mixed
     {
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+        $this->logger->debug(
+            'Use of SiriusLpa object as array (getter) in file '
+            . $trace[0]['file'] . ' on line ' . $trace[0]['line']
+        );
+
         return $this->lpa[$offset];
     }
 
     public function offsetSet(mixed $offset, mixed $value): void
     {
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+        $this->logger->debug(
+            'Use of SiriusLpa object as array (setter) in file '
+            . $trace[0]['file'] . ' on line ' . $trace[0]['line']
+        );
+
         $this->lpa[$offset] = $value;
     }
 

--- a/service-api/app/src/App/src/Service/Lpa/SiriusPerson.php
+++ b/service-api/app/src/App/src/Service/Lpa/SiriusPerson.php
@@ -13,6 +13,7 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use IteratorAggregate;
 use JsonSerializable;
+use Psr\Log\LoggerInterface;
 use Traversable;
 
 /**
@@ -28,7 +29,7 @@ class SiriusPerson implements
     IteratorAggregate,
     JsonSerializable
 {
-    public function __construct(private array $person)
+    public function __construct(private array $person, private LoggerInterface $logger)
     {
     }
 
@@ -87,16 +88,34 @@ class SiriusPerson implements
 
     public function offsetExists(mixed $offset): bool
     {
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+        $this->logger->debug(
+            'Use of SiriusPerson object as array (exists) in file '
+            . $trace[0]['file'] . ' on line ' . $trace[0]['line']
+        );
+
         return isset($this->person[$offset]);
     }
 
     public function offsetGet(mixed $offset): mixed
     {
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+        $this->logger->debug(
+            'Use of SiriusPerson object as array (getter) in file '
+            . $trace[0]['file'] . ' on line ' . $trace[0]['line']
+        );
+
         return $this->person[$offset];
     }
 
     public function offsetSet(mixed $offset, mixed $value): void
     {
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+        $this->logger->debug(
+            'Use of SiriusPerson object as array (setter) in file '
+            . $trace[0]['file'] . ' on line ' . $trace[0]['line']
+        );
+
         $this->person[$offset] = $value;
     }
 

--- a/service-api/app/test/AppTest/Service/ActorCodes/ActorCodeServiceTest.php
+++ b/service-api/app/test/AppTest/Service/ActorCodes/ActorCodeServiceTest.php
@@ -215,6 +215,7 @@ class ActorCodeServiceTest extends TestCase
             [
                 'uId' => $testUid,
             ],
+            $this->loggerProphecy->reveal(),
         );
 
         $mockActor = new LpaActor(

--- a/service-api/app/test/AppTest/Service/ActorCodes/Validation/CodesApiValidationStrategyTest.php
+++ b/service-api/app/test/AppTest/Service/ActorCodes/Validation/CodesApiValidationStrategyTest.php
@@ -71,6 +71,7 @@ class CodesApiValidationStrategyTest extends TestCase
                 [
                     'uId' => 'lpa-uid',
                 ],
+                $this->loggerProphecy->reveal(),
             ),
             new DateTime('now')
         );
@@ -190,6 +191,7 @@ class CodesApiValidationStrategyTest extends TestCase
                 [
                     'uId' => 'lpa-uid',
                 ],
+                $this->loggerProphecy->reveal(),
             ),
             new DateTime('now')
         );
@@ -230,6 +232,7 @@ class CodesApiValidationStrategyTest extends TestCase
                 [
                     'uId' => 'lpa-uid',
                 ],
+                $this->loggerProphecy->reveal(),
             ),
             new DateTime('now')
         );
@@ -342,6 +345,7 @@ class CodesApiValidationStrategyTest extends TestCase
                     ],
                     'uId'   => 'lpa-uid',
                 ],
+                $this->loggerProphecy->reveal(),
             ),
             new DateTime('now')
         );

--- a/service-api/app/test/AppTest/Service/Lpa/AddAccessForAllLpaTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/AddAccessForAllLpaTest.php
@@ -238,7 +238,8 @@ class AddAccessForAllLpaTest extends TestCase
                     'firstname'   => 'Donor',
                     'middlenames' => 'Example',
                     'surname'     => 'Person',
-                ]
+                ],
+                $this->loggerProphecy->reveal(),
             ),
             'donor',
             (string) $this->lpaUid,
@@ -299,6 +300,7 @@ class AddAccessForAllLpaTest extends TestCase
                     'registrationDate' => '2019-08-31',
                     'status'           => 'Registered',
                 ],
+                $this->loggerProphecy->reveal(),
             ),
             new DateTime()
         );
@@ -333,6 +335,7 @@ class AddAccessForAllLpaTest extends TestCase
                     'registrationDate' => '2019-08-31',
                     'status'           => 'Registered',
                 ],
+                $this->loggerProphecy->reveal(),
             ),
             new DateTime()
         );
@@ -519,6 +522,7 @@ class AddAccessForAllLpaTest extends TestCase
                         $attorney2,
                     ],
                 ],
+                $this->loggerProphecy->reveal(),
             ),
             new DateTime()
         );

--- a/service-api/app/test/AppTest/Service/Lpa/CheckLpaCleansedTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/CheckLpaCleansedTest.php
@@ -53,9 +53,12 @@ class CheckLpaCleansedTest extends TestCase
         );
 
         $actorDetailsMatch = new ActorMatch(
-            new SiriusPerson([
-                'uId' => '700000000002',
-            ]),
+            new SiriusPerson(
+                [
+                    'uId' => '700000000002',
+                ],
+                $this->loggerProphecy->reveal(),
+            ),
             '',
             '700000000001',
         );
@@ -83,9 +86,12 @@ class CheckLpaCleansedTest extends TestCase
         );
 
         $actorDetailsMatch = new ActorMatch(
-            new SiriusPerson([
-                                 'uId' => '700000000002',
-                             ]),
+            new SiriusPerson(
+                [
+                    'uId' => '700000000002',
+                ],
+                $this->loggerProphecy->reveal(),
+            ),
             '',
             '700000000001',
         );
@@ -111,9 +117,12 @@ class CheckLpaCleansedTest extends TestCase
         );
 
         $actorDetailsMatch = new ActorMatch(
-            new SiriusPerson([
-                 'uId' => '700000000002',
-             ]),
+            new SiriusPerson(
+                [
+                    'uId' => '700000000002',
+                ],
+                $this->loggerProphecy->reveal(),
+            ),
             '',
             '700000000001',
         );
@@ -139,9 +148,12 @@ class CheckLpaCleansedTest extends TestCase
         );
 
         $actorDetailsMatch = new ActorMatch(
-            new SiriusPerson([
-                 'uId' => '700000000002',
-             ]),
+            new SiriusPerson(
+                [
+                    'uId' => '700000000002',
+                ],
+                $this->loggerProphecy->reveal(),
+            ),
             '',
             '700000000001',
         );

--- a/service-api/app/test/AppTest/Service/Lpa/FindActorInLpaTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/FindActorInLpaTest.php
@@ -6,6 +6,7 @@ namespace AppTest\Service\Lpa;
 
 use App\Entity\LpaStore\LpaStoreDonor;
 use App\Entity\Person;
+use App\Entity\Sirius\SiriusLpa as CombinedSiriusLpa;
 use App\Entity\Sirius\SiriusLpaAttorney;
 use App\Entity\Sirius\SiriusLpaDonor;
 use App\Service\Lpa\FindActorInLpa;
@@ -15,6 +16,7 @@ use App\Service\Lpa\GetAttorneyStatus\AttorneyStatus;
 use App\Service\Lpa\SiriusLpa;
 use App\Service\Lpa\SiriusPerson;
 use DateTimeImmutable;
+use Monolog\Logger;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -50,6 +52,7 @@ class FindActorInLpaTest extends TestCase
                     $this->activeAttorneyFixtureOld(),
                 ],
             ],
+            $this->loggerProphecy->reveal(),
         );
 
         $this->getAttorneyStatusProphecy
@@ -89,7 +92,7 @@ class FindActorInLpaTest extends TestCase
             $this->activeAttorneyFixture(),
         ];
 
-        $lpa = new \App\Entity\Sirius\SiriusLpa(
+        $lpa = new CombinedSiriusLpa(
             applicationHasGuidance:     null,
             applicationHasRestrictions: null,
             applicationType:            null,
@@ -141,16 +144,16 @@ class FindActorInLpaTest extends TestCase
     public static function actorLookupDataProviderOldSiriusPerson(): array
     {
         return self::actorLookupDataProvider(
-            FindActorInLpaTest::activeAttorneyFixtureOld(),
-            FindActorInLpaTest::donorFixtureOld()
+            self::activeAttorneyFixtureOld(),
+            self::donorFixtureOld()
         );
     }
 
     public static function actorLookupDataProviderCombinedSirius(): array
     {
         return self::actorLookupDataProvider(
-            FindActorInLpaTest::activeAttorneyFixture(),
-            FindActorInLpaTest::donorFixture()
+            self::activeAttorneyFixture(),
+            self::donorFixture()
         );
     }
 
@@ -250,23 +253,26 @@ class FindActorInLpaTest extends TestCase
         ];
     }
 
-    public static function inactiveAttorneyFixtureOld(): SiriusPerson
+    private function inactiveAttorneyFixtureOld(): SiriusPerson
     {
-        return new SiriusPerson([
-            'uId'          => '700000002222',
-            'dob'          => '1977-11-21',
-            'firstname'    => 'Attorneyone',
-            'surname'      => 'Person',
-            'addresses'    => [
-                [
-                    'postcode' => 'Gg1 2ff',
+        return new SiriusPerson(
+            [
+                'uId'          => '700000002222',
+                'dob'          => '1977-11-21',
+                'firstname'    => 'Attorneyone',
+                'surname'      => 'Person',
+                'addresses'    => [
+                    [
+                        'postcode' => 'Gg1 2ff',
+                    ],
                 ],
+                'systemStatus' => false, // inactive attorney
             ],
-            'systemStatus' => false, // inactive attorney
-        ]);
+            $this->loggerProphecy->reveal(),
+        );
     }
 
-    public static function inactiveAttorneyFixture(): SiriusLpaAttorney
+    private function inactiveAttorneyFixture(): SiriusLpaAttorney
     {
         return new SiriusLpaAttorney(
             addressLine1: null,
@@ -289,23 +295,26 @@ class FindActorInLpaTest extends TestCase
         );
     }
 
-    public static function ghostAttorneyFixtureOld(): SiriusPerson
+    private function ghostAttorneyFixtureOld(): SiriusPerson
     {
-        return new SiriusPerson([
-            'uId'          => '700000003333',
-            'dob'          => '1960-05-05',
-            'firstname'    => '', // ghost attorney
-            'surname'      => '',
-            'addresses'    => [
-                [
-                    'postcode' => 'BB1 9ee',
+        return new SiriusPerson(
+            [
+                'uId'          => '700000003333',
+                'dob'          => '1960-05-05',
+                'firstname'    => '', // ghost attorney
+                'surname'      => '',
+                'addresses'    => [
+                    [
+                        'postcode' => 'BB1 9ee',
+                    ],
                 ],
+                'systemStatus' => true,
             ],
-            'systemStatus' => true,
-        ]);
+            $this->loggerProphecy->reveal(),
+        );
     }
 
-    public static function ghostAttorneyFixture(): Person
+    private function ghostAttorneyFixture(): Person
     {
         return new SiriusLpaAttorney(
             addressLine1: null,
@@ -328,42 +337,48 @@ class FindActorInLpaTest extends TestCase
         );
     }
 
-    public static function multipleAddressAttorneyFixtureOld(): SiriusPerson
+    private function multipleAddressAttorneyFixtureOld(): SiriusPerson
     {
-        return new SiriusPerson([
-            'uId'          => '700000004444',
-            'dob'          => '1980-03-01',
-            'firstname'    => 'Attorneythree',
-            'surname'      => 'Person',
-            'addresses'    => [ // multiple addresses
-                [
-                    'postcode' => 'Ab1 2Cd',
+        return new SiriusPerson(
+            [
+                'uId'          => '700000004444',
+                'dob'          => '1980-03-01',
+                'firstname'    => 'Attorneythree',
+                'surname'      => 'Person',
+                'addresses'    => [ // multiple addresses
+                    [
+                        'postcode' => 'Ab1 2Cd',
+                    ],
+                    [
+                        'postcode' => 'Bc2 3Df',
+                    ],
                 ],
-                [
-                    'postcode' => 'Bc2 3Df',
-                ],
+                'systemStatus' => true,
             ],
-            'systemStatus' => true,
-        ]);
+            $this->loggerProphecy->reveal(),
+        );
     }
 
-    public static function activeAttorneyFixtureOld(): SiriusPerson
+    private static function activeAttorneyFixtureOld(): SiriusPerson
     {
-        return new SiriusPerson([
-            'uId'          => '700000001234',
-            'dob'          => '1980-03-01',
-            'firstname'    => 'Test',
-            'surname'      => 'T’esting',
-            'addresses'    => [
-                [
-                    'postcode' => 'Ab1 2Cd',
+        return new SiriusPerson(
+            [
+                'uId'          => '700000001234',
+                'dob'          => '1980-03-01',
+                'firstname'    => 'Test',
+                'surname'      => 'T’esting',
+                'addresses'    => [
+                    [
+                        'postcode' => 'Ab1 2Cd',
+                    ],
                 ],
+                'systemStatus' => true,
             ],
-            'systemStatus' => true,
-        ]);
+            new Logger('test-output'),
+        );
     }
 
-    public static function activeAttorneyFixture(): SiriusLpaAttorney
+    private static function activeAttorneyFixture(): SiriusLpaAttorney
     {
         return new SiriusLpaAttorney(
             addressLine1: null,
@@ -386,22 +401,25 @@ class FindActorInLpaTest extends TestCase
         );
     }
 
-    public static function donorFixtureOld(): SiriusPerson
+    private static function donorFixtureOld(): SiriusPerson
     {
-        return new SiriusPerson([
-            'uId'       => '700000001111',
-            'dob'       => '1975-10-05',
-            'firstname' => 'Donor',
-            'surname'   => 'Person',
-            'addresses' => [
-                [
-                    'postcode' => 'PY1 3Kd',
+        return new SiriusPerson(
+            [
+                'uId'       => '700000001111',
+                'dob'       => '1975-10-05',
+                'firstname' => 'Donor',
+                'surname'   => 'Person',
+                'addresses' => [
+                    [
+                        'postcode' => 'PY1 3Kd',
+                    ],
                 ],
             ],
-        ]);
+            new Logger('test-output'),
+        );
     }
 
-    public static function donorFixture(): SiriusLpaDonor
+    private static function donorFixture(): SiriusLpaDonor
     {
         return new SiriusLpaDonor(
             addressLine1: null,

--- a/service-api/app/test/AppTest/Service/Lpa/GetAttorneyStatusTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/GetAttorneyStatusTest.php
@@ -30,7 +30,10 @@ class GetAttorneyStatusTest extends TestCase
     #[Test]
     public function returns_0_if_attorney_is_active(): void
     {
-        $attorney = new SiriusPerson(['id' => 7, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true]);
+        $attorney = new SiriusPerson(
+            ['id' => 7, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true],
+            $this->loggerProphecy->reveal(),
+        );
 
         $status = new GetAttorneyStatus(
             $this->loggerProphecy->reveal()
@@ -98,7 +101,10 @@ class GetAttorneyStatusTest extends TestCase
     #[Test]
     public function returns_1_if_attorney_is_a_ghost(): void
     {
-        $attorney = new SiriusPerson(['uId' => 7, 'firstname' => '', 'surname' => '', 'systemStatus' => true]);
+        $attorney = new SiriusPerson(
+            ['uId' => 7, 'firstname' => '', 'surname' => '', 'systemStatus' => true],
+            $this->loggerProphecy->reveal(),
+        );
 
         $status = new GetAttorneyStatus(
             $this->loggerProphecy->reveal()
@@ -166,7 +172,10 @@ class GetAttorneyStatusTest extends TestCase
     #[Test]
     public function returns_2_if_attorney_is_inactive(): void
     {
-        $attorney = new SiriusPerson(['uId' => 7, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => false]);
+        $attorney = new SiriusPerson(
+            ['uId' => 7, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => false],
+            $this->loggerProphecy->reveal(),
+        );
 
         $status = new GetAttorneyStatus(
             $this->loggerProphecy->reveal()

--- a/service-api/app/test/AppTest/Service/Lpa/GetTrustCorporationStatusTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/GetTrustCorporationStatusTest.php
@@ -34,7 +34,8 @@ class GetTrustCorporationStatusTest extends TestCase
                 'uId' => 7,
                 'companyName' => 'ABC Ltd',
                 'systemStatus' => true
-            ]
+            ],
+            $this->loggerProphecy->reveal(),
         );
 
         $status = new GetTrustCorporationStatus(
@@ -79,7 +80,8 @@ class GetTrustCorporationStatusTest extends TestCase
                 'uId'          => 8,
                 'companyName'  => '',
                 'systemStatus' => false
-            ]
+            ],
+            $this->loggerProphecy->reveal(),
         );
 
         $status = new GetTrustCorporationStatus(
@@ -124,7 +126,8 @@ class GetTrustCorporationStatusTest extends TestCase
                 'uId' => 7,
                 'companyName' => 'XYZ Ltd',
                 'systemStatus' => false
-            ]
+            ],
+            $this->loggerProphecy->reveal(),
         );
 
         $status = new GetTrustCorporationStatus(

--- a/service-api/app/test/AppTest/Service/Lpa/IsValidLpaTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/IsValidLpaTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace AppTest\Service\Lpa;
 
 use App\Service\Lpa\IsValidLpa;
+use App\Service\Lpa\SiriusLpa;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\LoggerInterface;
-use App\Service\Lpa\SiriusLpa;
 
 class IsValidLpaTest extends TestCase
 {
@@ -41,7 +41,8 @@ class IsValidLpaTest extends TestCase
                 'donor'  => [
                     'id' => 1,
                 ],
-            ]
+            ],
+            $this->loggerProphecy->reveal(),
         );
 
         $resolver = $this->isValidLpaResolver();
@@ -59,7 +60,8 @@ class IsValidLpaTest extends TestCase
                 'donor'  => [
                     'id' => 1,
                 ],
-            ]
+            ],
+            $this->loggerProphecy->reveal(),
         );
 
         $resolver = $this->isValidLpaResolver();
@@ -77,7 +79,8 @@ class IsValidLpaTest extends TestCase
                 'donor'  => [
                     'id' => 1,
                 ],
-            ]
+            ],
+            $this->loggerProphecy->reveal(),
         );
 
         $resolver = $this->isValidLpaResolver();

--- a/service-api/app/test/AppTest/Service/Lpa/ResolveActor/SiriusHasActorTraitTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/ResolveActor/SiriusHasActorTraitTest.php
@@ -11,39 +11,68 @@ use App\Service\Lpa\ResolveActor\SiriusHasActorTrait;
 use App\Service\Lpa\SiriusPerson;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Log\LoggerInterface;
 
 class SiriusHasActorTraitTest extends TestCase
 {
+    use ProphecyTrait;
+    private LoggerInterface|ObjectProphecy $loggerProphecy;
     private HasActorInterface $mock;
 
     public function setUp(): void
     {
-        $this->mock = new class () implements HasActorInterface {
+        $this->mock = new class (
+            $this->prophesize(LoggerInterface::class)->reveal()
+        ) implements HasActorInterface {
             use SiriusHasActorTrait;
+
+            public function __construct(private LoggerInterface $logger)
+            {
+            }
 
             private function getDonor(): SiriusPerson
             {
-                return new SiriusPerson([
-                    'id'     => 1,
-                    'uId'    => '123456789',
-                    'linked' => [['id' => 1, 'uId' => '123456789'], ['id' => 2, 'uId' => '234567890']],
-                ]);
+                return new SiriusPerson(
+                    [
+                        'id'     => 1,
+                        'uId'    => '123456789',
+                        'linked' => [['id' => 1, 'uId' => '123456789'], ['id' => 2, 'uId' => '234567890']],
+                    ],
+                    $this->logger,
+                );
             }
 
             private function getAttorneys(): array
             {
                 return [
-                    new SiriusPerson(['id' => 3, 'uId' => '345678901', 'firstname' => 'A', 'surname' => 'B']),
-                    new SiriusPerson(['id' => 4, 'uId' => '456789012', 'firstname' => 'B', 'surname' => 'C']),
-                    new SiriusPerson(['id' => 5, 'uId' => '567890123', 'firstname' => 'C', 'surname' => 'D']),
+                    new SiriusPerson(
+                        ['id' => 3, 'uId' => '345678901', 'firstname' => 'A', 'surname' => 'B'],
+                        $this->logger,
+                    ),
+                    new SiriusPerson(
+                        ['id' => 4, 'uId' => '456789012', 'firstname' => 'B', 'surname' => 'C'],
+                        $this->logger,
+                    ),
+                    new SiriusPerson(
+                        ['id' => 5, 'uId' => '567890123', 'firstname' => 'C', 'surname' => 'D'],
+                        $this->logger,
+                    ),
                 ];
             }
 
             private function getTrustCorporations(): array
             {
                 return [
-                    new SiriusPerson(['id' => 6, 'uId' => '678901234', 'companyName' => 'A']),
-                    new SiriusPerson(['id' => 7, 'uId' => '789012345', 'companyName' => 'B']),
+                    new SiriusPerson(
+                        ['id' => 6, 'uId' => '678901234', 'companyName' => 'A'],
+                        $this->logger,
+                    ),
+                    new SiriusPerson(
+                        ['id' => 7, 'uId' => '789012345', 'companyName' => 'B'],
+                        $this->logger,
+                    ),
                 ];
             }
         };

--- a/service-api/app/test/AppTest/Service/Lpa/SiriusLpaManagerTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/SiriusLpaManagerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace AppTest\Service\Lpa;
 
-use Common\Service\Lpa\Factory\Sirius;
 use App\DataAccess\{Repository\InstructionsAndPreferencesImagesInterface,
     Repository\LpasInterface,
     Repository\UserLpaActorMapInterface,
@@ -103,9 +102,12 @@ class SiriusLpaManagerTest extends TestCase
                              'id'           => 6,
                              'companyName'  => 'XYZ Ltd',
                              'systemStatus' => true,
-                            ]),
+                            ],
+                            $this->loggerProphecy->reveal(),
+                        ),
                     ],
                 ],
+                $this->loggerProphecy->reveal(),
             ),
             new DateTime()
         );
@@ -113,20 +115,23 @@ class SiriusLpaManagerTest extends TestCase
         $expectedLpaResponse = new Lpa(
             new SiriusLpa(
                 [
-                    'attorneys'          => [
+                    'attorneys'         => [
                         ['id' => 1, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true],
                         ['id' => 3, 'firstname' => 'A', 'systemStatus' => true],
                         ['id' => 4, 'surname' => 'B', 'systemStatus' => true],
                     ],
-                    'trustCorporations'  => [
+                    'trustCorporations' => [
                         new SiriusPerson(
                             [
                                 'id'           => 6,
                                 'companyName'  => 'XYZ Ltd',
                                 'systemStatus' => true,
-                            ]),
+                            ],
+                            $this->loggerProphecy->reveal(),
+                        ),
                     ],
                 ],
+                $this->loggerProphecy->reveal(),
             ),
             $lpaResponse->getLookupTime()
         );
@@ -138,42 +143,73 @@ class SiriusLpaManagerTest extends TestCase
         $this->lpasInterfaceProphecy->get($testUid)->willReturn($lpaResponse);
 
         $this->getAttorneyStatusProphecy
-            ->__invoke(new SiriusPerson(['id' => 1, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true]))
+            ->__invoke(
+                new SiriusPerson(
+                    ['id' => 1, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => true],
+                    $this->loggerProphecy->reveal(),
+                )
+            )
             ->willReturn(AttorneyStatus::ACTIVE_ATTORNEY);
 
         $this->getAttorneyStatusProphecy
-            ->__invoke(new SiriusPerson(['id' => 2, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => false]))
+            ->__invoke(
+                new SiriusPerson(
+                    ['id' => 2, 'firstname' => 'A', 'surname' => 'B', 'systemStatus' => false],
+                    $this->loggerProphecy->reveal(),
+                )
+            )
             ->willReturn(AttorneyStatus::INACTIVE_ATTORNEY);
 
         $this->getAttorneyStatusProphecy
-            ->__invoke(new SiriusPerson(['id' => 3, 'firstname' => 'A', 'systemStatus' => true]))
+            ->__invoke(
+                new SiriusPerson(
+                    ['id' => 3, 'firstname' => 'A', 'systemStatus' => true],
+                    $this->loggerProphecy->reveal(),
+                )
+            )
             ->willReturn(AttorneyStatus::ACTIVE_ATTORNEY);
 
         $this->getAttorneyStatusProphecy
-            ->__invoke(new SiriusPerson(['id' => 4, 'surname' => 'B', 'systemStatus' => true]))
+            ->__invoke(
+                new SiriusPerson(
+                    ['id' => 4, 'surname' => 'B', 'systemStatus' => true],
+                    $this->loggerProphecy->reveal(),
+                )
+            )
             ->willReturn(AttorneyStatus::ACTIVE_ATTORNEY);
 
         $this->getAttorneyStatusProphecy
-            ->__invoke(new SiriusPerson(['id' => 5, 'systemStatus' => true]))
+            ->__invoke(
+                new SiriusPerson(
+                    ['id' => 5, 'systemStatus' => true],
+                    $this->loggerProphecy->reveal(),
+                )
+            )
             ->willReturn(AttorneyStatus::GHOST_ATTORNEY);
 
         $this->getTrustCorporationStatusProphecy
             ->__invoke(
-                new SiriusPerson([
-                    'id'           => 6,
-                    'companyName'  => 'XYZ Ltd',
-                    'systemStatus' => true,
-                ])
+                new SiriusPerson(
+                    [
+                        'id'           => 6,
+                        'companyName'  => 'XYZ Ltd',
+                        'systemStatus' => true,
+                    ],
+                    $this->loggerProphecy->reveal(),
+                )
             )
             ->willReturn(0);
 
         $this->getTrustCorporationStatusProphecy
             ->__invoke(
-                new SiriusPerson([
-                    'id'           => 7,
-                    'companyName'  => 'ABC Ltd',
-                    'systemStatus' => true,
-                ])
+                new SiriusPerson(
+                    [
+                        'id'           => 7,
+                        'companyName'  => 'ABC Ltd',
+                        'systemStatus' => true,
+                    ],
+                    $this->loggerProphecy->reveal(),
+                )
             )
             ->willReturn(2);
 
@@ -217,6 +253,7 @@ class SiriusLpaManagerTest extends TestCase
                     ],
                     'inactiveAttorneys' => [],
                 ],
+                $this->loggerProphecy->reveal(),
             ),
             new DateTime()
         );
@@ -251,12 +288,17 @@ class SiriusLpaManagerTest extends TestCase
         )->willReturn($validState);
 
         // attorney status is active
-        $this->getAttorneyStatusProphecy->__invoke(new SiriusPerson([
-            'id'           => $t->ActorId,
-            'firstname'    => 'Test',
-            'surname'      => 'Test',
-            'systemStatus' => true,
-        ]))->willReturn(AttorneyStatus::ACTIVE_ATTORNEY);
+        $this->getAttorneyStatusProphecy->__invoke(
+            new SiriusPerson(
+                [
+                'id'           => $t->ActorId,
+                'firstname'    => 'Test',
+                'surname'      => 'Test',
+                'systemStatus' => true,
+                ],
+                $this->loggerProphecy->reveal(),
+            )
+        )->willReturn(AttorneyStatus::ACTIVE_ATTORNEY);
 
         return $t;
     }
@@ -309,6 +351,7 @@ class SiriusLpaManagerTest extends TestCase
                         ],
                     ],
                 ],
+                $this->loggerProphecy->reveal(),
             ),
             new DateTime(),
         );
@@ -344,19 +387,29 @@ class SiriusLpaManagerTest extends TestCase
         )->willReturn(true);
 
         // attorney status is active
-        $this->getAttorneyStatusProphecy->__invoke(new SiriusPerson([
-            'id'           => $t->ActorId,
-            'firstname'    => 'Test',
-            'surname'      => 'Test',
-            'systemStatus' => true,
-        ]))->willReturn(AttorneyStatus::ACTIVE_ATTORNEY);
+        $this->getAttorneyStatusProphecy->__invoke(
+            new SiriusPerson(
+                [
+                    'id'           => $t->ActorId,
+                    'firstname'    => 'Test',
+                    'surname'      => 'Test',
+                    'systemStatus' => true,
+                ],
+                $this->loggerProphecy->reveal(),
+            )
+        )->willReturn(AttorneyStatus::ACTIVE_ATTORNEY);
 
-        $this->getAttorneyStatusProphecy->__invoke(new SiriusPerson([
-            'id'           => 2,
-            'firstname'    => 'Test',
-            'surname'      => 'Test',
-            'systemStatus' => false,
-        ]))->willReturn(AttorneyStatus::INACTIVE_ATTORNEY);
+        $this->getAttorneyStatusProphecy->__invoke(
+            new SiriusPerson(
+                [
+                    'id'           => 2,
+                    'firstname'    => 'Test',
+                    'surname'      => 'Test',
+                    'systemStatus' => false,
+                ],
+                $this->loggerProphecy->reveal(),
+            )
+        )->willReturn(AttorneyStatus::INACTIVE_ATTORNEY);
 
         return $t;
     }
@@ -414,6 +467,7 @@ class SiriusLpaManagerTest extends TestCase
                     ],
                     'inactiveAttorneys' => [],
                 ],
+                $this->loggerProphecy->reveal(),
             ),
             $result['lpa']
         );
@@ -521,7 +575,8 @@ class SiriusLpaManagerTest extends TestCase
                     [
                         'uId'    => 'uid-1',
                         'status' => 'Registered',
-                    ]
+                    ],
+                    $this->loggerProphecy->reveal(),
                 ),
                 new DateTime(),
             ),
@@ -531,6 +586,7 @@ class SiriusLpaManagerTest extends TestCase
                         'uId'    => 'uid-2',
                         'status' => 'Registered',
                     ],
+                    $this->loggerProphecy->reveal(),
                 ),
                 new DateTime()
             ),
@@ -557,6 +613,7 @@ class SiriusLpaManagerTest extends TestCase
                        'status' => 'Registered',
                         'uId'   => 'uid-3',
                     ],
+                    $this->loggerProphecy->reveal(),
                 ),
                 new DateTime(),
             );
@@ -675,7 +732,8 @@ class SiriusLpaManagerTest extends TestCase
                     'inactiveAttorneys'          => [],
                     'applicationHasGuidance'     => true,
                     'applicationHasRestrictions' => true,
-                ]
+                ],
+                $this->loggerProphecy->reveal(),
             ),
             new DateTime()
         );

--- a/service-api/app/test/AppTest/Service/Lpa/SiriusLpaTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/SiriusLpaTest.php
@@ -7,16 +7,29 @@ namespace AppTest\Service\Lpa;
 use App\Service\Lpa\SiriusLpa;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Log\LoggerInterface;
 
 class SiriusLpaTest extends TestCase
 {
+    use ProphecyTrait;
+
+    private LoggerInterface|ObjectProphecy $loggerProphecy;
+
+    protected function setUp(): void
+    {
+        $this->loggerProphecy = $this->prophesize(LoggerInterface::class);
+    }
+
     #[Test]
     public function it_can_be_instantiated(): void
     {
         $sut = new SiriusLpa(
             [
                 'uId' => 700000000000,
-            ]
+            ],
+            $this->loggerProphecy->reveal(),
         );
 
         $this->assertInstanceOf(SiriusLpa::class, $sut);
@@ -28,7 +41,8 @@ class SiriusLpaTest extends TestCase
         $sut = new SiriusLpa(
             [
                 'uId' => 700000000000,
-            ]
+            ],
+            $this->loggerProphecy->reveal(),
         );
 
         $this->assertEquals(700000000000, $sut['uId']);
@@ -46,7 +60,8 @@ class SiriusLpaTest extends TestCase
         $sut = new SiriusLpa(
             [
                 'uId' => 700000000000,
-            ]
+            ],
+            $this->loggerProphecy->reveal(),
         );
 
         foreach ($sut as $key => $value) {
@@ -60,7 +75,8 @@ class SiriusLpaTest extends TestCase
         $sut = new SiriusLpa(
             [
                 'uId' => 700000000000,
-            ]
+            ],
+            $this->loggerProphecy->reveal(),
         );
 
         $this->assertEquals(
@@ -77,7 +93,8 @@ class SiriusLpaTest extends TestCase
         $sut = new SiriusLpa(
             [
                 'uId' => 700000000000,
-            ]
+            ],
+            $this->loggerProphecy->reveal(),
         );
 
         $this->assertJsonStringEqualsJsonString(
@@ -92,7 +109,8 @@ class SiriusLpaTest extends TestCase
             [
                 'uId'    => 700000000000,
                 'status' => 'Registered',
-            ]
+            ],
+            $this->loggerProphecy->reveal(),
         );
 
         $this->assertSame('700000000000', $sut->getUid());

--- a/service-api/app/test/AppTest/Service/Lpa/SiriusPersonTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/SiriusPersonTest.php
@@ -7,16 +7,29 @@ namespace AppTest\Service\Lpa;
 use App\Service\Lpa\SiriusPerson;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Log\LoggerInterface;
 
 class SiriusPersonTest extends TestCase
 {
+    use ProphecyTrait;
+
+    private LoggerInterface|ObjectProphecy $loggerProphecy;
+
+    protected function setUp(): void
+    {
+        $this->loggerProphecy = $this->prophesize(LoggerInterface::class);
+    }
+
     #[Test]
     public function it_can_be_instantiated(): void
     {
         $sut = new SiriusPerson(
             [
                 'uId' => 700000000000,
-            ]
+            ],
+            $this->loggerProphecy->reveal(),
         );
 
         $this->assertInstanceOf(SiriusPerson::class, $sut);
@@ -28,7 +41,8 @@ class SiriusPersonTest extends TestCase
         $sut = new SiriusPerson(
             [
                 'uId' => 700000000000,
-            ]
+            ],
+            $this->loggerProphecy->reveal(),
         );
 
         $this->assertEquals(700000000000, $sut['uId']);
@@ -46,7 +60,8 @@ class SiriusPersonTest extends TestCase
         $sut = new SiriusPerson(
             [
                 'uId' => 700000000000,
-            ]
+            ],
+            $this->loggerProphecy->reveal(),
         );
 
         foreach ($sut as $key => $value) {
@@ -60,7 +75,8 @@ class SiriusPersonTest extends TestCase
         $sut = new SiriusPerson(
             [
                 'uId' => 700000000000,
-            ]
+            ],
+            $this->loggerProphecy->reveal(),
         );
 
         $this->assertEquals(
@@ -77,7 +93,8 @@ class SiriusPersonTest extends TestCase
         $sut = new SiriusPerson(
             [
                 'uId' => 700000000000,
-            ]
+            ],
+            $this->loggerProphecy->reveal(),
         );
 
         $this->assertJsonStringEqualsJsonString(
@@ -94,7 +111,8 @@ class SiriusPersonTest extends TestCase
                 'uId' => 700000000000,
                 'systemStatus' => 1,
                 'companyName' => null,
-            ]
+            ],
+            $this->loggerProphecy->reveal(),
         );
 
         $this->assertSame('700000000000', $sut->getUid());


### PR DESCRIPTION
… discover all the hidden places it's being used.

# Purpose

Whilst trying to get the feature flagged tests working when it's enabled I keep coming across bits of the app that were never migrated to the new interfaces and continue to use the old array access.

This PR adds debug logging to those usages so that we can see them in the logs. 

It's quite possible that even whilst *not* logging at the debug level there will be a performance impact in production since the data is still collected. If that's found to be the case then we should back it out.

## Approach

Add log calls to offset* methods.

## Learning

If we'd done our due diligence when putting together the interim Sirius object and had mandated the usage of a factory class to build them (instead of 'newing' up everywhere) this PR would be about 4 files and 3 hours less work.

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [x] I have performed a self-review of my own code
* [x] I have added tests to prove my work
* [x] I have added relevant and appropriately leveled logging, **without PII**, to my code
* [ ] ~New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
* [ ] ~I have updated documentation (Confluence/GitHub wiki/tech debt doc)~
* [ ] ~I have added welsh translation tags and updated translation files~
* [ ] ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* [ ] ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* [ ] ~The product team have tested these changes~
