### PR TITLE
Remove confd for nginx config and use native templating instead

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,6 @@ services:
       WEB_DOMAIN: http://localhost:9001
       APP_HOST: viewer-app
       APP_PORT: 9000
-      NGINX_LOG_LEVEL: warn
     depends_on:
       - esbuild
       - viewer-app
@@ -82,7 +81,6 @@ services:
       WEB_DOMAIN: http://localhost:9002
       APP_HOST: actor-app
       APP_PORT: 9000
-      NGINX_LOG_LEVEL: warn
     depends_on:
       - esbuild
       - actor-app
@@ -162,7 +160,6 @@ services:
     environment:
       APP_HOST: api-app
       APP_PORT: 9000
-      NGINX_LOG_LEVEL: warn
     depends_on:
       - api-app
 

--- a/service-api/docker/web/Dockerfile
+++ b/service-api/docker/web/Dockerfile
@@ -1,23 +1,10 @@
-FROM golang:1.23-alpine AS confd_builder
-
-RUN apk add --no-cache make git && \
-    cd / && \
-    git clone https://github.com/kelseyhightower/confd.git build && \
-    cd build && \
-    git checkout 919444eb && \
-    make build
-
 FROM nginxinc/nginx-unprivileged:stable-alpine
 USER root
 
 RUN apk upgrade && \
   apk update curl
 
-# Add Confd to configure nginx on start
-COPY --from=confd_builder /build/bin/confd /usr/local/bin/confd
-RUN chmod +x /usr/local/bin/confd
-
-COPY service-api/docker/web/etc /etc
+COPY service-api/docker/web/default.conf.template /etc/nginx/templates/default.conf.template
 
 RUN apk --no-cache add libcap && \
     setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx && \

--- a/service-api/docker/web/Dockerfile
+++ b/service-api/docker/web/Dockerfile
@@ -14,6 +14,3 @@ COPY scripts/docker_hardening/harden-nginx.sh /harden-nginx.sh
 RUN /harden-nginx.sh && rm /harden-nginx.sh
 
 USER nginx
-
-CMD confd -onetime -backend env \
-  && nginx -g "daemon off;"

--- a/service-api/docker/web/default.conf.template
+++ b/service-api/docker/web/default.conf.template
@@ -30,7 +30,7 @@ server {
     server_name  _;
     server_tokens off;
 
-    error_log /var/log/nginx/error.log {{ getv "/nginx/log/level" "warn" }};
+    error_log /var/log/nginx/error.log "warn";
     access_log /var/log/nginx/access.log json_combined;
 
     gzip on;
@@ -53,7 +53,7 @@ server {
     # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
     #
     location ~ \.php$ {
-        fastcgi_pass   {{getv "/app/host" }}:{{getv "/app/port" }};
+        fastcgi_pass   ${APP_HOST}:${APP_PORT};
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
 

--- a/service-api/docker/web/etc/confd/conf.d/nginx.toml
+++ b/service-api/docker/web/etc/confd/conf.d/nginx.toml
@@ -1,4 +1,0 @@
-[template]
-src  = "nginx.conf"
-dest = "/etc/nginx/conf.d/default.conf"
-keys = ["/app/host", "/app/port", "/nginx/log/level"]

--- a/service-front/docker/web/Dockerfile
+++ b/service-front/docker/web/Dockerfile
@@ -1,11 +1,3 @@
-FROM golang:1.23-alpine AS confd_builder
-
-RUN apk add --no-cache make git && \
-    cd / && \
-    git clone https://github.com/kelseyhightower/confd.git build && \
-    cd build && \
-    git checkout 919444eb && \
-    make build
 
 FROM nginxinc/nginx-unprivileged:stable-alpine
 USER root
@@ -13,11 +5,7 @@ USER root
 RUN apk upgrade && \
   apk update curl
 
-# Add Confd to configure nginx on start
-COPY --from=confd_builder /build/bin/confd /usr/local/bin/confd
-RUN chmod +x /usr/local/bin/confd
-
-COPY service-front/docker/web/etc /etc
+COPY service-front/docker/web/default.conf.template /etc/nginx/templates/default.conf.template
 COPY service-front/docker/web/web /web
 
 RUN apk --no-cache add libcap && \
@@ -31,5 +19,4 @@ RUN /harden-nginx.sh && rm /harden-nginx.sh
 
 USER nginx
 
-CMD confd -onetime -backend env \
-  && nginx -g "daemon off;"
+

--- a/service-front/docker/web/default.conf.template
+++ b/service-front/docker/web/default.conf.template
@@ -58,7 +58,7 @@ server {
     server_name   _;
     server_tokens off;
 
-    error_log  /var/log/nginx/error.log {{ getv "/nginx/log/level" "warn" }};
+    error_log  /var/log/nginx/error.log "warn";
     access_log /var/log/nginx/access.log json_combined;
 
     gzip            on;
@@ -72,12 +72,12 @@ server {
     set $CSP_font    "font-src    'self'";
     set $CSP_form    "form-action 'self'";
     set $CSP_connect "connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com";
-    set $CSP_report  "report-uri {{ getv "/web/domain" "http://localhost" }}/_csp";
+    set $CSP_report  "report-uri ${WEB_DOMAIN}/_csp";
 
     add_header Content-Security-Policy-Report-Only "default-src 'none'; ${CSP_image}; ${CSP_font}; ${CSP_connect}; ${CSP_script} '${CSP_nonce}'; ${CSP_style} '${CSP_nonce}'; ${CSP_form}; ${CSP_report};";
 
     # add CORS headers
-    add_header Access-Control-Allow-Origin {{ getv "/web/domain" "http://localhost" }} always;
+    add_header Access-Control-Allow-Origin ${WEB_DOMAIN} always;
     add_header Access-Control-Allow-Credentials 'true' always;
     add_header Access-Control-Allow-Methods "GET,POST,OPTIONS";
     add_header Access-Control-Allow-Headers "Authorization,Accept,Origin,DNT,User-Agent,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range";
@@ -188,5 +188,5 @@ server {
 }
 
 upstream @php {
-    server {{getv "/app/host" }}:{{getv "/app/port" }};
+    server ${APP_HOST}:${APP_PORT};
 }

--- a/service-front/docker/web/etc/confd/conf.d/nginx.toml
+++ b/service-front/docker/web/etc/confd/conf.d/nginx.toml
@@ -1,4 +1,0 @@
-[template]
-src  = "nginx.conf"
-dest = "/etc/nginx/conf.d/default.conf"
-keys = ["/web/domain", "/app/host", "/app/port", "/nginx/log/level"]


### PR DESCRIPTION
# Purpose

Removes the older confd templating of web server files and replaces with the native nginx one. Fixes UML-3774
