### PR TITLE
UML-2852 Normalise names when checking equality

### DIFF
--- a/lambda-functions/upload-statistics/Dockerfile
+++ b/lambda-functions/upload-statistics/Dockerfile
@@ -10,9 +10,9 @@ RUN pip install --no-cache-dir --target /app -r /app/requirements.txt
 # Use a slim version of the base Python image to reduce the final image size
 FROM python:3.14-slim@sha256:6a27522252aef8432841f224d9baaa6e9fce07b07584154fa0b9a96603af7456
 
-# Update openssl to non-vulnerable version
+# Update openssl to non-vulnerable version
 RUN apt-get update && \
-    apt-get install openssl=3.5.4-1~deb13u2 -y --no-install-recommends && \
+    apt-get install openssl=3.5.5-1~deb13u2 -y --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 
 # Set working directory to function root directory

--- a/service-api/app/src/App/src/Service/Equals.php
+++ b/service-api/app/src/App/src/Service/Equals.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+final class Equals
+{
+    public static function firstNames(string $a, string $b): bool
+    {
+        return self::normaliseFirstNames($a) === self::normaliseFirstNames($b);
+    }
+
+    private static function normaliseFirstNames(string $s): string
+    {
+        // only take the first of the firstnames for comparison
+        return self::turnUnicodeCharToAscii(strtolower(explode(' ', trim($s))[0]));
+    }
+
+    public static function lastName(string $a, string $b): bool
+    {
+        return self::normaliseLastName($a) === self::normaliseLastName($b);
+    }
+
+    private static function normaliseLastName(string $s): string
+    {
+        return self::turnUnicodeCharToAscii(preg_replace('/\s+/', ' ', strtolower(trim($s))));
+    }
+
+    public static function postcode(string $a, string $b): bool
+    {
+        return self::normalisePostcode($a) === self::normalisePostcode($b);
+    }
+
+    private static function normalisePostcode(string $s): string
+    {
+        return strtolower(str_replace(' ', '', $s));
+    }
+
+    private static function turnUnicodeCharToAscii(string $s): string
+    {
+        $s = str_replace(['‘', '’'], '\'', $s);
+        $s = str_replace([
+            "\u{2010}", // (the other unicode) hyphen
+            "\u{2011}", // non-breaking hyphen
+            "\u{2012}", // figure dash
+            "\u{2013}", // en dash
+            "\u{2014}", // em dash
+        ], '-', $s);
+        return $s;
+    }
+}

--- a/service-api/app/src/App/src/Service/Lpa/Combined/RejectInvalidLpa.php
+++ b/service-api/app/src/App/src/Service/Lpa/Combined/RejectInvalidLpa.php
@@ -8,6 +8,7 @@ use App\DataAccess\Repository\Response\LpaInterface;
 use App\Exception\GoneException;
 use App\Exception\MissingCodeExpiryException;
 use App\Exception\NotFoundException;
+use App\Service\Equals;
 use DateTimeInterface;
 use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
@@ -41,9 +42,7 @@ class RejectInvalidLpa
         }
 
         // Does the donor match? If not then return nothing (Lpa not found with those details)
