### PR TITLE
UML-3780: Creation of sharecodes for all LPAs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       AWS_SECRET_ACCESS_KEY: "secretdevkey"
       LOGGING_LEVEL: "100" # \Monolog\Logger::DEBUG
       PHP_IDE_CONFIG: serverName=viewer-app
-      XDEBUG_CONFIG: client_host=host.docker.internal client_port=9000
+      XDEBUG_CONFIG: client_host=host.docker.internal
       XDEBUG_MODE: develop,debug,coverage # off # xdebug can be disable by replacing modes with "off"
       SESSION_EXPIRES: 30 # session expiry length to support timeout message.
       COOKIE_EXPIRES: 1440 # cookie expiry for complete logout - initial value to be 24 hours.
@@ -102,7 +102,7 @@ services:
       # Feature flags
       DELETE_LPA_FEATURE: "true"
       ALLOW_MERIS_LPAS: "false"
-      SUPPORT_DATASTORE_LPAS: "false"
+      SUPPORT_DATASTORE_LPAS: "true"
 
       # Local only
       API_SERVICE_URL:
@@ -111,7 +111,7 @@ services:
       AWS_SECRET_ACCESS_KEY: "secretdevkey"
       LOGGING_LEVEL: "100" # \Monolog\Logger::DEBUG
       PHP_IDE_CONFIG: serverName=actor-app
-      XDEBUG_CONFIG: client_host=host.docker.internal client_port=9000
+      XDEBUG_CONFIG: client_host=host.docker.internal
       XDEBUG_MODE: develop,debug,coverage # off # xdebug can be disable by replacing modes with "off"
       SESSION_EXPIRES: 20 # session expiry length to support timeout message.
       SESSION_EXPIRY_WARNING: 5 # session expiry warning time to trigger popup window.
@@ -185,7 +185,7 @@ services:
 
       # Feature flags
       ALLOW_MERIS_LPAS: "false"
-      SUPPORT_DATASTORE_LPAS: "false"
+      SUPPORT_DATASTORE_LPAS: "true"
 
       # Local only
       AWS_ACCESS_KEY_ID: "devkey"
@@ -197,8 +197,9 @@ services:
       PACT_BROKER_PUBLISH: "false"
       LOGGING_LEVEL: "100" # \Monolog\Logger::DEBUG
       PHP_IDE_CONFIG: serverName=api-app
-      XDEBUG_CONFIG: client_host=host.docker.internal client_port=9000
+      XDEBUG_CONFIG: client_host=host.docker.internal
       XDEBUG_MODE: develop,debug,coverage # off # xdebug can be disable by replacing modes with "off"
+      XDEBUG_TRIGGER: "true"
       NOTIFY_API_KEY:
 
   api-composer:

--- a/service-api/app/features/actor-create-access-code.feature
+++ b/service-api/app/features/actor-create-access-code.feature
@@ -29,3 +29,9 @@ Feature: The user is able to create access codes for organisations
     And The status of the LPA got Revoked
     When I request to give an organisation access to the LPA whose status changed to Revoked
     Then I am taken back to the dashboard page
+
+  @acceptance @integration
+  Scenario: As a user I can generate an access code for an organisation to one of my new LPA
+    Given I am on the dashboard page
+    When I request to give an organisation access to one of my new LPA
+    Then I am given a unique access code

--- a/service-api/app/features/context/Acceptance/LpaContext.php
+++ b/service-api/app/features/context/Acceptance/LpaContext.php
@@ -1731,7 +1731,7 @@ class LpaContext implements Context
                             'SiriusUid' => $this->lpaUid,
                             'Added'     => (new DateTime('2020-01-01'))->format('Y-m-d\TH:i:s.u\Z'),
                             'Id'        => $this->userLpaActorToken,
-                            'ActorId'   => $actorId,
+                            'ActorId'   => (string)$actorId,
                             'UserId'    => $this->userId,
                         ]
                     ),

