### PR TITLE
UML-3731: allow lambda access to DynamoDB

### DIFF
--- a/terraform/environment/lambda.tf
+++ b/terraform/environment/lambda.tf
@@ -135,6 +135,27 @@ data "aws_iam_policy_document" "lambda_event_receiver" {
     ]
     resources = [data.aws_kms_alias.event_receiver.target_key_arn]
   }
+
+  statement {
+    sid    = "DynamoDBTableAccess"
+    effect = "Allow"
+    resources = [
+      aws_dynamodb_table.user_lpa_actor_map.arn,
+      aws_dynamodb_table.use_users_table.arn
+    ]
+    actions = [
+      "dynamodb:BatchGetItem",
+      "dynamodb:BatchWriteItem",
+      "dynamodb:ConditionCheckItem",
+      "dynamodb:PutItem",
+      "dynamodb:DescribeTable",
+      "dynamodb:DeleteItem",
+      "dynamodb:GetItem",
+      "dynamodb:Scan",
+      "dynamodb:Query",
+      "dynamodb:UpdateItem"
+    ]
+  }
 }
 
 resource "aws_lambda_event_source_mapping" "receive_events_mapping" {


### PR DESCRIPTION
# Purpose

Allows the Lambda execution role permissions to read/write to DynamoDB. It's quite permissive at the moment, but we'll refine it later on.

Fixes UML-3731

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [x] I have performed a self-review of my own code
* [ ] I have added tests to prove my work
* [ ] I have added relevant and appropriately leveled logging, **without PII**, to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc)
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