-        if (
-            strtolower($lpa->getData()->getDonor()->getSurname()) !== strtolower($donorSurname)
-        ) {
+        if (!Equals::lastName($lpa->getData()->getDonor()->getSurname(), $donorSurname)) {
             $this->logger->info(
                 'The donor entered by the user to view the lpa with {code} does not match',
                 ['code' => $viewerCode]

--- a/service-api/app/src/App/src/Service/Lpa/FindActorInLpa.php
+++ b/service-api/app/src/App/src/Service/Lpa/FindActorInLpa.php
@@ -6,6 +6,7 @@ namespace App\Service\Lpa;
 
 use App\Entity\LpaStore\LpaStoreAttorney;
 use App\Exception\ActorDateOfBirthNotSetException;
+use App\Service\Equals;
 use App\Service\Lpa\FindActorInLpa\ActorMatch;
 use App\Service\Lpa\FindActorInLpa\ActorMatchingInterface;
 use App\Service\Lpa\FindActorInLpa\FindActorInLpaInterface;
@@ -149,15 +150,6 @@ class FindActorInLpa
             }
         }
 
-        $matchData = $this->normaliseComparisonData($matchData);
-        $actorData = $this->normaliseComparisonData(
-            [
-                'first_names' => $actor->getFirstname(),
-                'last_name'   => $actor->getSurname(),
-                'postcode'    => $actor->getPostcode(),
-            ]
-        );
-
         $this->logger->debug(
             'Doing actor data comparison against actor with id {actor_id}',
             [
@@ -183,15 +175,15 @@ class FindActorInLpa
             return self::NO_MATCH__DOB;
         }
 
-        $match = $actorData['first_names'] !== $matchData['first_names']
-            ? $match | self::NO_MATCH__FIRSTNAMES
-            : $match;
-        $match = $actorData['last_name'] !== $matchData['last_name']
-            ? $match | self::NO_MATCH__SURNAME
-            : $match;
-        $match = $actorData['postcode'] !== $matchData['postcode']
-            ? $match | self::NO_MATCH__POSTCODE
-            : $match;
+        $match = Equals::firstNames($actor->getFirstname(), $matchData['first_names'])
+            ? $match
+            : $match | self::NO_MATCH__FIRSTNAMES;
+        $match = Equals::lastName($actor->getSurname(), $matchData['last_name'])
+            ? $match
+            : $match | self::NO_MATCH__SURNAME;
+        $match = Equals::postcode($actor->getPostcode(), $matchData['postcode'])
+            ? $match
+            : $match | self::NO_MATCH__POSTCODE;
 
         if ($match === self::MATCH) {
             $this->logger->info(
@@ -213,34 +205,5 @@ class FindActorInLpa
         }
 
         return $match;
-    }
-
-    /**
-     * Formats data attributes for comparison in the older lpa journey
-     *
-     * @param array $data
-     * @return ?array
-     */
-    private function normaliseComparisonData(array $data): ?array
-    {
-        $data['first_names'] = $this->turnUnicodeCharToAscii(
-            strtolower(explode(' ', trim($data['first_names']))[0])
-        );
-        $data['last_name']   = $this->turnUnicodeCharToAscii(strtolower(trim($data['last_name'])));
-        $data['postcode']    = strtolower(str_replace(' ', '', $data['postcode']));
-
-        return $data;
-    }
-
-    /**
-     * Replace any unicode apostrophe's in string to an ascii [introduced to resolve iphone entry issue]
-     *
-     * @param string $string
-     * @return string
-     */
-    private function turnUnicodeCharToAscii(string $string): string
-    {
-        $charsToReplace = ['’'];
-        return str_ireplace($charsToReplace, '\'', $string);
     }
 }

--- a/service-api/app/src/App/src/Service/Lpa/SiriusLpaManager.php
+++ b/service-api/app/src/App/src/Service/Lpa/SiriusLpaManager.php
@@ -6,8 +6,10 @@ namespace App\Service\Lpa;
 
 use App\Enum\LpaSource;
 use App\Exception\ApiException;
+use App\Exception\MissingCodeExpiryException;
 use App\Exception\NotFoundException;
 use App\Service\Lpa\Combined\FilterActiveActors;
+use App\Service\Lpa\Combined\RejectInvalidLpa;
 use App\Service\Lpa\Combined\UserLpaActorToken as UserLpaActorTokenResponse;
 use App\Service\Lpa\IsValid\IsValidInterface;
 use App\Service\Lpa\ResolveActor\HasActorInterface;
@@ -36,6 +38,7 @@ class SiriusLpaManager implements LpaManagerInterface
         private ResolveActor $resolveActor,
         private IsValidLpa $isValidLpa,
         private FilterActiveActors $filterActiveActors,
+        private RejectInvalidLpa $rejectInvalidLpa,
         private LoggerInterface $logger,
     ) {
     }
@@ -130,43 +133,16 @@ class SiriusLpaManager implements LpaManagerInterface
 
         $lpa = $this->getByUid(new LpaUid($viewerCodeData['SiriusUid']));
 
