### PR TITLE
UML-3687 no read more link appears on modernised LPAs when it has restrictions…

### DIFF
--- a/service-front/app/src/Actor/templates/actor/partials/lpa-instructions-preferences-important-message.html.twig
+++ b/service-front/app/src/Actor/templates/actor/partials/lpa-instructions-preferences-important-message.html.twig
@@ -3,12 +3,14 @@
         {% trans %}
             This LPA has instructions.<br>
         {% endtrans %}
-        <a class="govuk-link" href="{{ path('lpa.instructions-preferences') }}"
-           data-gaEventType="onClick"
-           data-gaAction="Clicked Link"
-           data-gaCategory="Read More"
-           data-gaLabel="Read More - instructions and preferences"
-        > {% trans %}Read more{% endtrans %}</a>
+        {% if not (lpa.uId starts with 'M-') %}
+            <a class="govuk-link" href="{{ path('lpa.instructions-preferences') }}"
+               data-gaEventType="onClick"
+               data-gaAction="Clicked Link"
+               data-gaCategory="Read More"
+               data-gaLabel="Read More - instructions and preferences"
+            > {% trans %}Read more{% endtrans %}</a>
+        {% endif %}
     </p>
 {% endif %}
 {% if not is_donor_signature_date_too_old(lpa) and actorActive and lpa.applicationHasGuidance and not lpa.applicationHasRestrictions %}


### PR DESCRIPTION
# Purpose

_added if statement to hide read more button if the lpa is a modernise (starting with 'M-')

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [ ] I have performed a self-review of my own code