### PR TITLE
UML-3942: force dnf update

### DIFF
--- a/lambda-functions/event-receiver/Dockerfile
+++ b/lambda-functions/event-receiver/Dockerfile
@@ -14,8 +14,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /go/bin/main ./
 FROM public.ecr.aws/lambda/provided:al2023.2025.05.04.04@sha256:fed9eb1f995d9c1f714794e3c2223fd5a97990022eedbab6f6f0d711ba888ac6 AS production
 
 # Switch DNF to the latest AL2023.7 release (2023.7.20250512) and update SQLite packages
-RUN echo "2023.7.20250512" > /etc/dnf/vars/releasever
-RUN dnf clean all && \
+RUN echo "2023.7.20250512" > /etc/dnf/vars/releasever && \
+    dnf clean all && \
     dnf -y update sqlite-libs libarchive && \
     dnf clean all
 

--- a/lambda-functions/event-receiver/Dockerfile
+++ b/lambda-functions/event-receiver/Dockerfile
@@ -13,8 +13,11 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /go/bin/main ./
 
 FROM public.ecr.aws/lambda/provided:al2023.2025.05.04.04@sha256:fed9eb1f995d9c1f714794e3c2223fd5a97990022eedbab6f6f0d711ba888ac6 AS production
 
-RUN dnf update -y sqlite --releasever 2023.7.20250512 \
-    && dnf clean all
+# Switch DNF to the latest AL2023.7 release (2023.7.20250512) and update SQLite packages
+RUN echo "2023.7.20250512" > /etc/dnf/vars/releasever
+RUN dnf clean all && \
+    dnf -y update sqlite-libs libarchive && \
+    dnf clean all
 
 WORKDIR /var/task
 

--- a/lambda-functions/upload-statistics/Dockerfile
+++ b/lambda-functions/upload-statistics/Dockerfile
@@ -2,12 +2,15 @@ FROM public.ecr.aws/lambda/python:3.12@sha256:594f15713623d599aa3d2cefe4e239e40e
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 
-COPY app/ .
-
 COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
-RUN pip install --no-cache-dir -r requirements.txt && \
-    dnf update -y libarchive sqlite --releasever 2023.7.20250512 && \
+# Switch DNF to the latest AL2023.7 release (2023.7.20250512) and update SQLite packages
+RUN echo "2023.7.20250512" > /etc/dnf/vars/releasever
+RUN dnf clean all && \
+    dnf -y update sqlite sqlite-libs libarchive && \
     dnf clean all
 
-CMD [ "upload_statistics.lambda_handler" ]
+COPY app/ .
+
+CMD ["upload_statistics.lambda_handler"]

--- a/lambda-functions/upload-statistics/Dockerfile
+++ b/lambda-functions/upload-statistics/Dockerfile
@@ -6,8 +6,8 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Switch DNF to the latest AL2023.7 release (2023.7.20250512) and update SQLite packages
-RUN echo "2023.7.20250512" > /etc/dnf/vars/releasever
-RUN dnf clean all && \
+RUN echo "2023.7.20250512" > /etc/dnf/vars/releasever && \
+    dnf clean all && \
     dnf -y update sqlite sqlite-libs libarchive && \
     dnf clean all
 


### PR DESCRIPTION
# Purpose

Forcibly updates the DNF repo to a newer version AL2023 doesn't have access to currently. Will revert back to normal means once AL2023 includes `sqlite-libs` security fix. This only includes a CVE patch and shouldn't affect the behaviour of sqlite.

Fixes UML-3942

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [x] I have performed a self-review of my own code
* [ ] I have added tests to prove my work
* [ ] I have added relevant and appropriately leveled logging, **without PII**, to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc)
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
