### PR TITLE
Shared github action expects the terraform version to be in versions.tf

### DIFF
--- a/terraform/account/terraform.tf
+++ b/terraform/account/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.12.0"
+
 
   backend "s3" {
     bucket  = "opg.terraform.state"

--- a/terraform/account/versions.tf
+++ b/terraform/account/versions.tf
@@ -17,4 +17,6 @@ terraform {
       version = "~> 4.1.0"
     }
   }
+  required_version = "~> 1.12.0"
+
 }

--- a/terraform/environment/terraform.tf
+++ b/terraform/environment/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.12.0"
+
 
   backend "s3" {
     bucket  = "opg.terraform.state"

--- a/terraform/environment/versions.tf
+++ b/terraform/environment/versions.tf
@@ -13,4 +13,6 @@ terraform {
       version = "~> 3.25.0"
     }
   }
+
+  required_version = "~> 1.12.0"
 }


### PR DESCRIPTION
moving this here the action to be simplified for all other use cases

# Purpose

Align with other projects and allow updated github action to be simplified by no longer support the `.terraform-version` file as well