--- a/service-api/app/features/context/Acceptance/LpaContext.php
+++ b/service-api/app/features/context/Acceptance/LpaContext.php
@@ -1753,6 +1753,46 @@ class LpaContext implements Context
     }
 
     /**
+     * @When /^I request to give an organisation access to one of my new LPA$/
+     */
+    public function iRequestToGiveAnOrganisationAccessToOneOfMyNewLPA(): void
+    {
+        $this->organisation = 'TestOrg';
+        $this->accessCode   = 'XYZ321ABC987';
+        $actorId            = 700000000054;
+        $lpaUid             = 'M-XXXX-1111-YYYY';
+
+        // UserLpaActorMap::get
+        $this->awsFixtures->append(
+            new Result(
+                [
+                    'Item' => $this->marshalAwsResultData(
+                        [
+                            'LpaUid'    => $lpaUid,
+                            'Added'     => (new DateTime('2020-01-01'))->format('Y-m-d\TH:i:s.u\Z'),
+                            'Id'        => $this->userLpaActorToken,
+                            'ActorId'   => (string)$actorId,
+                            'UserId'    => $this->userId,
+                        ]
+                    ),
+                ]
+            )
+        );
+
+        // ViewerCodes::add
+        $this->awsFixtures->append(new Result());
+
+        // ViewerCodeService::createShareCode
+        $this->apiPost(
+            '/v1/lpas/' . $this->userLpaActorToken . '/codes',
+            ['organisation' => $this->organisation],
+            [
+                'user-token' => $this->userId,
+            ]
+        );
+    }
+
+    /**
      * @Given /^I request to go back and try again$/
      */
     public function iRequestToGoBackAndTryAgain(): void

--- a/service-api/app/features/context/Integration/LpaContext.php
+++ b/service-api/app/features/context/Integration/LpaContext.php
@@ -2065,6 +2065,37 @@ class LpaContext extends BaseIntegrationContext
     }
 
     /**
+     * @When /^I request to give an organisation access to one of my new LPA$/
+     */
+    public function iRequestToGiveAnOrganisationAccessToOneOfMyNewLPA(): void
+    {
+        $this->organisation = 'TestOrg';
+        $this->accessCode   = 'XYZ321ABC987';
+        $actorLpaId         = 700000000054;
+        $lpaUid             = 'M-XXXX-1111-YYYY';
+
+        // UserLpaActorMap::get
+        $this->awsFixtures->append(
+            new Result(
+                [
+                    'Item' => $this->marshalAwsResultData(
+                        [
+                            'LpaUid'    => $lpaUid,
+                            'Added'     => (new DateTime('2020-01-01'))->format('Y-m-d\TH:i:s.u\Z'),
+                            'Id'        => $this->userLpaActorToken,
+                            'ActorId'   => (string)$actorLpaId,
+                            'UserId'    => $this->userId,
+                        ]
+                    ),
+                ]
+            )
+        );
+
+        // ViewerCodes::add
+        $this->awsFixtures->append(new Result());
+    }
+
+    /**
      * @Given /^I request to go back and try again$/
      * @Then /^I am asked for my role on the LPA$/
      */

--- a/service-api/app/features/context/Integration/LpaContext.php
+++ b/service-api/app/features/context/Integration/LpaContext.php
@@ -2052,7 +2052,7 @@ class LpaContext extends BaseIntegrationContext
                             'SiriusUid' => $this->lpaUid,
                             'Added'     => (new DateTime('2020-01-01'))->format('Y-m-d\TH:i:s.u\Z'),
                             'Id'        => $this->userLpaActorToken,
-                            'ActorId'   => $actorLpaId,
+                            'ActorId'   => (string)$actorLpaId,
                             'UserId'    => $this->userId,
                         ]
                     ),

--- a/service-api/app/src/App/src/DataAccess/DynamoDb/ViewerCodes.php
+++ b/service-api/app/src/App/src/DataAccess/DynamoDb/ViewerCodes.php
@@ -67,7 +67,7 @@ class ViewerCodes implements ViewerCodesInterface
         string $siriusUid,
         DateTime $expires,
         string $organisation,
-        ?int $actorId,
+        ?string $actorId,
     ): void {
         // The current DateTime, including microseconds
         $now = (new DateTime())->format('Y-m-d\TH:i:s.u\Z');
@@ -83,7 +83,7 @@ class ViewerCodes implements ViewerCodesInterface
                     'Expires'      => ['S' => $expires->format('c')],
                     // We use 'c' so not to assume UTC.
                     'Organisation' => ['S' => $organisation],
-                    'CreatedBy'    => ['N' => (string)$actorId],
+                    'CreatedBy'    => ['S' => $actorId],
                     ],
                 'ConditionExpression' => 'attribute_not_exists(ViewerCode)',
             ]);

