### PR TITLE
UML-4088 - use the container_version variable to lookup and use the relevant image digest

### DIFF
--- a/.github/workflows/pull-request-path.yml
+++ b/.github/workflows/pull-request-path.yml
@@ -35,7 +35,7 @@ jobs:
     name: output workflow variables
     outputs:
       safe_branch_name: ${{ steps.safe_branch_name.outputs.safe }}
-      short_sha:  ${{ steps.variables.outputs.short_sha }}
+      short_sha: ${{ steps.variables.outputs.short_sha }}
       specific_path: ${{ steps.variables.outputs.path }}
       workspace_name: ${{ steps.set_workspace_name.outputs.workspace_name }}
 
@@ -50,25 +50,25 @@ jobs:
 
       - name: get changed files in the admin folder
         id: changed-files-admin
-        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c  # 46.0.5
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # 46.0.5
         with:
           files: |
             service-admin/**
       - name: get changed files in the event-receiver folder
         id: changed-files-event
-        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c  # 46.0.5
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # 46.0.5
         with:
           files: |
             lambda-functions/event-receiver/**
       - name: get changed files in the terraform folder
         id: changed-files-terraform
-        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c  # 46.0.5
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # 46.0.5
         with:
           files: |
             terraform/**
       - name: get changed docs files in any folder
         id: changed-files-docs
-        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c  # 46.0.5
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # 46.0.5
         with:
           files: |
             **/*.md
@@ -223,7 +223,7 @@ jobs:
     with:
       workspace: preproduction
       terraform_path: environment
-      container_version: main-${{ needs.workflow_variables.outputs.short_sha }}
+      container_version: ${{ needs.workflow_variables.outputs.safe_branch_name }}-${{ needs.workflow_variables.outputs.short_sha }}
       apply: false
       specific_path: all
       add_ttl: false

--- a/.github/workflows/trigger_build
+++ b/.github/workflows/trigger_build
@@ -1,3 +1,4 @@
 trigger a build
 trigger a build
 trigger build
+trigger a build