-        //---
-
-        // Check donor's surname
-
-        if (
-            is_null($lpa) ||
-            !Equals::lastName($lpa->getData()->getDonor()->getSurname(), $donorSurname)
-        ) {
+        if ($lpa === null) {
             throw new NotFoundException();
         }
 
-        //---
-        // Whilst the checks in this section could be done before we lookup the LPA, they are done
-        // at this point as we only want to acknowledge if a code has expired if donor surname matched.
-
-        if (!isset($viewerCodeData['Expires']) || !($viewerCodeData['Expires'] instanceof DateTime)) {
-            $this->logger->info(
-                'The code {code} entered by user to view LPA does not have an expiry date set.',
-                ['code' => $viewerCode]
-            );
+        // Whilst the checks in this invokable could be done before we look up the LPA, they are done
+        // at this point as we only want to acknowledge if a code has expired if the donor surname matched.
+        try {
+            ($this->rejectInvalidLpa)($lpa, $viewerCode, $donorSurname, $viewerCodeData);
+        } catch (MissingCodeExpiryException) {
             throw ApiException::create('Missing code expiry data in Dynamo response');
-        }
-
-        if (new DateTime() > $viewerCodeData['Expires']) {
-            $this->logger->info(
-                'The code {code} entered by user to view LPA has expired.',
-                [
-                    'code'      => $viewerCode,
-                    'expiredBy' => $viewerCodeData['Expires']->diff(new DateTime())->format('%R%a days'),
-                ],
-            );
-            throw new GoneException('Share code expired');
-        }
-
-        if (isset($viewerCodeData['Cancelled'])) {
-            $this->logger->info('The code {code} entered by user is cancelled.', ['code' => $viewerCode]);
-            throw new GoneException('Share code cancelled');
         }
 
         $lpaData = $lpa->getData();

--- a/service-api/app/src/App/src/Service/Lpa/SiriusLpaManager.php
+++ b/service-api/app/src/App/src/Service/Lpa/SiriusLpaManager.php
@@ -20,6 +20,7 @@ use App\DataAccess\Repository\{InstructionsAndPreferencesImagesInterface,
     ViewerCodeActivityInterface,
     ViewerCodesInterface};
 use App\Exception\GoneException;
+use App\Service\Equals;
 use App\Value\LpaUid;
 use DateTime;
 use Psr\Log\LoggerInterface;
@@ -134,8 +135,8 @@ class SiriusLpaManager implements LpaManagerInterface
         // Check donor's surname
 
         if (
-            is_null($lpa)
-            || strtolower($lpa->getData()->getDonor()->getSurname()) !== strtolower($donorSurname)
+            is_null($lpa) ||
+            !Equals::lastName($lpa->getData()->getDonor()->getSurname(), $donorSurname)
         ) {
             throw new NotFoundException();
         }

--- a/service-api/app/test/AppTest/Service/EqualsTest.php
+++ b/service-api/app/test/AppTest/Service/EqualsTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppTest\Service;
+
+use App\Service\Equals;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Equals::class)]
+class EqualsTest extends TestCase
+{
+    #[DataProvider('firstNamesProvider')]
+    #[Test]
+    public function testFirstNames($expected, $a, $b): void
+    {
+        $this->assertEquals($expected, Equals::firstNames($a, $b));
+    }
+
+    public static function firstNamesProvider(): array
+    {
+        return [
+            [
+                false,
+                'John',
+                'Gohn',
+            ],
+            [
+                true,
+                'John',
+                'John',
+            ], // easy
+            [
+                true,
+                'John',
+                '  John  ',
+            ], // trimmed
+            [
+                true,
+                'John',
+                'John James',
+            ], // only first of firstnames checked
+            [
+                true,
+                'O\'j\'o-h-n-a-t-h',
+                "O’j‘o\u{2010}h\u{2011}n\u{2012}a\u{2013}t\u{2014}h",
+            ], // normalises quotes and dashes to ' and -
+            [
+                true,
+                'JOHN',
+                'jOhn',
+            ], // ignores case
+        ];
+    }
+
+    #[DataProvider('lastNameProvider')]
+    #[Test]
+    public function testLastName(bool $expected, string $a, string $b): void
+    {
+        $this->assertEquals($expected, Equals::lastName($a, $b));
+    }
+
+    public static function lastNameProvider(): array
+    {
+        return [
+            [
+                false,
+                'John',
+                'Gohn',
+            ],
+            [
+                true,
+                'John',
+                'John',
+            ], // easy
+            [
+                true,
+                'John',
+                '  John  ',
+            ], // trimmed
+            [
+                false,
+                'John',
+                'John James',
+            ], // all names checked
+            [
+                true,
+                'John James Gary',
+                'John    James   	  Gary',
+            ], // all names checked with multiple spaces collapsed
+            [
+                true,
+                'O\'john',
+                'O’john',
+            ], // normalises ’ to '
+            [
+                true,
+                'JOHN',
+                'jOhn',
+            ], // ignores case
+        ];
+    }
+
+    #[DataProvider('postcodeProvider')]
+    #[Test]
+    public function testPostcode(bool $expected, string $a, string $b): void
+    {
+        $this->assertEquals($expected, Equals::postcode($a, $b));
+    }
+
+    public static function postcodeProvider(): array
+    {
+        return [
+            [
+                false,
+                'F11FF',
+                'F12FF',
+            ],
+            [
+                true,
+                'F11FF',
+                'F11FF',
+            ], // easy
+            [
+                true,
+                'F11FF',
+                '  F1 1FF  ',
+            ], // ignores spaces
+            [
+                true,
+                'F11FF',
+                'f11ff',
+            ], // ignores case
+        ];
+    }
+}

