### PR TITLE
Uml 3781 actor side code viewing

### DIFF
--- a/.idea/phpunit.xml
+++ b/.idea/phpunit.xml
@@ -4,8 +4,8 @@
     <option name="directories">
       <list>
         <option value="$PROJECT_DIR$/tests/smoke/tests" />
-        <option value="$PROJECT_DIR$/service-front/app/test" />
         <option value="$PROJECT_DIR$/service-api/app/test" />
+        <option value="$PROJECT_DIR$/service-front/app/test" />
       </list>
     </option>
   </component>

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,9 @@ rebuild:
 .PHONY: rebuild
 
 reset:
+	rm -R service-front/app/vendor service-api/app/vendor tests/smoke/vendor
 	$(MAKE) rebuild
+	$(COMPOSE) --profile tools build --no-cache
 	$(MAKE) pull
 	$(MAKE) composer_install
 .PHONY: reset
@@ -126,6 +128,7 @@ development_mode: enable_development_mode clear_config_cache
 composer_install:
 	$(COMPOSE) run --rm front-composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader
 	$(COMPOSE) run --rm api-composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader
+	$(COMPOSE) -f tests/smoke/docker-compose.smoke.yml run --rm smoke-tests composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader
 .PHONY: composer_install
 
 run_front_composer:
@@ -135,6 +138,10 @@ run_front_composer:
 run_api_composer:
 	$(COMPOSE) run --rm api-composer $(filter-out $@,$(MAKECMDGOALS))
 .PHONY: run_api_composer
+
+run_smoke_composer:
+	$(COMPOSE) -f tests/smoke/docker-compose.smoke.yml run --rm smoke-tests composer $(filter-out $@,$(MAKECMDGOALS))
+.PHONY: run_smoke_composer
 
 run_front_composer_update:
 	$(COMPOSE) run --rm front-composer update

--- a/docker-compose.dependencies.yml
+++ b/docker-compose.dependencies.yml
@@ -96,7 +96,7 @@ services:
   # PDF Generator
   service-pdf:
     container_name: service-pdf
-    image: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/pdf-service:v1.371.0
+    image: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/pdf-service:v1.375.0
     ports:
       - 9004:80
 

--- a/service-api/app/src/App/src/DataAccess/Repository/ViewerCodesInterface.php
+++ b/service-api/app/src/App/src/DataAccess/Repository/ViewerCodesInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\DataAccess\Repository;
 
+use App\Entity\Value\LpaUid;
 use DateTime;
 use DateTimeInterface;
 
@@ -36,21 +37,18 @@ interface ViewerCodesInterface
     /**
      * Gets a list of viewer codes for a given LPA
      *
-     * @param string $siriusUid
+     * @param LpaUid $lpaUid
      * @psalm-return ViewerCode[]
      * @return array
      */
-    public function getCodesByLpaId(string $siriusUid): array;
+    public function getCodesByLpaId(LpaUid $lpaUid): array;
 
     /**
      * Adds a code to the database.
      *
-     * $siriusUid is denormalised.
-     *
      * @param string        $code
      * @param string        $userLpaActorToken
-     * @param string|null   $siriusUid
-     * @param string|null   $lpaUid
+     * @param LpaUid        $lpaUid
      * @param DateTime      $expires
      * @param string        $organisation
      * @param string|null   $actorId
@@ -59,8 +57,7 @@ interface ViewerCodesInterface
     public function add(
         string $code,
         string $userLpaActorToken,
-        ?string $siriusUid,
-        ?string $lpaUid,
+        LpaUid $lpaUid,
         DateTime $expires,
         string $organisation,
         ?string $actorId,

--- a/service-api/app/src/App/src/Entity/Value/LpaUid.php
+++ b/service-api/app/src/App/src/Entity/Value/LpaUid.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Value;
+
+use App\Enum\LpaSource;
+
+/**
+ * Value object to encapsulate an LPA identifier
+ *
+ * Allows identification of the source system that the LPA can be found in.
+ */
+class LpaUid
+{
+    public function __construct(private string $lpaUid)
+    {
+    }
+
+    public function getLpaUid(): string
+    {
+        return $this->lpaUid;
+    }
+
+    public function getLpaSource(): LpaSource
+    {
+        return str_starts_with($this->lpaUid, 'M-')
+            ? LpaSource::LPASTORE
+            : LpaSource::SIRIUS;
+    }
+
+    public function __toString(): string
+    {
+        return $this->lpaUid;
+    }
+}

--- a/service-api/app/src/App/src/Enum/LpaSource.php
+++ b/service-api/app/src/App/src/Enum/LpaSource.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+enum LpaSource
+{
+    case SIRIUS;
+    case LPASTORE;
+}

--- a/service-api/app/src/App/src/Service/Lpa/RemoveLpa.php
+++ b/service-api/app/src/App/src/Service/Lpa/RemoveLpa.php
@@ -6,6 +6,7 @@ namespace App\Service\Lpa;
 
 use App\DataAccess\Repository\UserLpaActorMapInterface;
 use App\DataAccess\Repository\ViewerCodesInterface;
+use App\Entity\Value\LpaUid;
 use App\Exception\ApiException;
 use App\Exception\NotFoundException;
 use Exception;
