### PR TITLE
Fixes for CVE-2025-47907

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -252,11 +252,11 @@ services:
       AWS_ACCESS_KEY_ID: 'devkey'
       AWS_SECRET_ACCESS_KEY: 'secretdevkey'
     volumes:
-      - ./lambda-functions/upload-statistics/app/upload_statistics.py:/var/task/upload_statistics.py
+      - ./lambda-functions/upload-statistics/app/upload_statistics.py:/function/upload_statistics.py
       - ./lambda-functions/.aws-lambda-rie:/aws-lambda
     ports:
       - 9007:8080
-    entrypoint: [ "/aws-lambda/aws-lambda-rie", "python3", "-m", "awslambdaric" ]
+    entrypoint: [ "/aws-lambda/aws-lambda-rie", "/usr/local/bin/python", "-m", "awslambdaric" ]
     command: [ "upload_statistics.lambda_handler" ]
 
   proxy:

--- a/lambda-functions/event-receiver/Dockerfile
+++ b/lambda-functions/event-receiver/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.4-alpine@sha256:68932fa6d4d4059845c8f40ad7e654e626f3ebd3706eef7846f319293ab5cb7a  AS base
+FROM golang:1.24.6-alpine@sha256:c8c5f95d64aa79b6547f3b626eb84b16a7ce18a139e3e9ca19a8c078b85ba80d AS base
 
 ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 

--- a/lambda-functions/upload-statistics/Dockerfile
+++ b/lambda-functions/upload-statistics/Dockerfile
@@ -1,17 +1,22 @@
-FROM public.ecr.aws/lambda/python:3.13.2025.07.14.13@sha256:a0f66469ebd6324794f50f44a4943db71cc8cec9dda353adf0aee0c89b2d09d0 AS build
+FROM python:3.13@sha256:b3e52dd22ff14e2e6dcbc0f028f743dc037c74258e9af3d0a2fd8e6617d94d72 AS build-image
 
+# Copy function code
+RUN mkdir -p /app
+COPY requirements.txt /app
+
+# Install the function's dependencies
+RUN pip install \
+    --target /app \
+    -r /app/requirements.txt
+
+# Use a slim version of the base Python image to reduce the final image size
+FROM python:3.13-slim@sha256:980ddd811c2632839d0686dd466917ffd1a5c4217b38cc93cd93afce7756f472
+
+# Set working directory to function root directory
 WORKDIR /app
 
-COPY requirements.txt .
-
-RUN pip install --no-cache-dir -r requirements.txt -t .
-
-RUN echo "2023.8.20250707" > /etc/dnf/vars/releasever && \
-    dnf clean all && \
-    dnf -y update glib2 && \
-    dnf clean all
-
+COPY --from=build-image /app /app
 COPY /app .
 
-ENTRYPOINT ["python3", "-m", "awslambdaric"]
+ENTRYPOINT ["/usr/local/bin/python", "-m", "awslambdaric"]
 CMD ["upload_statistics.lambda_handler"]

--- a/lambda-functions/upload-statistics/Dockerfile
+++ b/lambda-functions/upload-statistics/Dockerfile
@@ -6,6 +6,7 @@ COPY requirements.txt /app
 
 # Install the function's dependencies
 RUN pip install \
+    --no-cache-dir \
     --target /app \
     -r /app/requirements.txt
 

--- a/service-admin/Dockerfile
+++ b/service-admin/Dockerfile
@@ -13,8 +13,8 @@ FROM golang:1.24.6-alpine@sha256:c8c5f95d64aa79b6547f3b626eb84b16a7ce18a139e3e9c
 
 RUN apk --no-cache add \
   build-base=0.5-r3 \
-  ca-certificates \
-  tzdata \
+  ca-certificates=20250619-r0 \
+  tzdata=2025b-r0 \
   && rm -rf /var/cache/apk/* \
   && adduser -D appuser
 

--- a/service-admin/Dockerfile
+++ b/service-admin/Dockerfile
@@ -9,14 +9,14 @@ COPY package.json package-lock.json ./
 RUN npm ci && npm run build
 
 # Build Go app
-FROM golang:1.24.4-alpine@sha256:68932fa6d4d4059845c8f40ad7e654e626f3ebd3706eef7846f319293ab5cb7a AS build-env
+FROM golang:1.24.6-alpine@sha256:c8c5f95d64aa79b6547f3b626eb84b16a7ce18a139e3e9ca19a8c078b85ba80d AS build-env
 
 RUN apk --no-cache add \
   build-base=0.5-r3 \
-  ca-certificates=20241121-r2	\
-  tzdata=2025b-r0 \
-  && rm -rf /var/cache/apk/* && update-ca-certificates && \
-  adduser -D appuser
+  ca-certificates \
+  tzdata \
+  && rm -rf /var/cache/apk/* \
+  && adduser -D appuser
 
 WORKDIR /app
 


### PR DESCRIPTION
# Purpose

Fixes the CVE relating to golang's stdlib

## Approach

Simple enough for the go projects but the python lambda included a binary in the base container that fails trivy validation so rip all that out and do our own image based on Amazons docs (https://docs.aws.amazon.com/lambda/latest/dg/python-image.html#python-image-clients)

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [x] I have performed a self-review of my own code
* I have added tests to prove my work
* I have added relevant and appropriately leveled logging, **without PII**, to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc)
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
