### PR TITLE
UML-3738: add role permissions to decrypt kms key

### DIFF
--- a/terraform/account/kms.tf
+++ b/terraform/account/kms.tf
@@ -200,9 +200,20 @@ data "aws_iam_policy_document" "event_receiver_kms" {
       identifiers = [
         "sqs.amazonaws.com",
         "events.amazonaws.com",
-        "lambda.amazonaws.com",
       ]
     }
+  }
+  statement {
+    sid       = "Allow Lambda Decrypt"
+    effect    = "Allow"
+    resources = ["*"]
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/event-receiver-${local.environment}"
+      ]
+    }
+
   }
 
   statement {


### PR DESCRIPTION
# Purpose

Allows the Lambda role to decrypt the KMS key

Fixes UML-3738

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [ ] I have performed a self-review of my own code
* [ ] I have added tests to prove my work
* [ ] I have added relevant and appropriately leveled logging, **without PII**, to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc)
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
