### PR TITLE
UML-3813 upgrade deprecated upload_artifact and download_artifact in CI build

### DIFF
--- a/.github/workflows/_build-and-push.yml
+++ b/.github/workflows/_build-and-push.yml
@@ -233,7 +233,7 @@ jobs:
           (inputs.specific_path == 'all' || inputs.specific_path == matrix.svc_prefix)
 
       - name: archive test results
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: service-${{ matrix.svc_prefix }}
           path: build/service-${{ matrix.svc_prefix }}

--- a/.github/workflows/_build-and-push.yml
+++ b/.github/workflows/_build-and-push.yml
@@ -127,7 +127,7 @@ jobs:
           (inputs.specific_path == 'all' || inputs.specific_path == matrix.svc_prefix)
 
       - name: download artifact
-        uses: actions/download-artifact@7fba95161a0924506ed1ae69cdbae8371ee00b3f
+        uses: actions/download-artifact@v4.1.8
         with:
           name: ${{ matrix.artifact_to_dl }}
           path: service-${{ matrix.svc_prefix }}/web/dist

--- a/.github/workflows/_codecov.yml
+++ b/.github/workflows/_codecov.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2 # pin@v3
       - name: download artifact for front tests
         id: download-artifact-front-tests
-        uses: actions/download-artifact@7fba95161a0924506ed1ae69cdbae8371ee00b3f
+        uses: actions/download-artifact@v4.1.8
         continue-on-error: true
         with:
           name: service-front
@@ -26,7 +26,7 @@ jobs:
         if: inputs.specific_path == 'all'
       - name: download artifact for api tests
         id: download-artifact-api-tests
-        uses: actions/download-artifact@7fba95161a0924506ed1ae69cdbae8371ee00b3f
+        uses: actions/download-artifact@v4.1.8
         continue-on-error: true
         with:
           name: service-api
@@ -34,7 +34,7 @@ jobs:
         if: inputs.specific_path == 'all'
       - name: download artifact for admin tests
         id: download-artifact-admin-tests
-        uses: actions/download-artifact@7fba95161a0924506ed1ae69cdbae8371ee00b3f
+        uses: actions/download-artifact@v4.1.8
         continue-on-error: true
         with:
           name: service-admin

--- a/.github/workflows/_node-build.yml
+++ b/.github/workflows/_node-build.yml
@@ -33,7 +33,7 @@ jobs:
           cd service-front/web/
           npm run build
       - name: archive dist
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # pin@v3.1.0
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: dist-web
           path: service-front/web/dist/

--- a/.github/workflows/_run-behat-tests.yml
+++ b/.github/workflows/_run-behat-tests.yml
@@ -92,7 +92,7 @@ jobs:
             vendor/bin/behat
 
       - name: archive failed test screenshots
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # pin@v3.1.0
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: behat-screenshots
           path: tests/smoke/failed_step_screenshots

--- a/.github/workflows/_run-behat-tests.yml
+++ b/.github/workflows/_run-behat-tests.yml
@@ -47,7 +47,7 @@ jobs:
         working-directory: tests/smoke
 
       - name: download cluster_config
-        uses: actions/download-artifact@7fba95161a0924506ed1ae69cdbae8371ee00b3f
+        uses: actions/download-artifact@v4.1.8
         with:
           name: environment_config_file_${{ inputs.workspace }}
           path: terraform/environment

--- a/.github/workflows/_run-terraform.yml
+++ b/.github/workflows/_run-terraform.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: upload environment cluster config file
         if: inputs.terraform_path == 'environment'
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # pin@v3.1.0
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: environment_config_file_${{ inputs.workspace }}
           path: terraform/environment/cluster_config.json

--- a/.github/workflows/_seed-database.yml
+++ b/.github/workflows/_seed-database.yml
@@ -24,7 +24,7 @@ jobs:
           role-session-name: OPGUseAnLPASeedGithubAction
 
       - name: download cluster_config
-        uses: actions/download-artifact@7fba95161a0924506ed1ae69cdbae8371ee00b3f
+        uses: actions/download-artifact@v4.1.8
         with:
           name: environment_config_file_${{ inputs.workspace }}
           path: terraform/environment

--- a/.github/workflows/_slack-notification.yml
+++ b/.github/workflows/_slack-notification.yml
@@ -40,7 +40,7 @@ jobs:
         run: pip install -r scripts/pipeline/requirements.txt
 
       - name: download cluster_config
-        uses: actions/download-artifact@7fba95161a0924506ed1ae69cdbae8371ee00b3f
+        uses: actions/download-artifact@v4.1.8
         with:
           name: environment_config_file_${{ inputs.workspace }}
           path: /tmp

--- a/.github/workflows/path-to-live.yml
+++ b/.github/workflows/path-to-live.yml
@@ -232,7 +232,7 @@ jobs:
         with:
           fetch-depth: '0'
       - name: download cluster_config
-        uses: actions/download-artifact@7fba95161a0924506ed1ae69cdbae8371ee00b3f
+        uses: actions/download-artifact@v4.1.8
         with:
           name: environment_config_file_production
           path: terraform/environment


### PR DESCRIPTION
# Purpose

_UML-3813 upload_artifact and download-artifact v3 are deprecated and will break a build. upgrade this. Using version nos instead of sha, so that renovate will maintain this_

## Approach

_update version in yml_

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [x] I have performed a self-review of my own code
* [ ] I have added tests to prove my work
* [ ] I have added relevant and appropriately leveled logging, **without PII**, to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc)
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