@@ -101,7 +102,7 @@ class RemoveLpa
 
     private function getListOfViewerCodesToBeUpdated(array $userActorLpa): ?array
     {
-        $siriusUid = $userActorLpa['SiriusUid'];
+        $siriusUid = new LpaUid($userActorLpa['SiriusUid']);
 
         //Lookup records in ViewerCodes table using siriusUid
         $viewerCodesData = $this->viewerCodesRepository->getCodesByLpaId($siriusUid);

--- a/service-api/app/src/App/src/Service/ViewerCodes/ViewerCodeService.php
+++ b/service-api/app/src/App/src/Service/ViewerCodes/ViewerCodeService.php
@@ -14,7 +14,6 @@ use App\DataAccess\Repository\{KeyCollisionException,
 use DateTime;
 use DateTimeZone;
 use Psr\Log\LoggerInterface;
-use App\Enum\LpaSource;
 
 /**
  * @psalm-import-type UserLpaActorMap from UserLpaActorMapInterface

--- a/service-api/app/src/App/src/Service/ViewerCodes/ViewerCodeService.php
+++ b/service-api/app/src/App/src/Service/ViewerCodes/ViewerCodeService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Service\ViewerCodes;
 
 use App\DataAccess\DynamoDb\UserLpaActorMap;
+use App\Entity\Value\LpaUid;
 use DateTimeInterface;
 use App\DataAccess\Repository\{KeyCollisionException,
     UserLpaActorMapInterface,
@@ -64,8 +65,7 @@ class ViewerCodeService
                 $this->viewerCodesRepository->add(
                     $code,
                     $map['Id'],
-                    $map['SiriusUid'] ?? null,
-                    $map['LpaUid'] ?? null,
+                    new LpaUid($map['SiriusUid'] ?? $map['LpaUid']),
                     $expires,
                     $organisation,
                     (string)$map['ActorId']
@@ -99,7 +99,7 @@ class ViewerCodeService
             return null;
         }
 
-        $uid   = $map['SiriusUid'] ?? $map['LpaUid'];
+        $uid   = new LpaUid($map['SiriusUid'] ?? $map['LpaUid']);
         $codes = $this->viewerCodesRepository->getCodesByLpaId($uid);
 
         if (!empty($codes)) {

--- a/service-api/app/test/AppTest/Entity/Value/LpaUidTest.php
+++ b/service-api/app/test/AppTest/Entity/Value/LpaUidTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppTest\Entity\Value;
+
+use App\Entity\Value\LpaUid;
+use App\Enum\LpaSource;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class LpaUidTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('lpaData')]
+    public function it_correctly_identifies_the_lpa_type(string $uid, LpaSource $source): void
+    {
+        $sut = new LpaUid($uid);
+
+        $this->assertEquals($source, $sut->getLpaSource());
+    }
+
+    public static function lpaData(): array
+    {
+        return [
+            'sirius type'    => ['700000000047', LpaSource::SIRIUS],
+            'lpa store type' => ['M-789Q-P4DF-4UX3', LpaSource::LPASTORE],
+        ];
+    }
+}

--- a/service-api/app/test/AppTest/Service/ViewerCodes/ViewerCodeServiceTest.php
+++ b/service-api/app/test/AppTest/Service/ViewerCodes/ViewerCodeServiceTest.php
@@ -8,6 +8,7 @@ use App\DataAccess\Repository\KeyCollisionException;
 use App\DataAccess\Repository\UserLpaActorMapInterface;
 use App\DataAccess\Repository\ViewerCodeActivityInterface;
 use App\DataAccess\Repository\ViewerCodesInterface;
+use App\Entity\Value\LpaUid;
 use App\Service\ViewerCodes\ViewerCodeService;
 use DateTime;
 use DateTimeImmutable;
@@ -54,8 +55,7 @@ class ViewerCodeServiceTest extends TestCase
             ->add(
                 Argument::type('string'),
                 'id',
-                '700000000047',
-                null,
+                new LpaUid('700000000047'),
                 $codeExpiry,
                 'token name',
                 '1234'
@@ -109,8 +109,7 @@ class ViewerCodeServiceTest extends TestCase
             ->add(
                 Argument::type('string'),
                 'id',
-                null,
-                'M-XXXX-1212-ZZZZ',
+                Argument::that(fn(LpaUid $value) => $value->getLpaUid() === 'M-XXXX-1212-ZZZZ'),
                 $codeExpiry,
                 'token name',
                 '1234'
@@ -125,10 +124,10 @@ class ViewerCodeServiceTest extends TestCase
             ->shouldBeCalled()
             ->willReturn(
                 [
-                    'Id'        => 'id',
-                    'UserId'    => 'user_id',
-                    'LpaUid'    => 'M-XXXX-1212-ZZZZ',
-                    'ActorId'   => '1234',
+                    'Id'      => 'id',
+                    'UserId'  => 'user_id',
+                    'LpaUid'  => 'M-XXXX-1212-ZZZZ',
+                    'ActorId' => '1234',
                 ]
             );
 
@@ -192,8 +191,7 @@ class ViewerCodeServiceTest extends TestCase
             ->add(
                 Argument::type('string'),
                 'id',
-                '700000000047',
-                null,
+                new LpaUid('700000000047'),
                 Argument::type(DateTime::class),
                 'token name',
                 '1234'


### PR DESCRIPTION
# Purpose

Get viewercode viewing functionality working on the actor side of the application for MLPAs

Fixes UML-3781

## Approach

For now we're going to store the codes with a SiriusUid field without regard to the actual source of the LPA future work to change the field name will need planning.

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [x] I have performed a self-review of my own code
* [x] I have added tests to prove my work
* [x] I have added relevant and appropriately leveled logging, **without PII**, to my code
* [ ] ~New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
* [ ] ~I have updated documentation (Confluence/GitHub wiki/tech debt doc)~
* [ ] ~I have added welsh translation tags and updated translation files~
* [ ] ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* [ ] ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* [ ] ~The product team have tested these changes~