--- a/service-api/app/src/App/src/DataAccess/Repository/ViewerCodesInterface.php
+++ b/service-api/app/src/App/src/DataAccess/Repository/ViewerCodesInterface.php
@@ -51,7 +51,7 @@ interface ViewerCodesInterface
      * @param string   $siriusUid
      * @param DateTime $expires
      * @param string   $organisation
-     * @param int|null $actorId
+     * @param string|null $actorId
      * @return void
      */
     public function add(
@@ -60,7 +60,7 @@ interface ViewerCodesInterface
         string $siriusUid,
         DateTime $expires,
         string $organisation,
-        ?int $actorId,
+        ?string $actorId,
     ): void;
 
     /**

--- a/service-api/app/src/App/src/DataAccess/Repository/ViewerCodesInterface.php
+++ b/service-api/app/src/App/src/DataAccess/Repository/ViewerCodesInterface.php
@@ -15,9 +15,10 @@ use DateTime;
  *     Added: string,
  *     Expires: string,
  *     Organisation: string,
- *     SiriusUid: string,
+ *     SiriusUid?: string,
+ *     LpaUid?: string,
  *     UserLpaActor: string,
- *     CreatedBy?: int,
+ *     CreatedBy?: string,
  *     Cancelled?: string,
  * }
  */
@@ -46,18 +47,21 @@ interface ViewerCodesInterface
      *
      * $siriusUid is denormalised.
      *
