### PR TITLE
UML-4090 - create an S3 VPC endpoint

### DIFF
--- a/.github/workflows/trigger_build
+++ b/.github/workflows/trigger_build
@@ -2,3 +2,4 @@ trigger a build
 trigger a build
 trigger build
 trigger a build
+trigger a build


### PR DESCRIPTION
# Purpose

Route requests to AWS S3 endpoints via a VPC endpoint

Fixes UML-4090

## Approach

- add gateway VPCe for S3

## Learning

- https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-s3.html
