### PR TITLE
generate a plan output, and apply that plan

### DIFF
--- a/.github/workflows/_run-terraform.yml
+++ b/.github/workflows/_run-terraform.yml
@@ -120,6 +120,9 @@ jobs:
         working-directory: terraform/${{ inputs.terraform_path }}
         continue-on-error: true
 
+      - name: terraform version info
+        run: terraform version
+
       - name: terraform init
         run: terraform init -input=false
         working-directory: terraform/${{ inputs.terraform_path }}
@@ -131,11 +134,8 @@ jobs:
           TF_VAR_admin_container_version: ${{ steps.version-output.outputs.admin-tag }}
         run: |
           terraform workspace show
-          terraform plan -input=false -parallelism=30 -lock-timeout=5m ${{ inputs.extra_vars }}
+          terraform plan -input=false -parallelism=30 -lock-timeout=5m -out=terraform.plan ${{ inputs.extra_vars }}
         working-directory: terraform/${{ inputs.terraform_path }}
-
-      - name: terraform version info
-        run: terraform version
 
       - name: add TTL to dynamodb for environment
         if: inputs.apply == 'true' && inputs.add_ttl == 'true'
@@ -151,7 +151,7 @@ jobs:
           TF_VAR_admin_container_version: ${{ steps.version-output.outputs.admin-tag }}
           CI: true
         run: |
-          terraform apply -lock-timeout=300s -input=false -auto-approve -parallelism=30 ${{ inputs.extra_vars }}
+          terraform apply -lock-timeout=300s -input=false -auto-approve -parallelism=30 terraform.plan ${{ inputs.extra_vars }}
         working-directory: terraform/${{ inputs.terraform_path }}
 
       - name: upload environment cluster config file


### PR DESCRIPTION
# Purpose

Use terraform plans in the apply, makes the terraform job quicker and applies what was printed in the plan, or fails if changes occurred in between the two steps

## Approach

- add an output for the terraform plan
- use terraform.plan in the apply
- move the terraform version command out of the way of the plan and apply

## Learning

- https://developer.hashicorp.com/terraform/cli/commands/plan