### PR TITLE
UML-4021 - use new network for all environments

### DIFF
--- a/terraform/environment/region/admin_ecs.tf
+++ b/terraform/environment/region/admin_ecs.tf
@@ -10,7 +10,7 @@ resource "aws_ecs_service" "admin" {
 
   network_configuration {
     security_groups  = [aws_security_group.admin_ecs_service.id]
-    subnets          = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
+    subnets          = true ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
     assign_public_ip = false
   }
 
@@ -60,7 +60,7 @@ moved {
 resource "aws_security_group" "admin_ecs_service" {
   name_prefix = "${var.environment_name}-admin-ecs-service"
   description = "Admin service security group"
-  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = true ? data.aws_vpc.main.id : data.aws_vpc.default.id
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/environment/region/admin_load_balancer.tf
+++ b/terraform/environment/region/admin_load_balancer.tf
@@ -3,7 +3,7 @@ resource "aws_lb_target_group" "admin" {
   port                 = 8080
   protocol             = "HTTP"
   target_type          = "ip"
-  vpc_id               = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id               = true ? data.aws_vpc.main.id : data.aws_vpc.default.id
   deregistration_delay = 0
 
   health_check {
@@ -26,7 +26,7 @@ resource "aws_lb" "admin" {
   internal                   = false #tfsec:ignore:aws-elb-alb-not-public - public alb
   load_balancer_type         = "application"
   drop_invalid_header_fields = true
-  subnets                    = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_subnet.public[*].id : data.aws_subnets.public.ids
+  subnets                    = true ? data.aws_subnet.public[*].id : data.aws_subnets.public.ids
   enable_deletion_protection = var.load_balancer_deletion_protection_enabled
 
   security_groups = [
@@ -123,7 +123,7 @@ moved {
 resource "aws_security_group" "admin_loadbalancer" {
   name_prefix = "${var.environment_name}-admin-loadbalancer"
   description = "Admin service application load balancer"
-  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = true ? data.aws_vpc.main.id : data.aws_vpc.default.id
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/environment/region/api_ecs.tf
+++ b/terraform/environment/region/api_ecs.tf
@@ -11,7 +11,7 @@ resource "aws_ecs_service" "api" {
 
   network_configuration {
     security_groups  = [aws_security_group.api_ecs_service.id]
-    subnets          = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
+    subnets          = true ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
     assign_public_ip = false
   }
 
@@ -68,7 +68,6 @@ resource "aws_service_discovery_service" "api_ecs" {
   }
 
   health_check_custom_config {
-    failure_threshold = 1
   }
 
   provider = aws.region
@@ -85,7 +84,7 @@ locals {
 resource "aws_security_group" "api_ecs_service" {
   name_prefix = "${var.environment_name}-api-ecs-service"
   description = "API service security group"
-  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = true ? data.aws_vpc.main.id : data.aws_vpc.default.id
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/environment/region/dns.tf
+++ b/terraform/environment/region/dns.tf
@@ -15,7 +15,7 @@ data "aws_route53_zone" "live_service_view_lasting_power_of_attorney" {
 
 resource "aws_service_discovery_private_dns_namespace" "internal_ecs" {
   name = "${var.environment_name}.ual.internal.ecs"
-  vpc  = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc  = true ? data.aws_vpc.main.id : data.aws_vpc.default.id
 
   provider = aws.region
 }

--- a/terraform/environment/region/mock_onelogin_ecs.tf
+++ b/terraform/environment/region/mock_onelogin_ecs.tf
@@ -12,7 +12,7 @@ resource "aws_ecs_service" "mock_onelogin" {
 
   network_configuration {
     security_groups  = [aws_security_group.mock_onelogin_ecs_service[0].id]
-    subnets          = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
+    subnets          = true ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
     assign_public_ip = false
   }
 
@@ -68,7 +68,6 @@ resource "aws_service_discovery_service" "mock_onelogin_ecs" {
   }
 
   health_check_custom_config {
-    failure_threshold = 1
   }
 
   provider = aws.region
@@ -86,7 +85,7 @@ resource "aws_security_group" "mock_onelogin_ecs_service" {
   count       = var.mock_onelogin_enabled ? 1 : 0
   name_prefix = "${var.environment_name}-mock-onelogin-ecs-service"
   description = "Mock One Login service security group"
-  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = true ? data.aws_vpc.main.id : data.aws_vpc.default.id
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/environment/region/mock_onelogin_load_balancer.tf
+++ b/terraform/environment/region/mock_onelogin_load_balancer.tf
@@ -4,7 +4,7 @@ resource "aws_lb_target_group" "mock_onelogin" {
   port                 = 8080
   protocol             = "HTTP"
   target_type          = "ip"
-  vpc_id               = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id               = true ? data.aws_vpc.main.id : data.aws_vpc.default.id
   deregistration_delay = 0
 
   health_check {
@@ -23,7 +23,7 @@ resource "aws_lb" "mock_onelogin" {
   internal                   = false #tfsec:ignore:aws-elb-alb-not-public - public alb
   load_balancer_type         = "application"
   drop_invalid_header_fields = true
-  subnets                    = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_subnet.public[*].id : data.aws_subnets.public.ids
+  subnets                    = true ? data.aws_subnet.public[*].id : data.aws_subnets.public.ids
   enable_deletion_protection = var.load_balancer_deletion_protection_enabled
 
   security_groups = [
@@ -79,7 +79,7 @@ resource "aws_security_group" "mock_onelogin_loadbalancer" {
   count       = var.mock_onelogin_enabled ? 1 : 0
   name_prefix = "${var.environment_name}-mock-onelogin-loadbalancer"
   description = "Mock One Login application load balancer"
-  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = true ? data.aws_vpc.main.id : data.aws_vpc.default.id
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/environment/region/outputs.tf
+++ b/terraform/environment/region/outputs.tf
@@ -71,5 +71,5 @@ output "receive_events_sqs_queue_name" {
 }
 
 output "vpc_id" {
-  value = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  value = true ? data.aws_vpc.main.id : data.aws_vpc.default.id
 }

--- a/terraform/environment/region/pdf_ecs.tf
+++ b/terraform/environment/region/pdf_ecs.tf
@@ -10,7 +10,7 @@ resource "aws_ecs_service" "pdf" {
 
   network_configuration {
     security_groups  = [aws_security_group.pdf_ecs_service.id]
-    subnets          = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
+    subnets          = true ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
     assign_public_ip = false
   }
 
@@ -67,7 +67,6 @@ resource "aws_service_discovery_service" "pdf_ecs" {
   }
 
   health_check_custom_config {
-    failure_threshold = 1
   }
 
   provider = aws.region
@@ -84,7 +83,7 @@ locals {
 resource "aws_security_group" "pdf_ecs_service" {
   name_prefix = "${var.environment_name}-pdf-ecs-service"
   description = "PDF generator service security group"
-  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = true ? data.aws_vpc.main.id : data.aws_vpc.default.id
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/environment/region/use_ecs.tf
+++ b/terraform/environment/region/use_ecs.tf
@@ -10,7 +10,7 @@ resource "aws_ecs_service" "use" {
 
   network_configuration {
     security_groups  = [aws_security_group.use_ecs_service.id]
-    subnets          = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
+    subnets          = true ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
     assign_public_ip = false
   }
 
@@ -61,7 +61,7 @@ moved {
 resource "aws_security_group" "use_ecs_service" {
   name_prefix = "${var.environment_name}-actor-ecs-service"
   description = "Use service security group"
-  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = true ? data.aws_vpc.main.id : data.aws_vpc.default.id
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/environment/region/use_load_balancer.tf
+++ b/terraform/environment/region/use_load_balancer.tf
@@ -11,7 +11,7 @@ resource "aws_lb_target_group" "use" {
   port                 = 80
   protocol             = "HTTP"
   target_type          = "ip"
-  vpc_id               = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id               = true ? data.aws_vpc.main.id : data.aws_vpc.default.id
   deregistration_delay = 0
   depends_on           = [aws_lb.use]
 
@@ -27,7 +27,7 @@ resource "aws_lb" "use" {
   internal                   = false #tfsec:ignore:aws-elb-alb-not-public - Intentionally public facing
   load_balancer_type         = "application"
   drop_invalid_header_fields = true
-  subnets                    = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_subnet.public[*].id : data.aws_subnets.public.ids
+  subnets                    = true ? data.aws_subnet.public[*].id : data.aws_subnets.public.ids
 
   enable_deletion_protection = var.load_balancer_deletion_protection_enabled
 
@@ -229,7 +229,7 @@ resource "aws_lb_listener_rule" "use_maintenance_welsh" {
 resource "aws_security_group" "use_loadbalancer" {
   name_prefix = "${var.environment_name}-actor-loadbalancer"
   description = "Allow inbound traffic"
-  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = true ? data.aws_vpc.main.id : data.aws_vpc.default.id
 
   provider = aws.region
 }
@@ -286,7 +286,7 @@ resource "aws_security_group_rule" "use_loadbalancer_egress" {
 resource "aws_security_group" "use_loadbalancer_route53" {
   name_prefix = "${var.environment_name}-actor-loadbalancer-route53"
   description = "Allow Route53 healthchecks"
-  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = true ? data.aws_vpc.main.id : data.aws_vpc.default.id
 
   provider = aws.region
 }

--- a/terraform/environment/region/viewer_ecs.tf
+++ b/terraform/environment/region/viewer_ecs.tf
@@ -10,7 +10,7 @@ resource "aws_ecs_service" "viewer" {
 
   network_configuration {
     security_groups  = [aws_security_group.viewer_ecs_service.id]
-    subnets          = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
+    subnets          = true ? data.aws_subnet.application[*].id : data.aws_subnets.private.ids
     assign_public_ip = false
   }
 
@@ -57,7 +57,7 @@ resource "aws_ecs_service" "viewer" {
 resource "aws_security_group" "viewer_ecs_service" {
   name_prefix = "${var.environment_name}-viewer-ecs-service"
   description = "Use service security group"
-  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = true ? data.aws_vpc.main.id : data.aws_vpc.default.id
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/environment/region/viewer_load_balancer.tf
+++ b/terraform/environment/region/viewer_load_balancer.tf
@@ -9,7 +9,7 @@ resource "aws_lb_target_group" "viewer" {
   port                 = 80
   protocol             = "HTTP"
   target_type          = "ip"
-  vpc_id               = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id               = true ? data.aws_vpc.main.id : data.aws_vpc.default.id
   deregistration_delay = 0
   depends_on           = [aws_lb.viewer]
 
@@ -25,7 +25,7 @@ resource "aws_lb" "viewer" {
   internal                   = false #tfsec:ignore:aws-elb-alb-not-public - public alb
   load_balancer_type         = "application"
   drop_invalid_header_fields = true
-  subnets                    = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_subnet.public[*].id : data.aws_subnets.public.ids
+  subnets                    = true ? data.aws_subnet.public[*].id : data.aws_subnets.public.ids
   enable_deletion_protection = var.load_balancer_deletion_protection_enabled
 
   security_groups = [
@@ -226,7 +226,7 @@ resource "aws_lb_listener_rule" "viewer_maintenance_welsh" {
 resource "aws_security_group" "viewer_loadbalancer" {
   name_prefix = "${var.environment_name}-viewer-loadbalancer"
   description = "View service application load balancer"
-  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = true ? data.aws_vpc.main.id : data.aws_vpc.default.id
   lifecycle {
     create_before_destroy = true
   }
@@ -289,7 +289,7 @@ resource "aws_security_group_rule" "viewer_loadbalancer_egress" {
 resource "aws_security_group" "viewer_loadbalancer_route53" {
   name_prefix = "${var.environment_name}-viewer-loadbalancer-route53"
   description = "View service Route53 healthchecks"
-  vpc_id      = data.aws_default_tags.current.tags.account-name != "production" ? data.aws_vpc.main.id : data.aws_vpc.default.id
+  vpc_id      = true ? data.aws_vpc.main.id : data.aws_vpc.default.id
 
   provider = aws.region
 }


### PR DESCRIPTION
# Purpose

Migrate production environment to new network

Fixes UML-4021

## Approach

- update network choice condition to always use new network
- remove deprecated attribute `failure_threshold` for `aws_service_discovery_service` (destructive change)

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_