--- a/service-api/app/test/AppTest/Service/Lpa/SiriusLpaManagerTest.php
+++ b/service-api/app/test/AppTest/Service/Lpa/SiriusLpaManagerTest.php
@@ -4,24 +4,27 @@ declare(strict_types=1);
 
 namespace AppTest\Service\Lpa;
 
-use App\DataAccess\{Repository\InstructionsAndPreferencesImagesInterface,
-    Repository\LpasInterface,
-    Repository\UserLpaActorMapInterface,
-    Repository\ViewerCodeActivityInterface,
-    Repository\ViewerCodesInterface};
-use App\DataAccess\Repository\Response\{InstructionsAndPreferencesImages, Lpa};
+use App\DataAccess\Repository\InstructionsAndPreferencesImagesInterface;
+use App\DataAccess\Repository\LpasInterface;
+use App\DataAccess\Repository\UserLpaActorMapInterface;
+use App\DataAccess\Repository\ViewerCodeActivityInterface;
+use App\DataAccess\Repository\ViewerCodesInterface;
+use App\DataAccess\Repository\Response\InstructionsAndPreferencesImages;
+use App\DataAccess\Repository\Response\Lpa;
 use App\Enum\InstructionsAndPreferencesImagesResult;
 use App\Exception\ApiException;
+use App\Exception\MissingCodeExpiryException;
 use App\Exception\NotFoundException;
 use App\Service\Features\FeatureEnabled;
-use App\Service\Lpa\{Combined\FilterActiveActors,
-    IsValidLpa,
-    ResolveActor,
-    ResolveActor\ActorType,
-    ResolveActor\LpaActor,
-    SiriusLpa,
-    SiriusLpaManager,
-    SiriusPerson};
+use App\Service\Lpa\Combined\FilterActiveActors;
+use App\Service\Lpa\IsValidLpa;
+use App\Service\Lpa\ResolveActor;
+use App\Service\Lpa\ResolveActor\ActorType;
+use App\Service\Lpa\ResolveActor\LpaActor;
+use App\Service\Lpa\SiriusLpa;
+use App\Service\Lpa\SiriusLpaManager;
+use App\Service\Lpa\SiriusPerson;
+use App\Service\Lpa\Combined\RejectInvalidLpa;
 use App\Value\LpaUid;
 use DateInterval;
 use DateTime;
@@ -47,6 +50,7 @@ class SiriusLpaManagerTest extends TestCase
     private IsValidLpa|ObjectProphecy $isValidLpaProphecy;
     private FilterActiveActors|ObjectProphecy $filterActiveActorProphecy;
     private FeatureEnabled|ObjectProphecy $featureEnabledProphecy;
+    private RejectInvalidLpa|ObjectProphecy $rejectInvalidLpaProphecy;
     private LoggerInterface|ObjectProphecy $loggerProphecy;
 
     public function setUp(): void
@@ -61,6 +65,7 @@ class SiriusLpaManagerTest extends TestCase
         $this->isValidLpaProphecy                  = $this->prophesize(IsValidLpa::class);
         $this->filterActiveActorsProphecy          = $this->prophesize(FilterActiveActors::class);
         $this->featureEnabledProphecy              = $this->prophesize(FeatureEnabled::class);
+        $this->rejectInvalidLpaProphecy            = $this->prophesize(RejectInvalidLpa::class);
         $this->loggerProphecy                      = $this->prophesize(LoggerInterface::class);
     }
 
@@ -75,6 +80,7 @@ class SiriusLpaManagerTest extends TestCase
             $this->resolveActorProphecy->reveal(),
             $this->isValidLpaProphecy->reveal(),
             $this->filterActiveActorsProphecy->reveal(),
