### PR TITLE
UML-4002 - migrate preproduction to new network

### DIFF
--- a/terraform/account/region/elasticache.tf
+++ b/terraform/account/region/elasticache.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "brute_force_cache_service" {
   name_prefix = "brute-force-cache-service"
   description = "brute force cache sg"
-  vpc_id      = data.aws_default_tags.current.tags.environment-name == "development" ? module.network.vpc.id : aws_default_vpc.default.id
+  vpc_id      = data.aws_default_tags.current.tags.environment-name != "production" ? module.network.vpc.id : aws_default_vpc.default.id
   lifecycle {
     create_before_destroy = true
   }
@@ -34,7 +34,7 @@ resource "aws_elasticache_replication_group" "brute_force_cache_replication_grou
   num_cache_clusters         = 2
   transit_encryption_enabled = true
   at_rest_encryption_enabled = true
-  subnet_group_name          = data.aws_default_tags.current.tags.environment-name == "development" ? aws_elasticache_subnet_group.private_subnets_fwn.name : aws_elasticache_subnet_group.private_subnets.name
+  subnet_group_name          = data.aws_default_tags.current.tags.environment-name != "production" ? aws_elasticache_subnet_group.private_subnets_fwn.name : aws_elasticache_subnet_group.private_subnets.name
   security_group_ids         = [aws_security_group.brute_force_cache_service.id]
 
   provider = aws.region

--- a/terraform/account/region/modules/dns_firewall/main.tf
+++ b/terraform/account/region/modules/dns_firewall/main.tf
@@ -23,7 +23,7 @@ resource "aws_route53_resolver_query_log_config" "egress" {
 
 resource "aws_route53_resolver_query_log_config_association" "egress" {
   resolver_query_log_config_id = aws_route53_resolver_query_log_config.egress.id
-  resource_id                  = data.aws_default_tags.current.tags.environment-name == "development" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  resource_id                  = data.aws_default_tags.current.tags.environment-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
   provider                     = aws.region
 }
 
@@ -99,7 +99,7 @@ resource "aws_route53_resolver_firewall_rule_group_association" "egress" {
   name                   = "egress"
   firewall_rule_group_id = aws_route53_resolver_firewall_rule_group.egress.id
   priority               = 500
-  vpc_id                 = data.aws_default_tags.current.tags.environment-name == "development" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id                 = data.aws_default_tags.current.tags.environment-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
 
   provider = aws.region
 }

--- a/terraform/environment/region/admin_ecs.tf
+++ b/terraform/environment/region/admin_ecs.tf
@@ -10,7 +10,7 @@ resource "aws_ecs_service" "admin" {
 
   network_configuration {
     security_groups  = [aws_security_group.admin_ecs_service.id]
-    subnets          = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
+    subnets          = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
     assign_public_ip = false
   }
 
@@ -60,7 +60,7 @@ moved {
 resource "aws_security_group" "admin_ecs_service" {
   name_prefix = "${var.environment_name}-admin-ecs-service"
   description = "Admin service security group"
-  vpc_id      = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/environment/region/admin_load_balancer.tf
+++ b/terraform/environment/region/admin_load_balancer.tf
@@ -3,7 +3,7 @@ resource "aws_lb_target_group" "admin" {
   port                 = 8080
   protocol             = "HTTP"
   target_type          = "ip"
-  vpc_id               = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id               = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
   deregistration_delay = 0
 
   health_check {
@@ -26,7 +26,7 @@ resource "aws_lb" "admin" {
   internal                   = false #tfsec:ignore:aws-elb-alb-not-public - public alb
   load_balancer_type         = "application"
   drop_invalid_header_fields = true
-  subnets                    = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_subnet.public[*].id : data.aws_subnets.public.ids
+  subnets                    = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_subnet.public[*].id : data.aws_subnets.public.ids
   enable_deletion_protection = var.load_balancer_deletion_protection_enabled
 
   security_groups = [
@@ -123,7 +123,7 @@ moved {
 resource "aws_security_group" "admin_loadbalancer" {
   name_prefix = "${var.environment_name}-admin-loadbalancer"
   description = "Admin service application load balancer"
-  vpc_id      = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/environment/region/api_ecs.tf
+++ b/terraform/environment/region/api_ecs.tf
@@ -11,7 +11,7 @@ resource "aws_ecs_service" "api" {
 
   network_configuration {
     security_groups  = [aws_security_group.api_ecs_service.id]
-    subnets          = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
+    subnets          = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
     assign_public_ip = false
   }
 
@@ -85,7 +85,7 @@ locals {
 resource "aws_security_group" "api_ecs_service" {
   name_prefix = "${var.environment_name}-api-ecs-service"
   description = "API service security group"
-  vpc_id      = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/environment/region/dns.tf
+++ b/terraform/environment/region/dns.tf
@@ -15,7 +15,7 @@ data "aws_route53_zone" "live_service_view_lasting_power_of_attorney" {
 
 resource "aws_service_discovery_private_dns_namespace" "internal_ecs" {
   name = "${var.environment_name}.ual.internal.ecs"
-  vpc  = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc  = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
 
   provider = aws.region
 }

--- a/terraform/environment/region/mock_onelogin_ecs.tf
+++ b/terraform/environment/region/mock_onelogin_ecs.tf
@@ -11,7 +11,7 @@ resource "aws_ecs_service" "mock_onelogin" {
 
   network_configuration {
     security_groups  = [aws_security_group.mock_onelogin_ecs_service.id]
-    subnets          = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
+    subnets          = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
     assign_public_ip = false
   }
 
@@ -83,7 +83,7 @@ locals {
 resource "aws_security_group" "mock_onelogin_ecs_service" {
   name_prefix = "${var.environment_name}-mock-onelogin-ecs-service"
   description = "Mock One Login service security group"
-  vpc_id      = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/environment/region/mock_onelogin_load_balancer.tf
+++ b/terraform/environment/region/mock_onelogin_load_balancer.tf
@@ -3,7 +3,7 @@ resource "aws_lb_target_group" "mock_onelogin" {
   port                 = 8080
   protocol             = "HTTP"
   target_type          = "ip"
-  vpc_id               = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id               = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
   deregistration_delay = 0
 
   health_check {
@@ -21,7 +21,7 @@ resource "aws_lb" "mock_onelogin" {
   internal                   = false #tfsec:ignore:aws-elb-alb-not-public - public alb
   load_balancer_type         = "application"
   drop_invalid_header_fields = true
-  subnets                    = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_subnet.public[*].id : data.aws_subnets.public.ids
+  subnets                    = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_subnet.public[*].id : data.aws_subnets.public.ids
   enable_deletion_protection = var.load_balancer_deletion_protection_enabled
 
   security_groups = [
@@ -74,7 +74,7 @@ resource "aws_lb_listener" "mock_onelogin_loadbalancer" {
 resource "aws_security_group" "mock_onelogin_loadbalancer" {
   name_prefix = "${var.environment_name}-mock-onelogin-loadbalancer"
   description = "Mock One Login application load balancer"
-  vpc_id      = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/environment/region/outputs.tf
+++ b/terraform/environment/region/outputs.tf
@@ -71,5 +71,5 @@ output "receive_events_sqs_queue_name" {
 }
 
 output "vpc_id" {
-  value = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  value = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
 }

--- a/terraform/environment/region/pdf_ecs.tf
+++ b/terraform/environment/region/pdf_ecs.tf
@@ -10,7 +10,7 @@ resource "aws_ecs_service" "pdf" {
 
   network_configuration {
     security_groups  = [aws_security_group.pdf_ecs_service.id]
-    subnets          = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
+    subnets          = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
     assign_public_ip = false
   }
 
@@ -84,7 +84,7 @@ locals {
 resource "aws_security_group" "pdf_ecs_service" {
   name_prefix = "${var.environment_name}-pdf-ecs-service"
   description = "PDF generator service security group"
-  vpc_id      = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/environment/region/use_ecs.tf
+++ b/terraform/environment/region/use_ecs.tf
@@ -10,7 +10,7 @@ resource "aws_ecs_service" "use" {
 
   network_configuration {
     security_groups  = [aws_security_group.use_ecs_service.id]
-    subnets          = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
+    subnets          = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
     assign_public_ip = false
   }
 
@@ -61,7 +61,7 @@ moved {
 resource "aws_security_group" "use_ecs_service" {
   name_prefix = "${var.environment_name}-actor-ecs-service"
   description = "Use service security group"
-  vpc_id      = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/environment/region/use_load_balancer.tf
+++ b/terraform/environment/region/use_load_balancer.tf
@@ -11,7 +11,7 @@ resource "aws_lb_target_group" "use" {
   port                 = 80
   protocol             = "HTTP"
   target_type          = "ip"
-  vpc_id               = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id               = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
   deregistration_delay = 0
   depends_on           = [aws_lb.use]
 
@@ -23,7 +23,7 @@ resource "aws_lb" "use" {
   internal                   = false #tfsec:ignore:aws-elb-alb-not-public - Intentionally public facing
   load_balancer_type         = "application"
   drop_invalid_header_fields = true
-  subnets                    = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_subnet.public[*].id : data.aws_subnets.public.ids
+  subnets                    = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_subnet.public[*].id : data.aws_subnets.public.ids
 
   enable_deletion_protection = var.load_balancer_deletion_protection_enabled
 
@@ -225,7 +225,7 @@ resource "aws_lb_listener_rule" "use_maintenance_welsh" {
 resource "aws_security_group" "use_loadbalancer" {
   name_prefix = "${var.environment_name}-actor-loadbalancer"
   description = "Allow inbound traffic"
-  vpc_id      = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
 
   provider = aws.region
 }
@@ -282,7 +282,7 @@ resource "aws_security_group_rule" "use_loadbalancer_egress" {
 resource "aws_security_group" "use_loadbalancer_route53" {
   name_prefix = "${var.environment_name}-actor-loadbalancer-route53"
   description = "Allow Route53 healthchecks"
-  vpc_id      = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
 
   provider = aws.region
 }

--- a/terraform/environment/region/viewer_ecs.tf
+++ b/terraform/environment/region/viewer_ecs.tf
@@ -10,7 +10,7 @@ resource "aws_ecs_service" "viewer" {
 
   network_configuration {
     security_groups  = [aws_security_group.viewer_ecs_service.id]
-    subnets          = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
+    subnets          = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
     assign_public_ip = false
   }
 
@@ -57,7 +57,7 @@ resource "aws_ecs_service" "viewer" {
 resource "aws_security_group" "viewer_ecs_service" {
   name_prefix = "${var.environment_name}-viewer-ecs-service"
   description = "Use service security group"
-  vpc_id      = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/environment/region/viewer_load_balancer.tf
+++ b/terraform/environment/region/viewer_load_balancer.tf
@@ -9,7 +9,7 @@ resource "aws_lb_target_group" "viewer" {
   port                 = 80
   protocol             = "HTTP"
   target_type          = "ip"
-  vpc_id               = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id               = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
   deregistration_delay = 0
   depends_on           = [aws_lb.viewer]
 
@@ -21,7 +21,7 @@ resource "aws_lb" "viewer" {
   internal                   = false #tfsec:ignore:aws-elb-alb-not-public - public alb
   load_balancer_type         = "application"
   drop_invalid_header_fields = true
-  subnets                    = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_subnet.public[*].id : data.aws_subnets.public.ids
+  subnets                    = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_subnet.public[*].id : data.aws_subnets.public.ids
   enable_deletion_protection = var.load_balancer_deletion_protection_enabled
 
   security_groups = [
@@ -222,7 +222,7 @@ resource "aws_lb_listener_rule" "viewer_maintenance_welsh" {
 resource "aws_security_group" "viewer_loadbalancer" {
   name_prefix = "${var.environment_name}-viewer-loadbalancer"
   description = "View service application load balancer"
-  vpc_id      = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
   lifecycle {
     create_before_destroy = true
   }
@@ -285,7 +285,7 @@ resource "aws_security_group_rule" "viewer_loadbalancer_egress" {
 resource "aws_security_group" "viewer_loadbalancer_route53" {
   name_prefix = "${var.environment_name}-viewer-loadbalancer-route53"
   description = "View service Route53 healthchecks"
-  vpc_id      = data.aws_default_tags.current.tags.account-name == "development" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
 
   provider = aws.region
 }


### PR DESCRIPTION
# Purpose

Use the network firewall in preproduction to manage egress

Fixes UML-4002

## Approach

- Change switch to migrate all accounts except production

I've checked plans against account and environment level production account and confirmed no changes will be made as a result of this PR.

See ticket for confirmation

## Learning

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [x] I have performed a self-review of my own code
* [ ] ~I have added tests to prove my work~
* [ ] ~I have added relevant and appropriately leveled logging, **without PII**, to my code~
* [ ] ~New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)~
* [ ] ~I have updated documentation (Confluence/GitHub wiki/tech debt doc)~
* [ ] ~I have added welsh translation tags and updated translation files~
* [ ] ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* [ ] ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* [ ] ~The product team have tested these changes~
