### PR TITLE
UML-3858: who paper verification code was sent to

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       SESSION_EXPIRES: 30 # session expiry length to support timeout message.
       COOKIE_EXPIRES: 1440 # cookie expiry for complete logout - initial value to be 24 hours.
       SUPPORT_DATASTORE_LPAS: "false"
-      PAPER_VERFICATION: "false"
+      PAPER_VERIFICATION: "true"
     depends_on:
       - api-web
 
@@ -102,7 +102,7 @@ services:
       # Feature flags
       DELETE_LPA_FEATURE: "true"
       ALLOW_MERIS_LPAS: "false"
-      SUPPORT_DATASTORE_LPAS: "true"
+      SUPPORT_DATASTORE_LPAS: "false"
 
       # Local only
       API_SERVICE_URL:
@@ -186,7 +186,7 @@ services:
 
       # Feature flags
       ALLOW_MERIS_LPAS: "false"
-      SUPPORT_DATASTORE_LPAS: "true"
+      SUPPORT_DATASTORE_LPAS: "false"
 
       # Local only
       AWS_ACCESS_KEY_ID: "devkey"

--- a/service-front/app/config/routes.php
+++ b/service-front/app/config/routes.php
@@ -59,6 +59,9 @@ $viewerRoutes = function (Application $app, MiddlewareFactory $factory, Containe
         Common\Handler\InstructionsPreferencesBefore2016Handler::class,
         'lpa.instructions-preferences-before-2016'
     );
+
+    //Paper Verification Code journey
+    $app->route('/paper-verification-code-sent-to', Viewer\Handler\PaperVerificationCodeSentToHandler::class, ['GET', 'POST'], 'paper-verification-code-sent-to');
 };
 
 $actorRoutes = function (Application $app, MiddlewareFactory $factory, ContainerInterface $container): void {

--- a/service-front/app/src/Viewer/src/Form/VerificationCode.php
+++ b/service-front/app/src/Viewer/src/Form/VerificationCode.php
@@ -4,15 +4,12 @@ declare(strict_types=1);
 
 namespace Viewer\Form;
 
-use Common\Filter\ActorViewerCodeFilter;
 use Common\Form\AbstractForm;
 use Common\Validator\NotEmptyConditional;
 use Laminas\Filter\StringToUpper;
 use Laminas\Filter\StringTrim;
 use Laminas\InputFilter\InputFilterProviderInterface;
 use Laminas\Validator\NotEmpty;
-use Laminas\Validator\Regex;
-use Laminas\Validator\StringLength;
 use Mezzio\Csrf\CsrfGuardInterface;
 
 class VerificationCode extends AbstractForm implements InputFilterProviderInterface
@@ -43,8 +40,8 @@ class VerificationCode extends AbstractForm implements InputFilterProviderInterf
                  'type'    => 'Radio',
                  'options' => [
                      'value_options' => [
-                         'Yes' => 'Yes',
-                         'No'  => 'No',
+                         'Attorney' => 'Attorney',
+                         'Donor'  => 'Donor',
                      ],
                  ],
             ]
