### PR TITLE
Dynamodb container removal

### DIFF
--- a/docker-compose.dependencies.yml
+++ b/docker-compose.dependencies.yml
@@ -22,8 +22,6 @@ services:
     depends_on:
       codes-gateway:
         condition: service_started
-      dynamodb-local:
-        condition: service_started
       kms:
         condition: service_started
       localstack:
@@ -36,25 +34,22 @@ services:
       IAP_IMAGES_API_ENDPOINT: http://api-gateway:5000
       LPA_DATA_STORE_API_ENDPOINT: http://mock-lpa-data-store:4014
       ONE_LOGIN_DISCOVERY_URL: http://mock-one-login:8080/.well-known/openid-configuration
-      AWS_ENDPOINT_DYNAMODB: http://dynamodb-local:8000
+      AWS_ENDPOINT_DYNAMODB: http://localstack:4566
       AWS_ENDPOINT_SECRETSMANAGER: http://localstack:4566
       AWS_ENDPOINT_SSM: http://localstack:4566
 
   api-seeding:
     depends_on:
-      - dynamodb-local
+      localstack:
+        condition: service_healthy
     environment:
-      AWS_ENDPOINT_DYNAMODB: dynamodb-local:8000
+      AWS_ENDPOINT_DYNAMODB: localstack:4566
       CODES_ENDPOINT: codes-gateway:4343
 
-  # -----
-  # Database
-  dynamodb-local:
-    command: "-jar DynamoDBLocal.jar -sharedDb"
-    image: "amazon/dynamodb-local:latest"
-    container_name: dynamodb-local
-    ports:
-      - 8000:8000
+  upload-stats-lambda:
+    depends_on:
+      localstack:
+        condition: service_healthy
 
   # -----
   # Code Generation API development environment
@@ -67,9 +62,10 @@ services:
     volumes:
       - ../opg-data-lpa-codes/lambda_functions/v1/:/var/www/lambda_functions/v1/
     depends_on:
-      - dynamodb-local
+      localstack:
+        condition: service_healthy
     environment:
-      LOCAL_URL: host.docker.internal #rather than host name as the port is hardcoded to 8000
+      LOCAL_URL: localstack #TODO port is hardcoded to 8000 in upstream repo. FixMe
       ENVIRONMENT: local
       AWS_ACCESS_KEY_ID: testing
       AWS_SECRET_ACCESS_KEY: testing

--- a/docker-compose.dependencies.yml
+++ b/docker-compose.dependencies.yml
@@ -43,8 +43,8 @@ services:
       localstack:
         condition: service_healthy
     environment:
-      AWS_ENDPOINT_DYNAMODB: localstack:4566
-      CODES_ENDPOINT: codes-gateway:4343
+      AWS_ENDPOINT_DYNAMODB: http://localstack:4566
+      CODES_ENDPOINT: http://codes-gateway:4343
 
   upload-stats-lambda:
     depends_on:
@@ -57,15 +57,13 @@ services:
     build:
       context: ../opg-data-lpa-codes/lambda_functions/v1
       dockerfile: Dockerfile-Local-Helper
-    ports:
-      - 4343:4343
     volumes:
       - ../opg-data-lpa-codes/lambda_functions/v1/:/var/www/lambda_functions/v1/
     depends_on:
       localstack:
         condition: service_healthy
     environment:
-      LOCAL_URL: localstack #TODO port is hardcoded to 8000 in upstream repo. FixMe
+      LOCAL_URL: http://localstack:4566
       ENVIRONMENT: local
       AWS_ACCESS_KEY_ID: testing
       AWS_SECRET_ACCESS_KEY: testing
@@ -159,8 +157,7 @@ services:
     environment:
       - DEBUG=1
       - DOCKER_HOST=unix:///var/run/docker.sock
-      - AWS_ENDPOINT_DYNAMODB=http://dynamodb-local:8000
-      - ENVIRONMENT=
+      - DYNAMODB_SHARE_DB=1 # needed for NoSQLWorkbench to function when connecting locally
     volumes:
       - ./mock-integrations/secrets-manager/private_key.pem:/private_key.pem
       - ./mock-integrations/secrets-manager/public_key.pem:/public_key.pem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -252,39 +252,11 @@ services:
       REGION: eu-west-1
       AWS_ACCESS_KEY_ID: 'devkey'
       AWS_SECRET_ACCESS_KEY: 'secretdevkey'
-    depends_on:
-      - localstack
     volumes:
       - ./lambda-functions/upload-statistics/app:/function/app
       - ./lambda-functions/.aws-lambda-rie:/aws-lambda
     ports:
       - 9007:8080
