### PR TITLE
UML-3807: add dynamodb envars to Lambda

### DIFF
--- a/terraform/environment/lambda.tf
+++ b/terraform/environment/lambda.tf
@@ -94,8 +94,10 @@ module "event_receiver" {
   source      = "./modules/lambda"
   lambda_name = "event-receiver"
   environment_variables = {
-    ENVIRONMENT = local.environment_name
-    REGION      = data.aws_region.current.name
+    ENVIRONMENT              = local.environment_name
+    REGION                   = data.aws_region.current.name
+    USER_LPA_ACTOR_MAP_TABLE = "${local.environment_name}-UserLpaActorMap"
+    ACTOR_USERS_TABLE        = "${local.environment_name}-ActorUsers"
   }
   image_uri   = "${data.aws_ecr_repository.use_an_lpa_event_receiver.repository_url}:${var.container_version}"
   ecr_arn     = data.aws_ecr_repository.use_an_lpa_event_receiver.arn


### PR DESCRIPTION
# Purpose

Gives the Event Receiver Lambda environment variables for the current environment DynamoDB tables. This will help simplify the current Lambda code.

Fixes UML-3807

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [x] I have performed a self-review of my own code
* [ ] I have added tests to prove my work
* [ ] I have added relevant and appropriately leveled logging, **without PII**, to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc)
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
