### PR TITLE
UAL-3816 - allow ecs api-app to execute lpa-store api gateway

### DIFF
--- a/terraform/environment/region.tf
+++ b/terraform/environment/region.tf
@@ -50,6 +50,7 @@ module "eu_west_1" {
   session_expiry_warning                           = local.environment.session_expiry_warning
   ship_metrics_queue_enabled                       = local.environment.ship_metrics_queue_enabled
   sirius_account_id                                = local.environment.sirius_account_id
+  lpa_store_account_id                             = local.environment.lpa_store_account_id
 
   admin_cognito = {
     id                          = aws_cognito_user_pool_client.use_a_lasting_power_of_attorney_admin.id
@@ -140,6 +141,7 @@ module "eu_west_2" {
   session_expiry_warning                           = local.environment.session_expiry_warning
   ship_metrics_queue_enabled                       = local.environment.ship_metrics_queue_enabled
   sirius_account_id                                = local.environment.sirius_account_id
+  lpa_store_account_id                             = local.environment.lpa_store_account_id
 
   admin_cognito = {
     id                          = aws_cognito_user_pool_client.use_a_lasting_power_of_attorney_admin.id

--- a/terraform/environment/region/api_ecs.tf
+++ b/terraform/environment/region/api_ecs.tf
@@ -327,9 +327,9 @@ data "aws_iam_policy_document" "api_permissions_role" {
       "execute-api:Invoke",
     ]
     resources = [
-      "arn:aws:execute-api:${data.aws_region.current.name}:${var.sirius_account_id}:*/*/GET/lpas",
-      "arn:aws:execute-api:${data.aws_region.current.name}:${var.sirius_account_id}:*/*/GET/lpas/*",
-      "arn:aws:execute-api:${data.aws_region.current.name}:${var.sirius_account_id}:*/*/GET/health-check",
+      "arn:aws:execute-api:${data.aws_region.current.name}:${var.lpa_store_account_id}:*/*/POST/lpas",
+      "arn:aws:execute-api:${data.aws_region.current.name}:${var.lpa_store_account_id}:*/*/GET/lpas/*",
+      "arn:aws:execute-api:${data.aws_region.current.name}:${var.lpa_store_account_id}:*/*/GET/health-check",
     ]
   }
 

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -282,3 +282,8 @@ variable "sirius_account_id" {
   description = "The AWS ID of the Sirius account."
   type        = string
 }
+
+variable "lpa_store_account_id" {
+  description = "The AWS ID of the LPA store account"
+  type        = string
+}

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -51,6 +51,7 @@
       "session_expiry_warning": 5,
       "ship_metrics_queue_enabled": true,
       "sirius_account_id": "288342028542",
+      "lpa_store_account_id": "493907465011",
       "receive_account_ids": [
         "653761790766"
       ],
@@ -153,6 +154,7 @@
       "session_expiry_warning": 5,
       "ship_metrics_queue_enabled": true,
       "sirius_account_id": "288342028542",
+      "lpa_store_account_id": "493907465011",
       "receive_account_ids": [
         "653761790766"
       ],
@@ -255,6 +257,7 @@
       "session_expiry_warning": 5,
       "ship_metrics_queue_enabled": true,
       "sirius_account_id": "288342028542",
+      "lpa_store_account_id": "493907465011",
       "receive_account_ids": [
         "653761790766"
       ],
@@ -357,6 +360,7 @@
       "session_expiry_warning": 5,
       "ship_metrics_queue_enabled": false,
       "sirius_account_id": "288342028542",
+      "lpa_store_account_id": "936779158973",
       "receive_account_ids": [
         "792093328875"
       ],
@@ -459,6 +463,7 @@
       "session_expiry_warning": 5,
       "ship_metrics_queue_enabled": false,
       "sirius_account_id": "649098267436",
+      "lpa_store_account_id": "764856231715",
       "receive_account_ids": [
         "313879017102"
       ],

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -74,6 +74,7 @@ variable "environments" {
       session_expiry_warning                           = number
       ship_metrics_queue_enabled                       = bool
       sirius_account_id                                = string
+      lpa_store_account_id                             = string
       receive_account_ids                              = list(string)
       load_balancer_deletion_protection_enabled        = bool
       notify_key_secret_name                           = string


### PR DESCRIPTION
# Purpose

Request to POST to the LPA store in it's development account returned a 403 error

Fixes UML-3816

## Approach

The IAM role for API ECS APP didn't have permission to execute the the POST or GET lpas endpoints for the correct account.

- add lpa store account variable
- pass to ecs api app task role
- fix http verb

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [x] I have performed a self-review of my own code
* [ ] I have added tests to prove my work
* [ ] I have added relevant and appropriately leveled logging, **without PII**, to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc)
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [x] The product team have tested these changes