-
-
-  # ---------------------------
-  # Lambda for ingestion from MLPA
-
-  event-receiver-lambda:
-    container_name: event-receiver
-    build:
-      context: ./lambda-functions/event-receiver
-      dockerfile: Dockerfile
-    environment:
-      AWS_LAMBDA_SERVER_PORT: '8080'
-      AWS_LAMBDA_RUNTIME_API: 'localhost:8080'
-      ENVIRONMENT: local
-      REGION: eu-west-1
-      AWS_ACCESS_KEY_ID: 'devkey'
-      AWS_SECRET_ACCESS_KEY: 'secretdevkey'
-    volumes:
-      - ./lambda-functions/event-receiver/app:/function/app
-      - ./lambda-functions/.aws-lambda-rie:/aws-lambda
-    entrypoint:
-      - /aws-lambda/aws-lambda-rie
-    command:
-      - ./main
-    ports:
-      - 9008:8080
 
   proxy:
     container_name: proxy

--- a/service-api/docker/seeding/start.sh
+++ b/service-api/docker/seeding/start.sh
@@ -6,13 +6,13 @@ echo Starting seeding...
 # DynamoDB setup and seeding for UaLPA
 # -----
 
-if ! [[ -z "${AWS_ENDPOINT_DYNAMODB}" ]]; then
+if [[ -n "${AWS_ENDPOINT_DYNAMODB}" ]]; then
     # If we're not running against AWS' endpoint
 
-    DYNAMODN_ENDPOINT=http://${AWS_ENDPOINT_DYNAMODB}
+    DYNAMODB_ENDPOINT=${AWS_ENDPOINT_DYNAMODB}
 
     echo Using local DynamoDB
-    /usr/local/bin/waitforit -address=tcp://${AWS_ENDPOINT_DYNAMODB} -timeout 60 -retry 6000 -debug
+    /usr/local/bin/waitforit -address=${AWS_ENDPOINT_DYNAMODB} -timeout 60 -retry 6000 -debug
 
     # ----------------------------------------------------------
     # Add any setup here that is performed with Terraform in AWS.
@@ -23,7 +23,7 @@ if ! [[ -z "${AWS_ENDPOINT_DYNAMODB}" ]]; then
     --key-schema AttributeName=Id,KeyType=HASH \
     --provisioned-throughput ReadCapacityUnits=10,WriteCapacityUnits=10 \
     --region eu-west-1 \
-    --endpoint $DYNAMODN_ENDPOINT \
+    --endpoint $DYNAMODB_ENDPOINT \
     --global-secondary-indexes \
       IndexName=IdentityIndex,KeySchema=["{AttributeName=Identity,KeyType=HASH}"],Projection="{ProjectionType=ALL}",ProvisionedThroughput="{ReadCapacityUnits=10,WriteCapacityUnits=10}" \
       IndexName=EmailIndex,KeySchema=["{AttributeName=Email,KeyType=HASH}"],Projection="{ProjectionType=ALL}",ProvisionedThroughput="{ReadCapacityUnits=10,WriteCapacityUnits=10}" \
@@ -35,7 +35,7 @@ if ! [[ -z "${AWS_ENDPOINT_DYNAMODB}" ]]; then
     aws dynamodb update-time-to-live \
     --table-name ActorUsers \
     --region eu-west-1 \
-    --endpoint $DYNAMODN_ENDPOINT \
+    --endpoint $DYNAMODB_ENDPOINT \
     --time-to-live-specification "Enabled=true, AttributeName=ExpiresTTL"
 
     aws dynamodb create-table \
@@ -44,7 +44,7 @@ if ! [[ -z "${AWS_ENDPOINT_DYNAMODB}" ]]; then
     --key-schema AttributeName=ViewerCode,KeyType=HASH \
     --provisioned-throughput ReadCapacityUnits=10,WriteCapacityUnits=10 \
     --region eu-west-1 \
-    --endpoint $DYNAMODN_ENDPOINT \
+    --endpoint $DYNAMODB_ENDPOINT \
     --global-secondary-indexes IndexName=SiriusUidIndex,KeySchema=["{AttributeName=SiriusUid,KeyType=HASH},{AttributeName=Expires,KeyType=RANGE}"],Projection="{ProjectionType=ALL}",ProvisionedThroughput="{ReadCapacityUnits=10,WriteCapacityUnits=10}"
 
     aws dynamodb create-table \
@@ -53,7 +53,7 @@ if ! [[ -z "${AWS_ENDPOINT_DYNAMODB}" ]]; then
     --key-schema AttributeName=ViewerCode,KeyType=HASH AttributeName=Viewed,KeyType=RANGE \
     --provisioned-throughput ReadCapacityUnits=10,WriteCapacityUnits=10 \
     --region eu-west-1 \
-    --endpoint $DYNAMODN_ENDPOINT
+    --endpoint $DYNAMODB_ENDPOINT
 
    aws dynamodb create-table \
       --attribute-definitions AttributeName=TimePeriod,AttributeType=S \
@@ -61,7 +61,7 @@ if ! [[ -z "${AWS_ENDPOINT_DYNAMODB}" ]]; then
       --key-schema AttributeName=TimePeriod,KeyType=HASH \
       --provisioned-throughput ReadCapacityUnits=10,WriteCapacityUnits=10 \
       --region eu-west-1 \
