### PR TITLE
removed environment flag when creating lambda function

### DIFF
--- a/localstack/localstack-init.sh
+++ b/localstack/localstack-init.sh
@@ -33,7 +33,6 @@ awslocal events put-targets \
 
 echo "Creating lambda"
 awslocal lambda create-function \
-    --environment Variables="{AWS_ENDPOINT_DYNAMODB=$AWS_ENDPOINT_DYNAMODB}" \
     --function-name event-receiver-lambda \
     --runtime provided.al2023 \
     --zip-file fileb:///event-receiver.zip \


### PR DESCRIPTION
# Purpose
removed un-needed line which was to set environment but since we are using localstack, it is not needed


## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [x] I have performed a self-review of my own code
* [x] I have added tests to prove my work
