### PR TITLE
UML-4060: change to detect-secrets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,8 @@ repos:
       - id: terraform_tflint
         args:
          - --args=--recursive
-  - repo: https://github.com/awslabs/git-secrets
-    rev: 5357e18bc27b42a827b6780564ea873a72ca1f01
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
     hooks:
-      - id: git-secrets
+    -   id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,677 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    ".github/workflows/dependabot-composer-npm-path.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/dependabot-composer-npm-path.yml",
+        "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
+        "is_verified": false,
+        "line_number": 50
+      }
+    ],
+    ".github/workflows/dependabot-terraform-upgrade.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/dependabot-terraform-upgrade.yml",
+        "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
+        "is_verified": false,
+        "line_number": 38
+      }
+    ],
+    ".github/workflows/path-to-live.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/path-to-live.yml",
+        "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
+        "is_verified": false,
+        "line_number": 85
+      }
+    ],
+    ".github/workflows/pull-request-path.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/pull-request-path.yml",
+        "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
+        "is_verified": false,
+        "line_number": 29
+      }
+    ],
+    ".github/workflows/scheduled-update-demo.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/scheduled-update-demo.yml",
+        "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
+        "is_verified": false,
+        "line_number": 30
+      }
+    ],
+    ".github/workflows/workflow-deploy-ref-to-env.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/workflow-deploy-ref-to-env.yml",
+        "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
+        "is_verified": false,
+        "line_number": 101
+      }
+    ],
+    "docker-compose.dependencies.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docker-compose.dependencies.yml",
+        "hashed_secret": "0555f9246a410f48acf7168a55e4c1f682bff111",
+        "is_verified": false,
+        "line_number": 42
+      }
+    ],
+    "docker-compose.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docker-compose.yml",
+        "hashed_secret": "e04e85b6c64a463fd4f449b7d7164cdf2e4da35d",
+        "is_verified": false,
+        "line_number": 57
+      }
+    ],
+    "mock-integrations/lpa-codes/mock-openapi.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "mock-integrations/lpa-codes/mock-openapi.yml",
+        "hashed_secret": "53d12a9fd589380afccb37bd399d091c13878be8",
+        "is_verified": false,
+        "line_number": 629
+      }
+    ],
+    "mock-integrations/opg-data-lpa/mock-openapi.yaml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "mock-integrations/opg-data-lpa/mock-openapi.yaml",
+        "hashed_secret": "a3a0c0d41960c4b2b58b4641bf7bac002045e80c",
+        "is_verified": false,
+        "line_number": 1518
+      }
+    ],
+    "mock-integrations/opg-data-lpa/opg-data-lpa-openapi.yml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "mock-integrations/opg-data-lpa/opg-data-lpa-openapi.yml",
+        "hashed_secret": "a3a0c0d41960c4b2b58b4641bf7bac002045e80c",
+        "is_verified": false,
+        "line_number": 188
+      }
+    ],
+    "scripts/deactivate_actor_codes/README.md": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "scripts/deactivate_actor_codes/README.md",
+        "hashed_secret": "36263c76947443b2f6e6b78153967ac4a7da99f9",
+        "is_verified": false,
+        "line_number": 41
+      }
+    ],
+    "service-admin/.vscode/launch.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "service-admin/.vscode/launch.json",
+        "hashed_secret": "9885f8af04289135df259e34bd22d17fe45ea81e",
+        "is_verified": false,
+        "line_number": 18
+      }
+    ],
+    "service-admin/internal/server/auth/authorisation_test.go": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "service-admin/internal/server/auth/authorisation_test.go",
+        "hashed_secret": "760804ba50617e631c4b699d76b06ace0f338886",
+        "is_verified": false,
+        "line_number": 29
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "service-admin/internal/server/auth/authorisation_test.go",
+        "hashed_secret": "3eb4e6b9d9a1b0c9630e2c025f5f3449a3c767d9",
+        "is_verified": false,
+        "line_number": 30
+      }
+    ],
+    "service-admin/internal/server/auth/signing_test.go": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "service-admin/internal/server/auth/signing_test.go",
+        "hashed_secret": "43293bd34e30f16eeeef30bb0d35dc34c4c65cb9",
+        "is_verified": false,
+        "line_number": 35
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "service-admin/internal/server/auth/signing_test.go",
+        "hashed_secret": "fe365a00f68f9fcf7113311b7a0ab6d97741c9ba",
+        "is_verified": false,
+        "line_number": 36
+      }
+    ],
+    "service-api/app/features/context/Acceptance/BaseAcceptanceContext.php": [
+      {
+        "type": "Secret Keyword",
+        "filename": "service-api/app/features/context/Acceptance/BaseAcceptanceContext.php",
+        "hashed_secret": "8b82a3a7f3ac6c0f1aa6274440030ccf83cd274d",
+        "is_verified": false,
+        "line_number": 54
+      }
+    ],
+    "service-api/app/features/context/Acceptance/LpaContext.php": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "service-api/app/features/context/Acceptance/LpaContext.php",
+        "hashed_secret": "e514a04792a9684fd4ae46f685f9ae4c0819ad0a",
+        "is_verified": false,
+        "line_number": 2403
+      }
+    ],
+    "service-api/app/features/context/Acceptance/OidcContext.php": [
+      {
+        "type": "Secret Keyword",
+        "filename": "service-api/app/features/context/Acceptance/OidcContext.php",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 277
+      }
+    ],
+    "service-api/app/features/context/Acceptance/ViewerContext.php": [
+      {
+        "type": "Secret Keyword",
+        "filename": "service-api/app/features/context/Acceptance/ViewerContext.php",
+        "hashed_secret": "7c6f19dfd094c2b229559492b1d1f45bb93c4eba",
+        "is_verified": false,
+        "line_number": 273
+      }
+    ],
+    "service-api/app/features/context/Integration/LpaContext.php": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "service-api/app/features/context/Integration/LpaContext.php",
+        "hashed_secret": "e514a04792a9684fd4ae46f685f9ae4c0819ad0a",
+        "is_verified": false,
+        "line_number": 2264
+      }
+    ],
+    "service-api/app/src/App/src/Service/Secrets/LpaDataStoreSecretManager.php": [
+      {
+        "type": "Secret Keyword",
+        "filename": "service-api/app/src/App/src/Service/Secrets/LpaDataStoreSecretManager.php",
+        "hashed_secret": "663098572b75d69638f431531fcefd4ab4fd8a56",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "service-api/app/src/App/src/Service/Secrets/OneLoginIdentityKeyPairManager.php": [
+      {
+        "type": "Secret Keyword",
+        "filename": "service-api/app/src/App/src/Service/Secrets/OneLoginIdentityKeyPairManager.php",
+        "hashed_secret": "f8ef6220eaf224e7af4e7ee5c1996b6849a78820",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "service-api/app/test/AppTest/DataAccess/ApiGateway/RequestSignerFactoryTest.php": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "service-api/app/test/AppTest/DataAccess/ApiGateway/RequestSignerFactoryTest.php",
+        "hashed_secret": "2ecf905b541c2ec6bee12fbee44c214aea64e34f",
+        "is_verified": false,
+        "line_number": 31
+      }
+    ],
+    "service-api/app/test/AppTest/DataAccess/ApiGateway/RequestSignerTest.php": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "service-api/app/test/AppTest/DataAccess/ApiGateway/RequestSignerTest.php",
+        "hashed_secret": "2ecf905b541c2ec6bee12fbee44c214aea64e34f",
+        "is_verified": false,
+        "line_number": 26
+      }
+    ],
+    "service-api/app/test/AppTest/Service/Notify/NotifyServiceTest.php": [
+      {
+        "type": "Secret Keyword",
+        "filename": "service-api/app/test/AppTest/Service/Notify/NotifyServiceTest.php",
+        "hashed_secret": "79847112d54ad80a472d818eb7df7fca28d413e6",
+        "is_verified": false,
+        "line_number": 134
+      }
+    ],
+    "service-api/app/test/AppTest/Service/Secrets/CachedSecretManagerTest.php": [
+      {
+        "type": "Secret Keyword",
+        "filename": "service-api/app/test/AppTest/Service/Secrets/CachedSecretManagerTest.php",
+        "hashed_secret": "d97a64119b8cb0a0234641d1659d1a838b11c8af",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "service-api/app/test/AppTest/Service/Secrets/CachedSecretManagerTest.php",
+        "hashed_secret": "5c5a15a8b0b3e154d77746945e563ba40100681b",
+        "is_verified": false,
+        "line_number": 55
+      }
+    ],
+    "service-api/app/test/AppTest/Service/Secrets/LpaDataStoreSecretManagerTest.php": [
+      {
+        "type": "Secret Keyword",
+        "filename": "service-api/app/test/AppTest/Service/Secrets/LpaDataStoreSecretManagerTest.php",
+        "hashed_secret": "01c92a77244f5e8e3b1e566c4a9266e724de6d98",
+        "is_verified": false,
+        "line_number": 35
+      }
+    ],
+    "service-api/app/test/AppTest/Service/User/ResolveOAuthUserTest.php": [
+      {
+        "type": "Secret Keyword",
+        "filename": "service-api/app/test/AppTest/Service/User/ResolveOAuthUserTest.php",
+        "hashed_secret": "c25f8ed2ae4f7e36903050e39270bf81a2ddd80a",
+        "is_verified": false,
+        "line_number": 44
+      }
+    ],
+    "service-api/app/test/FunctionalTest/AbstractFunctionalTestCase.php": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "service-api/app/test/FunctionalTest/AbstractFunctionalTestCase.php",
+        "hashed_secret": "2ecf905b541c2ec6bee12fbee44c214aea64e34f",
+        "is_verified": false,
+        "line_number": 25
+      }
+    ],
+    "service-api/seeding/put_actor_codes.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "service-api/seeding/put_actor_codes.py",
+        "hashed_secret": "e04e85b6c64a463fd4f449b7d7164cdf2e4da35d",
+        "is_verified": false,
+        "line_number": 71
+      }
+    ],
+    "service-front/app/features/context/Integration/AccountContext.php": [
+      {
+        "type": "Secret Keyword",
+        "filename": "service-front/app/features/context/Integration/AccountContext.php",
+        "hashed_secret": "de1e214345c60475539846a3335f698970226dc0",
+        "is_verified": false,
+        "line_number": 41
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "service-front/app/features/context/Integration/AccountContext.php",
+        "hashed_secret": "070d44d4390fcac70647816855f9bd84b0c1c7a1",
+        "is_verified": false,
+        "line_number": 42
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "service-front/app/features/context/Integration/AccountContext.php",
+        "hashed_secret": "9c142d8fdc243b23d6831ea74eb909e0447f6cbb",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "service-front/app/features/context/Integration/AccountContext.php",
+        "hashed_secret": "8b82a3a7f3ac6c0f1aa6274440030ccf83cd274d",
+        "is_verified": false,
+        "line_number": 68
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "service-front/app/features/context/Integration/AccountContext.php",
+        "hashed_secret": "9afa6d5054235e220204f1fa66c552acf950e3af",
+        "is_verified": false,
+        "line_number": 82
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "service-front/app/features/context/Integration/AccountContext.php",
+        "hashed_secret": "f2c57870308dc87f432e5912d4de6f8e322721ba",
+        "is_verified": false,
+        "line_number": 184
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "service-front/app/features/context/Integration/AccountContext.php",
+        "hashed_secret": "3b155f9ca527f32c0ae32aae03653da23e891692",
+        "is_verified": false,
+        "line_number": 253
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "service-front/app/features/context/Integration/AccountContext.php",
+        "hashed_secret": "024950367d58ea90fa48cd3e469b0de25c93949a",
+        "is_verified": false,
+        "line_number": 392
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "service-front/app/features/context/Integration/AccountContext.php",
+        "hashed_secret": "dec7dd342a499dfd4d283d872ccf598d8a7b6039",
+        "is_verified": false,
+        "line_number": 758
+      }
+    ],
+    "service-front/app/features/context/UI/AccountContext.php": [
+      {
+        "type": "Secret Keyword",
+        "filename": "service-front/app/features/context/UI/AccountContext.php",
+        "hashed_secret": "de1e214345c60475539846a3335f698970226dc0",
+        "is_verified": false,
+        "line_number": 32
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "service-front/app/features/context/UI/AccountContext.php",
+        "hashed_secret": "070d44d4390fcac70647816855f9bd84b0c1c7a1",
+        "is_verified": false,
+        "line_number": 33
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "service-front/app/features/context/UI/AccountContext.php",
+        "hashed_secret": "9c142d8fdc243b23d6831ea74eb909e0447f6cbb",
+        "is_verified": false,
+        "line_number": 34
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "service-front/app/features/context/UI/AccountContext.php",
+        "hashed_secret": "8b82a3a7f3ac6c0f1aa6274440030ccf83cd274d",
+        "is_verified": false,
+        "line_number": 85
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "service-front/app/features/context/UI/AccountContext.php",
+        "hashed_secret": "dec7dd342a499dfd4d283d872ccf598d8a7b6039",
+        "is_verified": false,
+        "line_number": 164
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "service-front/app/features/context/UI/AccountContext.php",
+        "hashed_secret": "8c684290ce0b8a8e6cee79a145e17554064a4760",
+        "is_verified": false,
+        "line_number": 455
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "service-front/app/features/context/UI/AccountContext.php",
+        "hashed_secret": "3b155f9ca527f32c0ae32aae03653da23e891692",
+        "is_verified": false,
+        "line_number": 626
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "service-front/app/features/context/UI/AccountContext.php",
+        "hashed_secret": "3a707210e4a9fb0dd6db0cbfc009b9a48d968e3e",
+        "is_verified": false,
+        "line_number": 703
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "service-front/app/features/context/UI/AccountContext.php",
+        "hashed_secret": "675d7d231edd2c342ffe29c859baebe6f07f911b",
+        "is_verified": false,
+        "line_number": 962
+      }
+    ],
+    "service-front/app/features/context/UI/LpaContext.php": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "service-front/app/features/context/UI/LpaContext.php",
+        "hashed_secret": "bc88e3676e1c3412fd76378abe23e690dc464915",
+        "is_verified": false,
+        "line_number": 427
+      }
+    ],
+    "service-front/app/test/CommonTest/Service/Security/UserIdentificationServiceTest.php": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "service-front/app/test/CommonTest/Service/Security/UserIdentificationServiceTest.php",
+        "hashed_secret": "f52f88264c146f2ddeaeb5e5bc2b866e7bcabc8f",
+        "is_verified": false,
+        "line_number": 39
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "service-front/app/test/CommonTest/Service/Security/UserIdentificationServiceTest.php",
+        "hashed_secret": "f2620b7ab2e3436329db55690ccd4bf088b923a7",
+        "is_verified": false,
+        "line_number": 95
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "service-front/app/test/CommonTest/Service/Security/UserIdentificationServiceTest.php",
+        "hashed_secret": "81636058483a2b4d66af81678a93f2c83519177f",
+        "is_verified": false,
+        "line_number": 105
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "service-front/app/test/CommonTest/Service/Security/UserIdentificationServiceTest.php",
+        "hashed_secret": "d241c1180d963948f25e98c22da50749f39e054c",
+        "is_verified": false,
+        "line_number": 112
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "service-front/app/test/CommonTest/Service/Security/UserIdentificationServiceTest.php",
+        "hashed_secret": "537885d125264641a653b9d92b007dd940101a8b",
+        "is_verified": false,
+        "line_number": 122
+      }
+    ],
+    "service-front/app/test/CommonTest/Service/Security/UserIdentityTest.php": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "service-front/app/test/CommonTest/Service/Security/UserIdentityTest.php",
+        "hashed_secret": "f52f88264c146f2ddeaeb5e5bc2b866e7bcabc8f",
+        "is_verified": false,
+        "line_number": 20
+      }
+    ],
+    "service-front/web/src/javascript/showHidePassword.test.js": [
+      {
+        "type": "Secret Keyword",
+        "filename": "service-front/web/src/javascript/showHidePassword.test.js",
+        "hashed_secret": "d97d1ee339e4eeaba8cac91dca37c8b4ec8f5501",
+        "is_verified": false,
+        "line_number": 23
+      }
+    ],
+    "terraform/account/secretsmanager.tf": [
+      {
+        "type": "Secret Keyword",
+        "filename": "terraform/account/secretsmanager.tf",
+        "hashed_secret": "c189207a55da45305c884fe2b50e086fcad4724b",
+        "is_verified": false,
+        "line_number": 53
+      }
+    ],
+    "terraform/account/terraform.tfvars.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "terraform/account/terraform.tfvars.json",
+        "hashed_secret": "fe5b9ef70e4cfdc5a4f19c2e82d769b05af7a38b",
+        "is_verified": false,
+        "line_number": 18
+      }
+    ],
+    "terraform/environment/terraform.tfvars.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "terraform/environment/terraform.tfvars.json",
+        "hashed_secret": "4922ecebb7bc3f94a6ed5271e4545cc2a8ce0ed1",
+        "is_verified": false,
+        "line_number": 33
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "terraform/environment/terraform.tfvars.json",
+        "hashed_secret": "f8ef6220eaf224e7af4e7ee5c1996b6849a78820",
+        "is_verified": false,
+        "line_number": 34
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "terraform/environment/terraform.tfvars.json",
+        "hashed_secret": "663098572b75d69638f431531fcefd4ab4fd8a56",
+        "is_verified": false,
+        "line_number": 44
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "terraform/environment/terraform.tfvars.json",
+        "hashed_secret": "88f5e668b3771b35fe58ee0d56ed97f44cd29fba",
+        "is_verified": false,
+        "line_number": 59
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "terraform/environment/terraform.tfvars.json",
+        "hashed_secret": "02ec08caee6f99ca33e0ac7eef82b8f6e51c4bbf",
+        "is_verified": false,
+        "line_number": 162
+      }
+    ],
+    "tests/smoke/context/AccountContext.php": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/smoke/context/AccountContext.php",
+        "hashed_secret": "a4b6d7dfd6a4b817f479556ff250da0055c30f6f",
+        "is_verified": false,
+        "line_number": 37
+      }
+    ]
+  },
+  "generated_at": "2025-09-02T13:31:17Z"
+}


### PR DESCRIPTION
# Purpose

Change from git-secrets to detect-secrets

Fixes UML-4060

## Approach

git-secrets isn't natively supported in pre-commit, but detect-secrets is

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [ ] I have performed a self-review of my own code
* [ ] I have added tests to prove my work
* [ ] I have added relevant and appropriately leveled logging, **without PII**, to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc)
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