-      --endpoint $DYNAMODN_ENDPOINT
+      --endpoint $DYNAMODB_ENDPOINT
 
     aws dynamodb create-table \
     --attribute-definitions AttributeName=Id,AttributeType=S AttributeName=UserId,AttributeType=S AttributeName=ActivationCode,AttributeType=S \
@@ -70,7 +70,7 @@ if ! [[ -z "${AWS_ENDPOINT_DYNAMODB}" ]]; then
     --key-schema AttributeName=Id,KeyType=HASH \
     --provisioned-throughput ReadCapacityUnits=10,WriteCapacityUnits=10 \
     --region eu-west-1 \
-    --endpoint $DYNAMODN_ENDPOINT \
+    --endpoint $DYNAMODB_ENDPOINT \
     --global-secondary-indexes IndexName=UserIndex,KeySchema=["{AttributeName=UserId,KeyType=HASH}"],Projection="{ProjectionType=ALL}",ProvisionedThroughput="{ReadCapacityUnits=10,WriteCapacityUnits=10}"\
       IndexName=ActivationCodeIndex,KeySchema=["{AttributeName=ActivationCode,KeyType=HASH}"],Projection="{ProjectionType=ALL}",ProvisionedThroughput="{ReadCapacityUnits=10,WriteCapacityUnits=10}"\
       IndexName=SiriusUidIndex,KeySchema=["{AttributeName=SiriusUid,KeyType=HASH}"],Projection="{ProjectionType=ALL}",ProvisionedThroughput="{ReadCapacityUnits=10,WriteCapacityUnits=10}"
@@ -78,7 +78,7 @@ if ! [[ -z "${AWS_ENDPOINT_DYNAMODB}" ]]; then
      aws dynamodb update-time-to-live \
     --table-name UserLpaActorMap \
     --region eu-west-1 \
-    --endpoint $DYNAMODN_ENDPOINT \
+    --endpoint $DYNAMODB_ENDPOINT \
     --time-to-live-specification "Enabled=true, AttributeName=ActivateBy"
 
 fi
@@ -90,10 +90,10 @@ python /app/seeding/dynamodb.py
 # DynamoDB setup and seeding for codes service
 # -----
 
-if ! [[ -z "${CODES_ENDPOINT}" ]]; then
+if [[ -n "${CODES_ENDPOINT}" ]]; then
   # Setup the local codes service
-  /usr/local/bin/waitforit -address=tcp://${CODES_ENDPOINT} -timeout 60 -retry 6000 -debug
-  curl -X POST -H 'Authorization: asdf1234567890' http://${CODES_ENDPOINT}/setup/dynamodb/create/table
+  /usr/local/bin/waitforit -address=${CODES_ENDPOINT} -timeout 60 -retry 6000 -debug
+  curl -X POST -H 'Authorization: asdf1234567890' ${CODES_ENDPOINT}/setup/dynamodb/create/table
 fi
 
 # Seed code service database

--- a/service-api/seeding/dynamodb.py
+++ b/service-api/seeding/dynamodb.py
@@ -11,9 +11,8 @@ import pytz
 
 if 'AWS_ENDPOINT_DYNAMODB' in os.environ:
     # For local development
-    dynamodb_endpoint_url = 'http://' + os.environ['AWS_ENDPOINT_DYNAMODB']
     dynamodb = boto3.resource(
-        'dynamodb', region_name='eu-west-1', endpoint_url=dynamodb_endpoint_url)
+        'dynamodb', region_name='eu-west-1', endpoint_url=os.environ['AWS_ENDPOINT_DYNAMODB'])
 
 else:
 

--- a/service-api/seeding/put_actor_codes.py
+++ b/service-api/seeding/put_actor_codes.py
@@ -61,16 +61,16 @@ class LpaCodesSeeder:
 
     def create_dynamodb_resources_for_local(self, docker_mode):
         if docker_mode:
-            url = "dynamodb-local"
+            url = "http://localstack:4566"
         else:
-            url = "localhost"
+            url = "http://localhost:4566"
         self.dynamodb = boto3.resource(
             "dynamodb",
             region_name="eu-west-1",
             aws_access_key_id="devkey",
             aws_secret_access_key="secretdevkey",
             aws_session_token="",
-            endpoint_url=f"http://{url}:8000"
+            endpoint_url=url
         )
 
     def put_actor_codes(self):


### PR DESCRIPTION
# Purpose
Removes DynamoDB as a container from the stack in preference of the builtin functionality of localstack.

## Approach

Make the port number options (i.e. not hardcoded) in the upstream codes service repo and then alter our urls so we can specify the port.

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [x] I have performed a self-review of my own code
* [ ] ~I have added tests to prove my work~
* [ ] ~I have added relevant and appropriately leveled logging, **without PII**, to my code~
* [ ] ~New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
* [ ] ~I have updated documentation (Confluence/GitHub wiki/tech debt doc)~
* [ ] ~I have added welsh translation tags and updated translation files~
* [ ] ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* [ ] ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* [ ] ~The product team have tested these changes~