--- a/terraform/environment/region/admin_ecs.tf
+++ b/terraform/environment/region/admin_ecs.tf
@@ -232,7 +232,7 @@ locals {
     {
       cpu         = 1,
       essential   = true,
-      image       = "${data.aws_ecr_repository.use_an_lpa_admin_app.repository_url}:${var.admin_container_version}",
+      image       = "${data.aws_ecr_repository.use_an_lpa_admin_app.repository_url}@${data.aws_ecr_image.use_an_lpa_admin_app.image_digest}",
       mountPoints = [],
       name        = "app",
       portMappings = [

--- a/terraform/environment/region/api_ecs.tf
+++ b/terraform/environment/region/api_ecs.tf
@@ -370,7 +370,7 @@ locals {
     {
       cpu         = 1,
       essential   = true,
-      image       = "${data.aws_ecr_repository.use_an_lpa_api_web.repository_url}:${var.container_version}",
+      image       = "${data.aws_ecr_repository.use_an_lpa_api_web.repository_url}@${data.aws_ecr_image.use_an_lpa_api_web.image_digest}",
       mountPoints = [],
       name        = "web",
       portMappings = [
@@ -474,7 +474,7 @@ locals {
     {
       cpu         = 1,
       essential   = true,
-      image       = "${data.aws_ecr_repository.use_an_lpa_api_app.repository_url}:${var.container_version}",
+      image       = "${data.aws_ecr_repository.use_an_lpa_api_app.repository_url}@${data.aws_ecr_image.use_an_lpa_api_app.image_digest}",
       mountPoints = [],
       name        = "app",
       portMappings = [

--- a/terraform/environment/region/data_sources.tf
+++ b/terraform/environment/region/data_sources.tf
@@ -48,9 +48,32 @@ data "aws_ecr_repository" "use_an_lpa_front_web" {
   name     = "use_an_lpa/front_web"
 }
 
+data "aws_ecr_image" "use_an_lpa_front_web" {
+  repository_name = "use_an_lpa/front_web"
+  image_tag       = var.container_version
+  provider        = aws.management
+}
+
 data "aws_ecr_repository" "use_an_lpa_front_app" {
   provider = aws.management
   name     = "use_an_lpa/front_app"
+}
+
+data "aws_ecr_image" "use_an_lpa_front_app" {
+  repository_name = "use_an_lpa/front_app"
+  image_tag       = var.container_version
+  provider        = aws.management
+}
+
+data "aws_ecr_repository" "use_an_lpa_api_web" {
+  provider = aws.management
+  name     = "use_an_lpa/api_web"
+}
+
+data "aws_ecr_image" "use_an_lpa_api_web" {
+  repository_name = "use_an_lpa/api_web"
+  image_tag       = var.container_version
+  provider        = aws.management
 }
 
 data "aws_ecr_repository" "use_an_lpa_api_app" {
@@ -58,9 +81,10 @@ data "aws_ecr_repository" "use_an_lpa_api_app" {
   name     = "use_an_lpa/api_app"
 }
 
-data "aws_ecr_repository" "use_an_lpa_api_web" {
-  provider = aws.management
-  name     = "use_an_lpa/api_web"
+data "aws_ecr_image" "use_an_lpa_api_app" {
+  repository_name = "use_an_lpa/api_app"
+  image_tag       = var.container_version
+  provider        = aws.management
 }
 
 data "aws_ecr_repository" "use_an_lpa_pdf" {
@@ -80,6 +104,14 @@ data "aws_ecr_repository" "use_an_lpa_admin_app" {
   name     = "use_an_lpa/admin_app"
 }
 
+data "aws_ecr_image" "use_an_lpa_admin_app" {
+  repository_name = "use_an_lpa/admin_app"
+  image_tag       = var.admin_container_version
+  provider        = aws.management
+}
+
+
+// Secrets
 data "aws_secretsmanager_secret" "notify_api_key" {
   name = var.notify_key_secret_name
 

--- a/terraform/environment/region/use_ecs.tf
+++ b/terraform/environment/region/use_ecs.tf
@@ -204,7 +204,7 @@ locals {
     {
       cpu         = 1,
       essential   = true,
-      image       = "${data.aws_ecr_repository.use_an_lpa_front_web.repository_url}:${var.container_version}",
+      image       = "${data.aws_ecr_repository.use_an_lpa_front_web.repository_url}@${data.aws_ecr_image.use_an_lpa_front_web.image_digest}",
       mountPoints = [],
       name        = "web",
       portMappings = [
@@ -277,7 +277,7 @@ locals {
     {
       cpu         = 1,
       essential   = true,
-      image       = "${data.aws_ecr_repository.use_an_lpa_front_app.repository_url}:${var.container_version}",
+      image       = "${data.aws_ecr_repository.use_an_lpa_front_app.repository_url}@${data.aws_ecr_image.use_an_lpa_front_app.image_digest}",
       mountPoints = [],
       name        = "app",
       portMappings = [

--- a/terraform/environment/region/viewer_ecs.tf
+++ b/terraform/environment/region/viewer_ecs.tf
@@ -181,7 +181,7 @@ locals {
     {
       cpu         = 1,
       essential   = true,
-      image       = "${data.aws_ecr_repository.use_an_lpa_front_web.repository_url}:${var.container_version}",
+      image       = "${data.aws_ecr_repository.use_an_lpa_front_web.repository_url}@${data.aws_ecr_image.use_an_lpa_front_web.image_digest}",
       mountPoints = [],
       name        = "web",
       portMappings = [
@@ -250,7 +250,7 @@ locals {
     {
       cpu         = 1,
       essential   = true,
-      image       = "${data.aws_ecr_repository.use_an_lpa_front_app.repository_url}:${var.container_version}",
+      image       = "${data.aws_ecr_repository.use_an_lpa_front_app.repository_url}@${data.aws_ecr_image.use_an_lpa_front_app.image_digest}",
       mountPoints = [],
       name        = "app",
       portMappings = [


### PR DESCRIPTION
# Purpose

Terraform doesn't trigger a new deployment when the container version latest, because it sees no difference in the string.

Fixes UML-4088

## Approach

- add aws_ecr_image data source for each image (pdf already does this)
- replace `:${var.container_version}` with the image_digest attribute for each image
- replace `:${var.admin_container_version}` with the image_digest attribute for the admin image
- use the image tag made by this run when planning a preproduction deployment

## Learning

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecr_image
