### PR TITLE
move planfile to the end and extend lock-timeout

### DIFF
--- a/.github/workflows/_run-terraform.yml
+++ b/.github/workflows/_run-terraform.yml
@@ -151,7 +151,7 @@ jobs:
           TF_VAR_admin_container_version: ${{ steps.version-output.outputs.admin-tag }}
           CI: true
         run: |
-          terraform apply -lock-timeout=300s -input=false -auto-approve -parallelism=30 terraform.plan ${{ inputs.extra_vars }}
+          terraform apply -lock-timeout=500s -input=false -auto-approve -parallelism=30 ${{ inputs.extra_vars }} terraform.plan
         working-directory: terraform/${{ inputs.terraform_path }}
 
       - name: upload environment cluster config file


### PR DESCRIPTION
# Purpose

Use terraform plans in the apply, makes the terraform job quicker and applies what was printed in the plan, or fails if changes occurred in between the two steps

## Approach

- Move planfile to the end of the command
- extend lockfile timeout

## Learning

- https://developer.hashicorp.com/terraform/cli/commands/plan
- https://developer.hashicorp.com/terraform/cli/commands/apply