-     * @param string   $code
-     * @param string   $userLpaActorToken
-     * @param string   $siriusUid
-     * @param DateTime $expires
-     * @param string   $organisation
-     * @param string|null $actorId
+     * @param string        $code
+     * @param string        $userLpaActorToken
+     * @param string|null   $siriusUid
+     * @param string|null   $lpaUid
+     * @param DateTime      $expires
+     * @param string        $organisation
+     * @param string|null   $actorId
+     *
      * @return void
      */
     public function add(
         string $code,
         string $userLpaActorToken,
-        string $siriusUid,
+        ?string $siriusUid,
+        ?string $lpaUid,
         DateTime $expires,
         string $organisation,
         ?string $actorId,

--- a/service-api/app/src/App/src/Service/ViewerCodes/ViewerCodeService.php
+++ b/service-api/app/src/App/src/Service/ViewerCodes/ViewerCodeService.php
@@ -14,6 +14,7 @@ use App\DataAccess\Repository\{KeyCollisionException,
 use DateTime;
 use DateTimeZone;
 use Psr\Log\LoggerInterface;
+use App\Enum\LpaSource;
 
 /**
  * @psalm-import-type UserLpaActorMap from UserLpaActorMapInterface
@@ -51,7 +52,17 @@ class ViewerCodeService
         }
         //---
 
-        $uid = $map['SiriusUid'] ?? $map['LpaUid'];
+        //$uid = $map['SiriusUid'] ?? $map['LpaUid'];
+
+        //
+        if (isset($map['SiriusUid'])) {
+            $SiriusUid = $map['SiriusUid'];
+            $LpaUid    = null;
+        } else {
+            $LpaUid    = $map['LpaUid'];
+            $SiriusUid = null;
+        }
+        //
 
         $expires = new DateTime(
             '23:59:59 +30 days',              // Set to the last moment of the day, x days from now.
@@ -67,10 +78,11 @@ class ViewerCodeService
                 $this->viewerCodesRepository->add(
                     $code,
                     $map['Id'],
-                    $uid,
+                    $SiriusUid,
+                    $LpaUid,
                     $expires,
                     $organisation,
-                    $map['ActorId']
+                    (string)$map['ActorId']
                 );
 
                 $added = true;

--- a/service-api/app/src/App/src/Service/ViewerCodes/ViewerCodeService.php
+++ b/service-api/app/src/App/src/Service/ViewerCodes/ViewerCodeService.php
@@ -44,25 +44,21 @@ class ViewerCodeService
      */
     public function addCode(string $token, string $userId, string $organisation): ?array
     {
+        $lpaUid    = null;
+        $siriusUid = null;
+
         $map = $this->userLpaActorMapRepository->get($token);
 
         // Ensure the passed userId matches the passed token
         if ($userId !== $map['UserId']) {
             return null;
         }
-        //---
 
-        //$uid = $map['SiriusUid'] ?? $map['LpaUid'];
-
-        //
         if (isset($map['SiriusUid'])) {
-            $SiriusUid = $map['SiriusUid'];
-            $LpaUid    = null;
+            $siriusUid = $map['SiriusUid'];
         } else {
-            $LpaUid    = $map['LpaUid'];
-            $SiriusUid = null;
+            $lpaUid = $map['LpaUid'];
         }
-        //
 
         $expires = new DateTime(
             '23:59:59 +30 days',              // Set to the last moment of the day, x days from now.
@@ -78,8 +74,8 @@ class ViewerCodeService
                 $this->viewerCodesRepository->add(
                     $code,
                     $map['Id'],
-                    $SiriusUid,
-                    $LpaUid,
+                    $siriusUid,
+                    $lpaUid,
                     $expires,
                     $organisation,
                     (string)$map['ActorId']

--- a/service-api/app/src/App/src/Service/ViewerCodes/ViewerCodeService.php
+++ b/service-api/app/src/App/src/Service/ViewerCodes/ViewerCodeService.php
@@ -49,10 +49,10 @@ class ViewerCodeService
         if ($userId !== $map['UserId']) {
             return null;
         }
-
         //---
 
-        $uid     = $map['SiriusUid'] ?? $map['LpaUid'];
+        $uid = $map['SiriusUid'] ?? $map['LpaUid'];
+
         $expires = new DateTime(
             '23:59:59 +30 days',              // Set to the last moment of the day, x days from now.
             new DateTimeZone('Europe/London') // Ensures we compensate for GMT vs BST.

--- a/service-api/app/test/AppTest/Service/ViewerCodes/ViewerCodeServiceTest.php
+++ b/service-api/app/test/AppTest/Service/ViewerCodes/ViewerCodeServiceTest.php
@@ -41,7 +41,7 @@ class ViewerCodeServiceTest extends TestCase
     }
 
     #[Test]
-    public function it_will_make_a_new_viewer_code_for_an_lpa(): void
+    public function it_will_make_a_new_viewer_code_for_a_Sirius_lpa(): void
     {
         // code will expire 30 days from midnight of the day the test runs
         $codeExpiry = new DateTime(
@@ -55,9 +55,10 @@ class ViewerCodeServiceTest extends TestCase
                 Argument::type('string'),
                 'id',
                 '700000000047',
+                null,
                 Argument::exact($codeExpiry),
                 'token name',
-                1234
+                '1234'
             )
             ->shouldBeCalled();
 
@@ -93,6 +94,62 @@ class ViewerCodeServiceTest extends TestCase
         $this->assertArrayHasKey('organisation', $result);
         $this->assertEquals('token name', $result['organisation']);
     }
+
+    #[Test]
+    public function it_will_make_a_new_viewer_code_for_a_data_store_lpa(): void
+    {
+        // code will expire 30 days from midnight of the day the test runs
+        $codeExpiry = new DateTime(
+            '23:59:59 +30 days',                // Set to the last moment of the day, x days from now.
+            new DateTimeZone('Europe/London')   // Ensures we compensate for GMT vs BST.
+        );
+
+        $viewerCodeRepoProphecy = $this->prophesize(ViewerCodesInterface::class);
+        $viewerCodeRepoProphecy
+            ->add(
+                Argument::type('string'),
+                'id',
+                null,
+                'M-XXXX-1212-ZZZZ',
+                Argument::exact($codeExpiry),
+                'token name',
+                '1234'
+            )
+            ->shouldBeCalled();
+
+        $viewerCodeActivityRepoProphecy = $this->prophesize(ViewerCodeActivityInterface::class);
+
+        $userActorLpaRepoProphecy = $this->prophesize(UserLpaActorMapInterface::class);
+        $userActorLpaRepoProphecy
+            ->get('user_actor_lpa_token')
+            ->shouldBeCalled()
+            ->willReturn(
+                [
+                    'Id'        => 'id',
+                    'UserId'    => 'user_id',
+                    'LpaUid' => 'M-XXXX-1212-ZZZZ',
+                    'ActorId'   => '1234',
+                ]
+            );
+
+        $loggerProphecy = $this->prophesize(LoggerInterface::class);
+
+        $service = new ViewerCodeService(
+            $viewerCodeRepoProphecy->reveal(),
+            $viewerCodeActivityRepoProphecy->reveal(),
+            $userActorLpaRepoProphecy->reveal(),
+            $loggerProphecy->reveal(),
+        );
+
+        $result = $service->addCode('user_actor_lpa_token', 'user_id', 'token name');
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('code', $result);
+        $this->assertArrayHasKey('expires', $result);
+        $this->assertArrayHasKey('organisation', $result);
+        $this->assertEquals('token name', $result['organisation']);
+    }
+
 
     #[Test]
     public function it_wont_create_a_code_if_user_does_not_match(): void
@@ -136,9 +193,10 @@ class ViewerCodeServiceTest extends TestCase
                 Argument::type('string'),
                 'id',
                 '700000000047',
+                null,
                 Argument::type(DateTime::class),
                 'token name',
-                1234
+                '1234'
             )
             ->shouldBeCalledTimes(2)
             ->will(function () use (&$callCount) {
@@ -161,7 +219,7 @@ class ViewerCodeServiceTest extends TestCase
                     'Id'        => 'id',
                     'UserId'    => 'user_id',
                     'SiriusUid' => '700000000047',
-                    'ActorId'   => 1234,
+                    'ActorId'   => '1234',
                 ]
             );
 

--- a/service-front/app/src/Actor/templates/actor/lpa-show-viewercode-combined-lpa.html.twig
+++ b/service-front/app/src/Actor/templates/actor/lpa-show-viewercode-combined-lpa.html.twig
@@ -49,29 +49,6 @@
 
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-three-quarters">
-                    {% if not feature_enabled("instructions_and_preferences") %}
-                        <div class="govuk-warning-text">
-                            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                            <span class="govuk-visually-hidden">{% trans %}Warning{% endtrans %}</span>
-                            {% if is_donor_signature_date_too_old(lpa) %}
-                                <p class="govuk-body"><strong class="govuk-warning-text__text">
-                                        {% trans %}If there are instructions or preferences on this LPA, you may also be asked to show the paper LPA.{% endtrans %}
-                                    </strong></p>
-                            {% elseif lpa.applicationHasRestrictions and lpa.applicationHasGuidance %}
-                                <p class="govuk-body"><strong class="govuk-warning-text__text">
-                                        {% trans %}As there are instructions and preferences on this LPA, you may also be asked to show the paper LPA.{% endtrans %}
-                                    </strong></p>
-                            {% elseif lpa.applicationHasRestrictions %}
-                                <p class="govuk-body"><strong class="govuk-warning-text__text">
-                                        {% trans %}As there are instructions on this LPA, you may also be asked to show the paper LPA.{% endtrans %}
-                                    </strong></p>
-                            {% elseif lpa.applicationHasGuidance %}
-                                <p class="govuk-body"><strong class="govuk-warning-text__text">
-                                        {% trans %}As there are preferences on this LPA, you may also be asked to show the paper LPA.{% endtrans %}
-                                    </strong></p>
-                            {% endif %}
-                        </div>
-                    {% endif %}
 
                     <h2 class="govuk-body-l govuk-!-font-weight-bold">{% trans %}What to do next{% endtrans %}</h2>
 
@@ -88,7 +65,6 @@
 
                     </p>
 
-                    {% if feature_enabled('instructions_and_preferences') %}
                         {% if not is_donor_signature_date_too_old(lpa) %}
                             <p class="govuk-body">
                                 {% if lpa.applicationHasRestrictions and lpa.applicationHasGuidance %}
@@ -105,15 +81,6 @@
                                     {% endtrans %}
                                 {% endif %}
                             </p>
-                        {% elseif is_donor_signature_date_too_old(lpa) %}
-                            {% if lpa.applicationHasRestrictions or lpa.applicationHasGuidance %}
-                                <p class="govuk-body">
-                                    {% trans %}
-                                        Scanned copies of the donor’s preferences or instructions will be shown in the LPA summary. You’ll need to show organisations the paper LPA if any part of these cannot be read properly.
-                                    {% endtrans %}
-                                </p>
-                            {% endif %}
-                        {% endif %}
                     {% endif %}
 
                     {% if lpa.caseSubtype.value == 'pfa' %}


### PR DESCRIPTION
# Purpose

Share code creation currently stores code records with reference to a SiriusLPA which is not appropriate for LpaStore types.
This change is to accommodate code creation for LpaStore types too.

Fixes UML-3780

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [X] I have performed a self-review of my own code
* [X] I have added tests to prove my work
* [ ] I have added relevant and appropriately leveled logging, **without PII**, to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc)
-* [ ] I have added welsh translation tags and updated translation files-
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
