### PR TITLE
UML-3506 - Add test alarms for 4xx error anomalies

### DIFF
--- a/terraform/environment/region/cloudwatch_alarms.tf
+++ b/terraform/environment/region/cloudwatch_alarms.tf
@@ -46,6 +46,78 @@ resource "aws_cloudwatch_metric_alarm" "actor_5xx_errors" {
   provider = aws.region
 }
 
+# 4XX anomaly alarms
+resource "aws_cloudwatch_metric_alarm" "viewer_4xx_anomaly" {
+  actions_enabled     = false
+  alarm_description   = "Anomaly detection for 4XX Errors returned to viewer users in ${var.environment_name}"
+  alarm_name          = "${var.environment_name} viewer 4XX anomaly"
+  datapoints_to_alarm = 2
+  evaluation_periods  = 2
+  threshold_metric_id = "ad1"
+  comparison_operator = "GreaterThanUpperThreshold"
+
+  insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
+  ok_actions    = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
+  metric_query {
+    id          = "ad1"
+    expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
+    label       = "4XX anomaly detection band"
+    return_data = true
+  }
+  metric_query {
+    id          = "m1"
+    return_data = true
+    metric {
+      metric_name = "HTTPCode_Target_4XX_Count"
+      namespace   = "AWS/ApplicationELB"
+      period      = 60
+      stat        = "Sum"
+      dimensions = {
+        "LoadBalancer" = trimprefix(split(":", aws_lb.viewer.arn)[5], "loadbalancer/")
+      }
+    }
+  }
+  provider = aws.region
+}
+resource "aws_cloudwatch_metric_alarm" "actor_4xx_anomaly" {
+  actions_enabled     = false
+  alarm_description   = "Anomaly detection for 4XX Errors returned to actor users in ${var.environment_name}"
+  alarm_name          = "${var.environment_name} actor 4XX anomaly"
+  datapoints_to_alarm = 2
+  evaluation_periods  = 2
+  threshold_metric_id = "ad1"
+  comparison_operator = "GreaterThanUpperThreshold"
+
+  insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
+  ok_actions    = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
+  metric_query {
+    id          = "ad1"
+    expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
+    label       = "4XX anomaly detection band"
+    return_data = true
+  }
+  metric_query {
+    id          = "m1"
+    return_data = true
+    metric {
+      metric_name = "HTTPCode_Target_4XX_Count"
+      namespace   = "AWS/ApplicationELB"
+      period      = 60
+      stat        = "Sum"
+      dimensions = {
+        "LoadBalancer" = trimprefix(split(":", aws_lb.use.arn)[5], "loadbalancer/")
+      }
+    }
+  }
+  provider = aws.region
+}
+
 resource "aws_cloudwatch_metric_alarm" "unexpected_data_lpa_api_resposnes" {
   actions_enabled     = true
   alarm_name          = "${var.environment_name}_unexpected_data_lpa_api_resposnes"


### PR DESCRIPTION
# Purpose

Add cloudwatch alarms for detecting anomalies in the number of 4xx series errors on the actor and viewer load balancers.

Fixes UML-3506

## Approach

Added in the alarms with `actions_enabled = false`. Will monitor over time and adjust the sensitivity as needed. 

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [x] I have performed a self-review of my own code
* [ ] I have added tests to prove my work
* [ ] I have added relevant and appropriately leveled logging, **without PII**, to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc)
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