@@ -62,6 +59,7 @@ class VerificationCode extends AbstractForm implements InputFilterProviderInterf
                 'validators' => [
                     [
                         'name'                   => NotEmpty::class,
+                        'break_chain_on_failure' => true,
                         'options'                => [
                             'message' => [
                                 NotEmpty::IS_EMPTY => 'Select who the paper verification code was sent to',
@@ -81,7 +79,7 @@ class VerificationCode extends AbstractForm implements InputFilterProviderInterf
                         'options' => [
                             'message'         => 'Enter attorney name',
                             'dependant'       => 'verification_code_receiver',
-                            'dependant_value' => 'Yes',
+                            'dependant_value' => 'Donor',
                         ],
                     ],
                 ],

--- a/service-front/app/src/Viewer/src/Form/VerificationCode.php
+++ b/service-front/app/src/Viewer/src/Form/VerificationCode.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Viewer\Form;
+
+use Common\Filter\ActorViewerCodeFilter;
+use Common\Form\AbstractForm;
+use Common\Validator\NotEmptyConditional;
+use Laminas\Filter\StringToUpper;
+use Laminas\Filter\StringTrim;
+use Laminas\InputFilter\InputFilterProviderInterface;
+use Laminas\Validator\NotEmpty;
+use Laminas\Validator\Regex;
+use Laminas\Validator\StringLength;
+use Mezzio\Csrf\CsrfGuardInterface;
+
+class VerificationCode extends AbstractForm implements InputFilterProviderInterface
+{
+    public const FORM_NAME = 'verification_code';
+
+    /** @var array<array-key, mixed> */
+    protected array $messageTemplates = [
+        self::NOT_SAME => 'Do you want to continue?' .
+            ' You have not used this service for 30 minutes.' .
+            ' Click continue to use any details you entered',
+    ];
+
+    public function __construct(CsrfGuardInterface $csrfGuard)
+    {
+        parent::__construct(self::FORM_NAME, $csrfGuard);
+
+        $this->add(
+            [
+                'name' => 'attorney_name',
+                'type' => 'Text',
+            ]
+        );
+
+        $this->add(
+            [
+                 'name'    => 'verification_code_receiver',
+                 'type'    => 'Radio',
+                 'options' => [
+                     'value_options' => [
+                         'Yes' => 'Yes',
+                         'No'  => 'No',
+                     ],
+                 ],
+            ]
+        );
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function getInputFilterSpecification(): array
+    {
+        return [
+            'verification_code_receiver' => [
+                'required'   => true,
+                'validators' => [
+                    [
+                        'name'                   => NotEmpty::class,
+                        'options'                => [
+                            'message' => [
+                                NotEmpty::IS_EMPTY => 'Select who the paper verification code was sent to',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'attorney_name'   => [
+                'filters'    => [
+                    ['name' => StringTrim::class],
+                    ['name' => StringToUpper::class],
+                ],
+                'validators' => [
+                    [
+                        'name'    => NotEmptyConditional::class,
+                        'options' => [
+                            'message'         => 'Enter attorney name',
+                            'dependant'       => 'verification_code_receiver',
+                            'dependant_value' => 'Yes',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/service-front/app/src/Viewer/src/Handler/AbstractPVSCodeHandler.php
+++ b/service-front/app/src/Viewer/src/Handler/AbstractPVSCodeHandler.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Viewer\Handler;
+
+use Common\Handler\AbstractHandler;
+use Common\Handler\CsrfGuardAware;
+use Common\Handler\LoggerAware;
+use Common\Handler\SessionAware;
+use Common\Handler\Traits\CsrfGuard;
+use Common\Handler\Traits\Logger;
+use Common\Handler\Traits\Session;
+use Common\Workflow\State;
+use Common\Workflow\WorkflowStep;
+use Mezzio\Session\SessionInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Viewer\Workflow\PaperVerificationShareCode;
+
+/**
+ * A base for our workflow for both Share Code and Paper Verification codes
+ *
+ * Abstract Paper Verification Share Code Handler
+ */
+abstract class AbstractPVSCodeHandler extends AbstractHandler implements
+    CsrfGuardAware,
+    SessionAware,
+    LoggerAware,
+    WorkflowStep
+{
+    use CsrfGuard;
+    use Logger;
+    use Session;
+    use State;
+
+    protected ?SessionInterface $session;
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->session = $this->getSession($request, 'session');
+
+        if ($this->isMissingPrerequisite($request)) {
+            return $this->redirectToRoute('home');
+        }
+
+        return match ($request->getMethod()) {
+            'POST' => $this->handlePost($request),
+            default => $this->handleGet($request),
+        };
+    }
+
+    abstract public function handleGet(ServerRequestInterface $request): ResponseInterface;
+
+    abstract public function handlePost(ServerRequestInterface $request): ResponseInterface;
+
+    /**
+     * @inheritDoc
+     */
+    public function state(ServerRequestInterface $request): PaperVerificationShareCode
+    {
+        return $this->loadState($request, PaperVerificationShareCode::class);
+    }
+}

--- a/service-front/app/src/Viewer/src/Handler/EnterCodeHandler.php
+++ b/service-front/app/src/Viewer/src/Handler/EnterCodeHandler.php
@@ -16,6 +16,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 use Viewer\Form\ShareCode;
+use Common\Service\Features\FeatureEnabled;
 
 /**
  * @codeCoverageIgnore
@@ -28,6 +29,7 @@ class EnterCodeHandler extends AbstractHandler implements CsrfGuardAware
     public function __construct(
         TemplateRendererInterface $renderer,
         UrlHelper $urlHelper,
+        private FeatureEnabled $featureEnabled,
         private SystemMessageService $systemMessageService,
     ) {
         parent::__construct($renderer, $urlHelper);
@@ -48,7 +50,11 @@ class EnterCodeHandler extends AbstractHandler implements CsrfGuardAware
                 $session->set('code', $lpaCode);
                 $session->set('surname', $form->getData()['donor_surname']);
 
-                return $this->redirectToRoute('check-code');
+                $template = ($this->featureEnabled)('paper_verification')
+                    ? 'paper-verification-code-sent-to'
+                    : 'check-code';
+
+                return $this->redirectToRoute($template);
             }
         }
 

--- a/service-front/app/src/Viewer/src/Handler/PaperVerificationCodeSentToHandler.php
+++ b/service-front/app/src/Viewer/src/Handler/PaperVerificationCodeSentToHandler.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Viewer\Handler;
+
+use Common\Handler\AbstractHandler;
+use Common\Handler\CsrfGuardAware;
+use Common\Handler\Traits\CsrfGuard;
+use Common\Handler\Traits\Session as SessionTrait;
+use Common\Service\Features\FeatureEnabled;
+use Common\Service\SystemMessage\SystemMessageService;
+use Common\Workflow\WorkflowState;
+use Laminas\Diactoros\Response\HtmlResponse;
+use Mezzio\Helper\UrlHelper;
+use Mezzio\Template\TemplateRendererInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Viewer\Form\VerificationCode;
+
+
+/**
+ * @codeCoverageIgnore
+ */
+class PaperVerificationCodeSentToHandler extends AbstractPVSCodeHandler
+{
+    private VerificationCode $form;
+
+    //use CsrfGuard;
+    //use SessionTrait;
+
+    public function __construct(
+        TemplateRendererInterface $renderer,
+        UrlHelper $urlHelper,
+        private FeatureEnabled $featureEnabled,
+        private SystemMessageService $systemMessageService,
+    ) {
+        parent::__construct($renderer, $urlHelper);
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->form = new VerificationCode($this->getCsrfGuard($request));
+        $this->systemMessages = $this->systemMessageService->getMessages();
+
+        return parent::handle($request);
+    }
+
+    public function handleGet(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->state($request)->reset();
+
+        $template = ($this->featureEnabled)('paper_verification')
+            ? 'viewer::paper-verification-code-sent-to'
+            : 'viewer::enter-code';
+
+        return new HtmlResponse($this->renderer->render($template, [
+            'form'       => $this->form->prepare(),
+            'en_message' => $this->systemMessages['view/en'] ?? null,
+            'cy_message' => $this->systemMessages['view/cy'] ?? null,
+        ]));
+    }
+
+    public function handlePost(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->form->setData($request->getParsedBody());
+
+        if ($this->form->isValid()) {
+            $this->session->set('code_receiver', $this->form->getData()['verification_code_receiver']);
+
+           // $this->state($request)->code_receiver = $this->form->getData()['verification_code_receiver'];
+            return $this->redirectToRoute($this->nextPage($this->state($request)));
+        }
+
+        $template = ($this->featureEnabled)('paper_verification')
+            ? 'viewer::paper-verification-code-sent-to'
+            : 'viewer::enter-code';
+
+        return new HtmlResponse($this->renderer->render($template, [
+            'form'       => $this->form->prepare(),
+            'en_message' => $this->systemMessages['view/en'] ?? null,
+            'cy_message' => $this->systemMessages['view/cy'] ?? null,
+        ]));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isMissingPrerequisite(ServerRequestInterface $request): bool
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function nextPage(WorkflowState $state): string
+    {
+        return 'check-code';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function lastPage(WorkflowState $state): string
+    {
+        return 'home';
+    }
+}

--- a/service-front/app/src/Viewer/src/Workflow/PaperVerificationShareCode.php
+++ b/service-front/app/src/Viewer/src/Workflow/PaperVerificationShareCode.php
@@ -9,7 +9,7 @@ use Common\Workflow\WorkflowState;
 use DateTimeImmutable;
 use DateTimeInterface;
 
-class PaperVerificationCode implements WorkflowState
+class PaperVerificationShareCode implements WorkflowState
 {
     use JsonSerializable;
 

--- a/service-front/app/src/Viewer/templates/viewer/paper-verification-code-sent-to.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/paper-verification-code-sent-to.html.twig
@@ -37,22 +37,8 @@
                                 ]}
                             ) }}
 
-                            <div><details class="govuk-details" data-module="govuk-details" data-gaEventType="onClick" data-gaCategory="Details">
-                                <summary class="govuk-details__summary">
-                                    <span class="govuk-details__summary-text">
-                                        {% trans %}Help with finding out who the paper verification code was sent to{% endtrans %}
-                                    </span>
-                                </summary>
-
-                                <div class="govuk-details__text">
-                                    <ul class="govuk-list govuk-list--bullet">
-                                        <li>{% trans %}To be added{% endtrans %}</li>
-                                        <li>{% trans %}To be added{% endtrans %}</li>
-                                    </ul>
-                                </div>
-                            </details></div>
-
                         </fieldset>
+
                     </div>
                     <div class="moj-button-menu">
                         <div class="moj-button-menu__wrapper">

--- a/service-front/app/src/Viewer/templates/viewer/paper-verification-code-sent-to.html.twig
+++ b/service-front/app/src/Viewer/templates/viewer/paper-verification-code-sent-to.html.twig
@@ -1,0 +1,77 @@
+{% extends '@actor/layout.html.twig' %}
+
+{% block html_title %}{% trans %}Who the paper verification code was sent to{% endtrans %} - {{ parent() }}{% endblock %}
+
+{% block content %}
+    <div class="govuk-width-container">
+
+        <main class="govuk-main-wrapper" id="main-content" role="main">
+            {{ govuk_error_summary(form) }}
+
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds">
+
+                    {{ govuk_form_open(form) }}
+                    {{ govuk_form_element(form.get('__csrf')) }}
+
+                    <div class="govuk-form-group">
+                        <fieldset class="govuk-fieldset">
+
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                <h1 class="govuk-heading-xl">
+                                    {% trans %}Who the paper verification code was sent to{% endtrans %}
+                                </h1>
+                            </legend>
+
+                            {{ govuk_form_element(form.get('verification_code_receiver'), {'value_options':
+                                [
+                                    {
+                                        'label': 'An attorney'| trans,
+                                        'value': 'Attorney',
+                                        'conditionalContent': {"attorney_name": govuk_form_element(form.get('attorney_name'),{'label': 'Enter the attorneys name as it appears on the notice of registration'| trans})}
+                                    },
+                                    {
+                                        'label': 'The donor, (Donor name to be extracted and displayed here)'| trans,
+                                        'value': 'Donor'
+                                    }
+                                ]}
+                            ) }}
+
+                            <div><details class="govuk-details" data-module="govuk-details" data-gaEventType="onClick" data-gaCategory="Details">
+                                <summary class="govuk-details__summary">
+                                    <span class="govuk-details__summary-text">
+                                        {% trans %}Help with finding out who the paper verification code was sent to{% endtrans %}
+                                    </span>
+                                </summary>
+
+                                <div class="govuk-details__text">
+                                    <ul class="govuk-list govuk-list--bullet">
+                                        <li>{% trans %}To be added{% endtrans %}</li>
+                                        <li>{% trans %}To be added{% endtrans %}</li>
+                                    </ul>
+                                </div>
+                            </details></div>
+
+                        </fieldset>
+                    </div>
+                    <div class="moj-button-menu">
+                        <div class="moj-button-menu__wrapper">
+
+                            <button role="button" type="submit" data-prevent-double-click="true" draggable="false"
+                                    class="govuk-button moj-button-menu__item" data-module="govuk-button">
+                                {% trans %}Continue{% endtrans %}
+                            </button>
+                            <a href="{{ path('home') }}" role="button" draggable="false"
+                               class="govuk-button moj-button-menu__item govuk-button--secondary "
+                               data-module="govuk-button">
+                                {% trans %}Cancel{% endtrans %}
+                            </a>
+                        </div>
+                    </div>
+                    {{ govuk_form_close() }}
+                </div>
+
+            </div>
+        </main>
+    </div>
+{% endblock %}

--- a/service-front/app/test/ViewerTest/Form/VerificationCodeSentToTest.php
+++ b/service-front/app/test/ViewerTest/Form/VerificationCodeSentToTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ViewerTest\Form;
+
+use Viewer\Form\VerificationCode;
+use Common\Form\AbstractForm;
+use Common\Form\Element\Csrf;
+use Laminas\Form\Element\Radio;
+use CommonTest\Form\{LaminasFormTests, TestsLaminasForm};
+use Laminas\Form\Element\Text;
+use Mezzio\Csrf\CsrfGuardInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+class VerificationCodeSentToTest extends TestCase implements TestsLaminasForm
+{
+    use LaminasFormTests;
+    use ProphecyTrait;
+
+    protected VerificationCode $form;
+
+    public function getForm(): AbstractForm
+    {
+        return $this->form;
+    }
+
+    public function getFormName(): string
+    {
+        return 'verification_code';
+    }
+
+    public function getFormElements(): array
+    {
+        return [
+            '__csrf'     => Csrf::class,
+            'attorney_name'   => Text::class,
+            'verification_code_receiver' => Radio::class,
+        ];
+    }
+
+    public function setUp(): void
+    {
+        $guardProphecy = $this->prophesize(CsrfGuardInterface::class);
+        $this->form    = new VerificationCode($guardProphecy->reveal());
+    }
+}

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -66,7 +66,7 @@
         "delete_lpa_feature": true,
         "allow_meris_lpas": false,
         "support_datastore_lpas": true,
-        "paper_verification": false
+        "paper_verification": true
       },
       "dynamodb_tables": {
         "actor_codes": {


### PR DESCRIPTION
# Purpose

A new page to enter who the paper verification code was sent to 

Fixes UML-3858

## Approach

New page
New handler using new workflow
Content addition in both languages


## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [X] I have performed a self-review of my own code
* [ ] I have added tests to prove my work
* [ ] I have added relevant and appropriately leveled logging, **without PII**, to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc)
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