+            $this->rejectInvalidLpaProphecy->reveal(),
             $this->loggerProphecy->reveal(),
         );
     }
@@ -779,31 +785,27 @@ class SiriusLpaManagerTest extends TestCase
     }
 
     #[Test]
-    public function cannot_get_lpa_with_invalid_donor_by_viewer_code(): void
-    {
-        $t = $this->init_valid_get_by_viewer_account();
-
-        $service = $this->getLpaService();
-
-        $this->expectException(NotFoundException::class);
-        $result = $service->getByViewerCode($t->ViewerCode, 'different-donor-name', null);
-    }
-
-    #[Test]
     public function cannot_get_lpa_by_viewer_code_with_missing_expiry(): void
     {
         $t = $this->init_valid_get_by_viewer_account();
 
         $service = $this->getLpaService();
 
-        //---
-
-        $this->viewerCodesInterfaceProphecy->get($t->ViewerCode)->willReturn([
+        $viewerCodeData = [
             'ViewerCode'   => $t->ViewerCode,
             'SiriusUid'    => $t->SiriusUid,
-            //'Expires' => $t->Expires,             <-- Expires is removed
             'Organisation' => $t->Organisation,
-        ]);
+        ];
+
+        //---
+
+        $this->viewerCodesInterfaceProphecy
+            ->get($t->ViewerCode)
+            ->willReturn($viewerCodeData);
+
+        $this->rejectInvalidLpaProphecy
+            ->__invoke($t->Lpa, $t->ViewerCode, $t->DonorSurname, $viewerCodeData)
+            ->willThrow(new MissingCodeExpiryException());
 
         //---
 
@@ -814,7 +816,7 @@ class SiriusLpaManagerTest extends TestCase
     }
 
     #[Test]
-    public function cannot_get_lpa_by_viewer_code_with_cancelled(): void
+    public function cannot_get_lpa_by_viewer_code_when_rejected(): void
     {
         $t = $this->init_valid_get_by_viewer_account();
 
@@ -822,42 +824,26 @@ class SiriusLpaManagerTest extends TestCase
 
         //---
 
-        $this->viewerCodesInterfaceProphecy->get($t->ViewerCode)->willReturn([
+        $viewerCodeData = [
             'ViewerCode'   => $t->ViewerCode,
             'SiriusUid'    => $t->SiriusUid,
             'Expires'      => new DateTime('1 hour'),
             'Cancelled'    => true,
             'Organisation' => $t->Organisation,
-        ]);
+        ];
+
+        $this->viewerCodesInterfaceProphecy
+            ->get($t->ViewerCode)
+            ->willReturn($viewerCodeData);
+
+        $this->rejectInvalidLpaProphecy
+            ->__invoke($t->Lpa, $t->ViewerCode, $t->DonorSurname, $viewerCodeData)
+            ->willThrow(new RuntimeException('Share code blah'));
 
         //---
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Share code cancelled');
-
-        $service->getByViewerCode($t->ViewerCode, $t->DonorSurname, null);
-    }
-
-    #[Test]
-    public function cannot_get_lpa_by_viewer_code_with_expired_expiry(): void
-    {
-        $t = $this->init_valid_get_by_viewer_account();
-
-        $service = $this->getLpaService();
-
-        //---
-
-        $this->viewerCodesInterfaceProphecy->get($t->ViewerCode)->willReturn([
-            'ViewerCode'   => $t->ViewerCode,
-            'SiriusUid'    => $t->SiriusUid,
-            'Expires'      => new DateTime('-1 hour'),
-            'Organisation' => $t->Organisation,
-        ]);
-
-        //---
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Share code expired');
+        $this->expectExceptionMessage('Share code blah');
 
         $service->getByViewerCode($t->ViewerCode, $t->DonorSurname, null);
     }


### PR DESCRIPTION
Other options I could probably be convinced to swap to:
- make these non-static so the class can be injected (I didn't because I am currently in a "mocked unit testing is just writing code twice" phase)
- create separate classes for each thing as a value type with an `equals` method to use (I didn't because I thought it wouldn't be as obvious in the code; also there is no way to overload `==`, right?)
- remove the class and use with `use function` (I didn't because then I'd have to figure out what to do with the helper functions that are currently private)
- something else I haven't thought of...