### PR TITLE
upgrade tj-actions/files-changed to post incident version

### DIFF
--- a/.github/workflows/_ecr-scanning.yml
+++ b/.github/workflows/_ecr-scanning.yml
@@ -41,4 +41,4 @@ jobs:
         run: python ./scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py --search use_an_lpa --tag ${TAG} --print_to_terminal --fail_pipe
 
       - name: Check ECR scan results
-        run: python ./scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py --search pdf_service --print_to_terminal
+        run: python ./scripts/pipeline/check_ecr_scan_results/aws_ecr_scan_results.py --search pdf-service --print_to_terminal

--- a/.github/workflows/path-to-live.yml
+++ b/.github/workflows/path-to-live.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: get changed docs files in any folder
         id: changed-files-docs
-        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  // 46.0.1
         with:
           files: |
             **/*.md

--- a/.github/workflows/path-to-live.yml
+++ b/.github/workflows/path-to-live.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: get changed docs files in any folder
         id: changed-files-docs
-        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  // 46.0.1
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  # 46.0.1
         with:
           files: |
             **/*.md

--- a/.github/workflows/pull-request-path.yml
+++ b/.github/workflows/pull-request-path.yml
@@ -50,25 +50,25 @@ jobs:
 
       - name: get changed files in the admin folder
         id: changed-files-admin
-        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  // 46.0.1
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  # 46.0.1
         with:
           files: |
             service-admin/**
       - name: get changed files in the event-receiver folder
         id: changed-files-event
-        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  // 46.0.1
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  # 46.0.1
         with:
           files: |
             lambda-functions/event-receiver/**
       - name: get changed files in the terraform folder
         id: changed-files-terraform
-        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  // 46.0.1
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  # 46.0.1
         with:
           files: |
             terraform/**
       - name: get changed docs files in any folder
         id: changed-files-docs
-        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  // 46.0.1
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  # 46.0.1
         with:
           files: |
             **/*.md

--- a/.github/workflows/pull-request-path.yml
+++ b/.github/workflows/pull-request-path.yml
@@ -50,25 +50,25 @@ jobs:
 
       - name: get changed files in the admin folder
         id: changed-files-admin
-        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  // 46.0.1
         with:
           files: |
             service-admin/**
       - name: get changed files in the event-receiver folder
         id: changed-files-event
-        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  // 46.0.1
         with:
           files: |
             lambda-functions/event-receiver/**
       - name: get changed files in the terraform folder
         id: changed-files-terraform
-        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  // 46.0.1
         with:
           files: |
             terraform/**
       - name: get changed docs files in any folder
         id: changed-files-docs
-        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  // 46.0.1
         with:
           files: |
             **/*.md

--- a/.github/workflows/workflow-deploy-ref-to-env.yml
+++ b/.github/workflows/workflow-deploy-ref-to-env.yml
@@ -60,13 +60,13 @@ jobs:
 
       - name: get changed files in the admin folder
         id: changed-files-admin
-        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  // 46.0.1
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  # 46.0.1
         with:
           files: |
             service-admin/**
       - name: get changed files in the terraform folder
         id: changed-files-terraform
-        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  // 46.0.1
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  # 46.0.1
         with:
           files: |
             terraform/**

--- a/.github/workflows/workflow-deploy-ref-to-env.yml
+++ b/.github/workflows/workflow-deploy-ref-to-env.yml
@@ -60,13 +60,13 @@ jobs:
 
       - name: get changed files in the admin folder
         id: changed-files-admin
-        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  // 46.0.1
         with:
           files: |
             service-admin/**
       - name: get changed files in the terraform folder
         id: changed-files-terraform
-        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32  // 46.0.1
         with:
           files: |
             terraform/**

--- a/terraform/environment/region/data_sources.tf
+++ b/terraform/environment/region/data_sources.tf
@@ -99,7 +99,7 @@ data "aws_ecr_repository" "use_an_lpa_api_web" {
 
 data "aws_ecr_repository" "use_an_lpa_pdf" {
   provider = aws.management
-  name     = "pdf_service"
+  name     = "pdf-service"
 }
 
 data "aws_ecr_image" "pdf_service" {


### PR DESCRIPTION
# Purpose

The tj-actions/files-changed action had been compromised, and tags pointed to malicious code.

Upgrade to a new tag (specifying commit sha) that doesn't have the malicious commit.

## Approach

- upgrade tj-actions/files-changed to sha 2f7c5bfce28377bc069a65ba478de0a74aa0ca32 (v46.0.1)

## Learning

- https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised
