### PR TITLE
Uml 3999 Implement apostrophe normalisation in viewer

### DIFF
--- a/service-front/app/src/Common/src/Filter/ActorViewerCodeFilter.php
+++ b/service-front/app/src/Common/src/Filter/ActorViewerCodeFilter.php
@@ -4,19 +4,23 @@ declare(strict_types=1);
 
 namespace Common\Filter;
 
-use Laminas\Filter\AbstractFilter;
+use Exception;
+use Laminas\Filter\FilterInterface;
 
-class ActorViewerCodeFilter extends AbstractFilter
+class ActorViewerCodeFilter implements FilterInterface
 {
     /**
-     * @param string $code
-     * @return string
+     * @throws Exception
      */
-    public function filter($code): string
+    public function filter($value): string
     {
-        // Remove C- (hyphen) or C– (en dash) or C— (em dash) or V- from start of the code if present
-        $code = preg_replace('/^((v|c)(–|—|-| ))?/i', '', strtoupper($code));
+        if (!is_string($value)) {
+            throw new Exception('Invalid filter value - expecting string');
+        }
 
-        return (new StripSpacesAndHyphens())->filter($code);
+        // Remove C- (hyphen) or C– (en dash) or C— (em dash) or V- from start of the code if present
+        $value = preg_replace('/^((v|c)(–|—|-| ))?/i', '', strtoupper($value));
+
+        return (new StripSpacesAndHyphens())->filter($value);
     }
 }

--- a/service-front/app/src/Common/src/Filter/ConvertQuotesToApostrophe.php
+++ b/service-front/app/src/Common/src/Filter/ConvertQuotesToApostrophe.php
@@ -4,16 +4,20 @@ declare(strict_types=1);
 
 namespace Common\Filter;
 
-use Laminas\Filter\AbstractFilter;
+use Exception;
+use Laminas\Filter\FilterInterface;
 
-class ConvertQuotesToApostrophe extends AbstractFilter
+class ConvertQuotesToApostrophe implements FilterInterface
 {
     /**
-     * @param string $name
-     * @return string
+     * @throws Exception
      */
-    public function filter($name): string
+    public function filter($value): string
     {
-        return  str_replace(['‘', '’'], "'", $name);
+        if (!is_string($value)) {
+            throw new Exception('Invalid filter value - expecting string');
+        }
+
+        return str_replace(['‘', '’'], "'", $value);
     }
 }

--- a/service-front/app/src/Common/src/Filter/ShareCodeFilter.php
+++ b/service-front/app/src/Common/src/Filter/ShareCodeFilter.php
@@ -4,29 +4,33 @@ declare(strict_types=1);
 
 namespace Common\Filter;
 
-use Laminas\Filter\AbstractFilter;
+use Exception;
+use Laminas\Filter\FilterInterface;
 
-class ShareCodeFilter extends AbstractFilter
+class ShareCodeFilter implements FilterInterface
 {
     /**
-     * @param string $code
-     * @return string
+     * @throws Exception
      */
-    public function filter($code): string
+    public function filter($value): string
     {
-        $code = strtoupper($code);
-        // replaces other dashes with normal dash
-        $code = preg_replace('/[–—]/u', '-', $code);
+        if (!is_string($value)) {
+            throw new Exception('Invalid filter value - expecting string');
+        }
 
-        if (preg_match('/^P[\- ]/', $code)) {
+        $value = strtoupper($value);
+        // replaces other dashes with normal dash
+        $value = preg_replace('/[–—]/u', '-', $value);
+
+        if (preg_match('/^P[\- ]/', $value)) {
             // remove spaces or multiple hyphens to one
-            $code = preg_replace('/[\- ]+/', '-', $code);
-            return preg_replace('/^P\-*/', 'P-', $code);
+            $value = preg_replace('/[\- ]+/', '-', $value);
+            return preg_replace('/^P\-*/', 'P-', $value);
         }
 
         // V codes - removes V- and hyphens (maintaining current behaviour)
-        $code = preg_replace('/^V[\- ]*/', '', $code);
+        $value = preg_replace('/^V[\- ]*/', '', $value);
 
-        return preg_replace('/[\- ]+/', '', $code);
+        return preg_replace('/[\- ]+/', '', $value);
     }
 }

--- a/service-front/app/src/Common/src/Filter/StripSpacesAndHyphens.php
+++ b/service-front/app/src/Common/src/Filter/StripSpacesAndHyphens.php
@@ -4,16 +4,20 @@ declare(strict_types=1);
 
 namespace Common\Filter;
 
-use Laminas\Filter\AbstractFilter;
+use Exception;
+use Laminas\Filter\FilterInterface;
 
-class StripSpacesAndHyphens extends AbstractFilter
+class StripSpacesAndHyphens implements FilterInterface
 {
     /**
-     * @param string $value
-     * @return string
+     * @throws Exception
      */
     public function filter($value): string
     {
+        if (!is_string($value)) {
+            throw new Exception('Invalid filter value - expecting string');
+        }
+
         // strip out whitespace
         $value = str_replace(' ', '', $value);
         // strip out en dash

--- a/service-front/app/src/Viewer/src/Form/PVShareCode.php
+++ b/service-front/app/src/Viewer/src/Form/PVShareCode.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Viewer\Form;
 
+use Common\Filter\ConvertQuotesToApostrophe;
 use Common\Filter\ShareCodeFilter;
 use Common\Form\AbstractForm;
 use Laminas\Filter\StringTrim;
 use Laminas\InputFilter\InputFilterProviderInterface;
 use Laminas\Validator\NotEmpty;
-use Laminas\Validator\Regex;
 use Laminas\Validator\StringLength;
 use Mezzio\Csrf\CsrfGuardInterface;
 
@@ -75,6 +75,7 @@ class PVShareCode extends AbstractForm implements InputFilterProviderInterface
                 'required'   => true,
                 'filters'    => [
                     ['name' => StringTrim::class],
+                    ['name' => ConvertQuotesToApostrophe::class],
                 ],
                 'validators' => [
                     [

--- a/service-front/app/src/Viewer/src/Form/ShareCode.php
+++ b/service-front/app/src/Viewer/src/Form/ShareCode.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Viewer\Form;
 
 use Common\Filter\ActorViewerCodeFilter;
+use Common\Filter\ConvertQuotesToApostrophe;
 use Common\Form\AbstractForm;
 use Laminas\Filter\StringTrim;
 use Laminas\InputFilter\InputFilterProviderInterface;
@@ -86,6 +87,7 @@ class ShareCode extends AbstractForm implements InputFilterProviderInterface
                 'required'   => true,
                 'filters'    => [
                     ['name' => StringTrim::class],
+                    ['name' => ConvertQuotesToApostrophe::class],
                 ],
                 'validators' => [
                     [

--- a/service-front/app/test/CommonTest/Filter/ActorViewerCodeFilterTest.php
+++ b/service-front/app/test/CommonTest/Filter/ActorViewerCodeFilterTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace CommonTest\Filter;
 
-use PHPUnit\Framework\Attributes\DataProvider;
 use Common\Filter\ActorViewerCodeFilter;
+use Exception;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 
@@ -20,8 +22,16 @@ class ActorViewerCodeFilterTest extends TestCase
         $this->filter = new ActorViewerCodeFilter();
     }
 
+    #[Test]
+    public function it_expects_a_string_input(): void
+    {
+        $this->expectException(Exception::class);
+        $this->filter->filter(12);
+    }
+
+    #[Test]
     #[DataProvider('codeFormatProvider')]
-    public function testRemovesPrefixAndHyphensAndWhitespace(string $code, string $expected): void
+    public function removesPrefixAndHyphensAndWhitespace(string $code, string $expected): void
     {
         $formattedCode = $this->filter->filter($code);
         $this->assertEquals($expected, $formattedCode);

--- a/service-front/app/test/CommonTest/Filter/ConvertQuotesToApostropheTest.php
+++ b/service-front/app/test/CommonTest/Filter/ConvertQuotesToApostropheTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace CommonTest\Filter;
 
-use PHPUnit\Framework\Attributes\DataProvider;
 use Common\Filter\ConvertQuotesToApostrophe;
+use Exception;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 
@@ -20,8 +22,16 @@ class ConvertQuotesToApostropheTest extends TestCase
         $this->filter = new ConvertQuotesToApostrophe();
     }
 
+    #[Test]
+    public function it_expects_a_string_input(): void
+    {
+        $this->expectException(Exception::class);
+        $this->filter->filter(12);
+    }
+
+    #[Test]
     #[DataProvider('nameFormatProvider')]
-    public function testConvertQuotesToApostrophe(string $name, string $expected): void
+    public function convertQuotesToApostrophe(string $name, string $expected): void
     {
         $formattedName = $this->filter->filter($name);
         $this->assertEquals($expected, $formattedName);

--- a/service-front/app/test/CommonTest/Filter/ShareCodeFilterTest.php
+++ b/service-front/app/test/CommonTest/Filter/ShareCodeFilterTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace CommonTest\Filter;
 
 use Common\Filter\ShareCodeFilter;
+use Exception;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 
@@ -20,8 +22,16 @@ class ShareCodeFilterTest extends TestCase
         $this->filter = new ShareCodeFilter();
     }
 
+    #[Test]
+    public function it_expects_a_string_input(): void
+    {
+        $this->expectException(Exception::class);
+        $this->filter->filter(12);
+    }
+
+    #[Test]
     #[DataProvider('codeFormatProvider')]
-    public function testRemovesPrefixAndHyphensAndWhitespace(string $code, string $expected): void
+    public function removesPrefixAndHyphensAndWhitespace(string $code, string $expected): void
     {
         $formattedCode = $this->filter->filter($code);
         $this->assertEquals($expected, $formattedCode);

--- a/service-front/app/test/CommonTest/Filter/StripSpacesAndHyphensTest.php
+++ b/service-front/app/test/CommonTest/Filter/StripSpacesAndHyphensTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace CommonTest\Filter;
 
-use PHPUnit\Framework\Attributes\DataProvider;
 use Common\Filter\StripSpacesAndHyphens;
+use Exception;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 
@@ -20,8 +22,16 @@ class StripSpacesAndHyphensTest extends TestCase
         $this->filter = new StripSpacesAndHyphens();
     }
 
+    #[Test]
+    public function it_expects_a_string_input(): void
+    {
+        $this->expectException(Exception::class);
+        $this->filter->filter(12);
+    }
+
+    #[Test]
     #[DataProvider('codeFormatProvider')]
-    public function testRemovesHyphensAndWhitespace(string $code, string $expected): void
+    public function removesHyphensAndWhitespace(string $code, string $expected): void
     {
         $formattedCode = $this->filter->filter($code);
         $this->assertEquals($expected, $formattedCode);


### PR DESCRIPTION
# Purpose

Adds the already implemented apostrophe normalisation filter to the viewer code entry forms. 

Additionally refactors the filters away from the deprecated InputFilters abstract class to interface usage.

Fixes UML-3999

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [x] I have performed a self-review of my own code
* [x] I have added tests to prove my work
* ~I have added relevant and appropriately leveled logging, **without PII**, to my code~
* ~New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc)~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* [ ] The product team have tested these changes
