### PR TITLE
Uml 4300 handle account migrations differently

### DIFF
--- a/service-api/app/features/actor-one-login.feature
+++ b/service-api/app/features/actor-one-login.feature
@@ -8,7 +8,23 @@ Feature: Authorise One Login
      Then I am redirected to the one login service
 
   @acceptance
-  Scenario: I can successfully sign in via one login
+  Scenario: I can successfully sign in via one login as a completely new user
+    Given I do not have a local account
+    And I have an unknown One Login identity
+    When I complete a One Login sign-in process
+    Then I am returned to the use an lpa service
+    And the login process is a success
+
+  @acceptance
+  Scenario: I can successfully sign in via one login as a migrating user
+    Given I have a local account
+    And I have an unknown One Login identity
+    When I complete a One Login sign-in process
+    Then I am returned to the use an lpa service
+    And the login process is a success
+
+  @acceptance
+  Scenario: I can successfully sign in via one login as an existing user
     Given I have a local account
       And I have a matching One Login identity
      When I complete a One Login sign-in process
@@ -16,7 +32,7 @@ Feature: Authorise One Login
       And the login process is a success
 
   @acceptance
-  Scenario Outline: I can successfully sign in via one login with a changed email
+  Scenario: I can successfully sign in via one login with a changed email
     Given I have a local account
       And the identity provided by One Login has a "new email"
      When I complete a One Login sign-in process
@@ -24,7 +40,7 @@ Feature: Authorise One Login
       And the login process is a success
 
   @acceptance
-  Scenario Outline: I can successfully sign in via one login with a different subject
+  Scenario: I can successfully sign in via one login with a different subject
     Given I have a local account
       And the identity provided by One Login has a "different subject than expected"
      When I complete a One Login sign-in process

--- a/service-api/app/features/actor-one-login.feature
+++ b/service-api/app/features/actor-one-login.feature
@@ -4,19 +4,29 @@ Feature: Authorise One Login
   @acceptance
   Scenario: I initiate authentication via one login
     Given I wish to login to the use an lpa service
-    When I start the login process
-    Then I am redirected to the one login service
+     When I start the login process
+     Then I am redirected to the one login service
 
   @acceptance
   Scenario: I can successfully sign in via one login
-    Given I have completed a successful one login sign-in process
-      And I have an existing local account
-     When I am returned to the use an lpa service
-     Then I am taken to my dashboard
+    Given I have a local account
+      And I have a matching One Login identity
+     When I complete a One Login sign-in process
+     Then I am returned to the use an lpa service
+      And the login process is a success
 
   @acceptance
-  Scenario: I can successfully log out via one login
-    Given I have completed a successful one login sign-in process
-    And I have an existing local account
-    When I am returned to the use an lpa service
-    Then I am taken to my dashboard
+  Scenario Outline: I can successfully sign in via one login with a changed email
+    Given I have a local account
+      And the identity provided by One Login has a "new email"
+     When I complete a One Login sign-in process
+     Then I am returned to the use an lpa service
+      And the login process is a success
+
+  @acceptance
+  Scenario Outline: I can successfully sign in via one login with a different subject
+    Given I have a local account
+      And the identity provided by One Login has a "different subject than expected"
+     When I complete a One Login sign-in process
+     Then I am returned to the use an lpa service
+      And the login process is a success

--- a/service-api/app/features/context/Acceptance/OidcContext.php
+++ b/service-api/app/features/context/Acceptance/OidcContext.php
@@ -36,6 +36,14 @@ class OidcContext implements Context
     use BaseAcceptanceContextTrait;
     use SetupEnv;
 
+    public const LOGIN_TYPE = [
+        'NEW_ACCOUNT'               => 0, // completely new account
+        'MIGRATING_USER'            => 1, // local 'identityless' account and unknown one login - email will match
+        'EXISTING_USER'             => 2, // just a normal login
+        'EXISTING_USER_NEW_EMAIL'   => 3, // one login supplying a new email
+        'EXISTING_USER_NEW_SUBJECT' => 4, // an unknown one login account has an email we know of
+    ];
+
     public string $oneLoginClientPrivateKey;
     public string $oneLoginClientPublicKey;
     public string $oneLoginIssuerPublicKey;
@@ -180,6 +188,27 @@ class OidcContext implements Context
         ];
     }
 
+    #[Given('I do not have a local account')]
+    public function iDoNotHaveALocalAccount(): void
+    {
+        $this->localAccount = [];
+    }
+
+    #[Given('I have an unknown One Login identity')]
+    public function iHaveAnUnknownOneLoginIdentity(): void
+    {
+        $this->identityEmail   = 'test@example.com';
+        $this->identitySubject = 'urn:fdc:gov.uk:2022:unique_id';
+
+        if (count($this->localAccount) > 0) {
+            $this->type = self::LOGIN_TYPE['MIGRATING_USER'];
+        } else {
+            $this->type = self::LOGIN_TYPE['NEW_ACCOUNT'];
+        }
+
+        $this->fixIdentity();
+    }
+
     #[Given('I have a matching One Login identity')]
     #[Given('the identity provided by One Login has a :type')]
     public function iHaveAMatchingOneLoginIdentity(string $type = ''): void
@@ -189,39 +218,19 @@ class OidcContext implements Context
 
         switch ($type) {
             case '':
-                $this->type = 0;
+                $this->type = self::LOGIN_TYPE['EXISTING_USER'];
                 break;
             case 'new email':
                 $this->identityEmail = 'new.email@example.com';
-                $this->type          = 0;
+                $this->type          = self::LOGIN_TYPE['EXISTING_USER_NEW_EMAIL'];
                 break;
             case 'different subject than expected':
                 $this->identitySubject = 'urn:fdc:gov.uk:2022:new_unique_id';
-                $this->type            = 1;
+                $this->type            = self::LOGIN_TYPE['EXISTING_USER_NEW_SUBJECT'];
                 break;
-            default:
         }
 
-        $this->oneLoginIdentity = function (RequestInterface $request): ResponseInterface {
-            Assert::assertSame('/userinfo', $request->getUri()->getPath());
-            Assert::assertSame('Bearer ' . $this->accessToken, $request->getHeader('authorization')[0]);
-
-            return new Response(
-                StatusCodeInterface::STATUS_OK,
-                [],
-                json_encode(
-                    [
-                        'sub'                                             => $this->identitySubject,
-                        'email'                                           => $this->identityEmail,
-                        'email_verified'                                  => true,
-                        'phone'                                           => '01406946277',
-                        'phone_verified'                                  => true,
-                        'updated_at'                                      => time(),
-                        'https://vocab.account.gov.uk/v1/coreIdentityJWT' => $this->coreIdentityTokenSetup(),
-                    ],
-                ),
-            );
-        };
+        $this->fixIdentity();
     }
 
     #[When('I complete a One Login sign-in process')]
@@ -290,13 +299,20 @@ class OidcContext implements Context
         $this->apiFixtures->append($this->oneLoginIdentity);
 
         switch ($this->type) {
-            case 0: // an identity exists and matches (email may differ)
+            case self::LOGIN_TYPE['EXISTING_USER_NEW_EMAIL']:
+            case self::LOGIN_TYPE['EXISTING_USER']:
+                // an identity exists and matches (email may differ)
                 $this->fetchByIdentityFixtures();
                 break;
-            case 1: // the identity does not exist (email may match, record may have different identity)
+            case self::LOGIN_TYPE['EXISTING_USER_NEW_SUBJECT']:
+                // the identity does not exist (email may match, record may have different identity)
+                $this->fetchByEmailFixtures(true);
+                break;
+            case self::LOGIN_TYPE['MIGRATING_USER']:
+                // the identity does not exist (email may match, record may have different identity)
                 $this->fetchByEmailFixtures(false);
                 break;
-            default: // everything else
+            case self::LOGIN_TYPE['NEW_ACCOUNT']:
                 $this->newUserFixtures();
                 break;
         }
@@ -384,7 +400,6 @@ class OidcContext implements Context
         Assert::assertArrayHasKey('Id', $user);
         Assert::assertArrayHasKey('Identity', $user);
         Assert::assertArrayHasKey('Email', $user);
-        Assert::assertArrayHasKey('LastLogin', $user);
 
         Assert::assertArrayNotHasKey('Password', $user);
 
@@ -425,7 +440,7 @@ class OidcContext implements Context
         // Not needed in this context
     }
 
-    private function fetchByEmailFixtures($hasIdentity = false): void
+    private function fetchByEmailFixtures(bool $hasIdentity = false): void
     {
         /** @see ActorUsers::getByIdentity() */
         $this->awsFixtures->append(
@@ -453,6 +468,30 @@ class OidcContext implements Context
             );
 
             /** @see ResolveOAuthUser::updateEmail() */
+            $this->awsFixtures->append(
+                function (Command $command): ResultInterface {
+                    Assert::assertEquals('TransactWriteItems', $command->getName());
+
+                    Assert::assertCount(2, $command['TransactItems']);
+
+                    return new Result([]);
+                }
+            );
+        } else {
+            /** @see ActorUsers::getByEmail() */
+            $this->awsFixtures->append(
+                new Result(
+                    [
+                        'Items' => [
+                            $this->marshalAwsResultData(
+                                $this->localAccount
+                            ),
+                        ],
+                    ],
+                ),
+            );
+
+            /** @see ResolveOAuthUser::addNewUser() */
             $this->awsFixtures->append(
                 function (Command $command): ResultInterface {
                     Assert::assertEquals('TransactWriteItems', $command->getName());
@@ -500,5 +539,57 @@ class OidcContext implements Context
 
     private function newUserFixtures(): void
     {
+        /** @see ActorUsers::getByIdentity() */
+        $this->awsFixtures->append(
+            new Result(
+                [
+                    'Items' => [],
+                ],
+            ),
+        );
+
+        /** @see ActorUsers::getByEmail() */
+        $this->awsFixtures->append(
+            new Result(
+                [
+                    'Items' => [],
+                ],
+            ),
+        );
+
+        /** @see ResolveOAuthUser::addNewUser() */
+        $this->awsFixtures->append(
+            function (Command $command): ResultInterface {
+                Assert::assertEquals('TransactWriteItems', $command->getName());
+
+                Assert::assertCount(2, $command['TransactItems']);
+
+                return new Result([]);
+            }
+        );
+    }
+
+    private function fixIdentity(): void
+    {
+        $this->oneLoginIdentity = function (RequestInterface $request): ResponseInterface {
+            Assert::assertSame('/userinfo', $request->getUri()->getPath());
+            Assert::assertSame('Bearer ' . $this->accessToken, $request->getHeader('authorization')[0]);
+
+            return new Response(
+                StatusCodeInterface::STATUS_OK,
+                [],
+                json_encode(
+                    [
+                        'sub'                                             => $this->identitySubject,
+                        'email'                                           => $this->identityEmail,
+                        'email_verified'                                  => true,
+                        'phone'                                           => '01406946277',
+                        'phone_verified'                                  => true,
+                        'updated_at'                                      => time(),
+                        'https://vocab.account.gov.uk/v1/coreIdentityJWT' => $this->coreIdentityTokenSetup(),
+                    ],
+                ),
+            );
+        };
     }
 }

--- a/service-api/app/features/context/Acceptance/OidcContext.php
+++ b/service-api/app/features/context/Acceptance/OidcContext.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace BehatTest\Context\Acceptance;
 
+use App\DataAccess\DynamoDb\ActorUsers;
+use App\Service\User\ResolveOAuthUser;
 use AppTest\OidcUtilities;
 use Aws\Command;
 use Aws\Result;
@@ -14,6 +16,7 @@ use Behat\Step\Then;
 use Behat\Step\When;
 use BehatTest\Context\BaseAcceptanceContextTrait;
 use BehatTest\Context\SetupEnv;
+use Closure;
 use DateTimeImmutable;
 use Fig\Http\Message\StatusCodeInterface;
 use GuzzleHttp\Psr7\Response;
@@ -37,25 +40,43 @@ class OidcContext implements Context
     public string $oneLoginClientPublicKey;
     public string $oneLoginIssuerPublicKey;
     public string $oneLoginOutOfBandPublicKey;
-    public string $accessToken = '12345';
-    public string $clientId    = 'client-id';
-    public string $nonce       = 'nonce1234';
-    public string $sub         = 'urn:fdc:gov.uk:2022:unique_id';
-    public string $email       = 'test@example.com';
-    public string $birthday    = '1970-01-01';
+    public string $accessToken     = '12345';
+    public string $clientId        = 'client-id';
+    public string $nonce           = 'nonce1234';
+    public string $identityEmail   = '';
+    public string $identitySubject = '';
+    public int $type               = 0;
+
+    /**
+     * @var array{
+     *  Id: string,
+     *  Identity?: string,
+     *  Email: string,
+     *  Password: string,
+     *  LastLogin: string
+     * }
+     */
+    public array $localAccount        = [];
+    public ?Closure $oneLoginIdentity = null;
 
     protected function coreIdentityTokenSetup(): string
     {
-        [$token, $this->oneLoginOutOfBandPublicKey] =
-            OidcUtilities::generateCoreIdentityToken($this->sub, $this->birthday);
+        [
+            $token,
+            $this->oneLoginOutOfBandPublicKey,
+        ] =
+            OidcUtilities::generateCoreIdentityToken($this->identitySubject, '1970-01-01');
 
         return $token;
     }
 
     protected function identityTokenSetup(): string
     {
-        [$token, $this->oneLoginIssuerPublicKey] = OidcUtilities::generateIdentityToken(
-            $this->sub,
+        [
+            $token,
+            $this->oneLoginIssuerPublicKey,
+        ] = OidcUtilities::generateIdentityToken(
+            $this->identitySubject,
             $this->clientId,
             $this->nonce,
         );
@@ -72,14 +93,17 @@ class OidcContext implements Context
 
         apcu_clear_cache();
 
-        [$this->oneLoginClientPrivateKey, $this->oneLoginClientPublicKey] = OidcUtilities::generateKeyPair(
+        [
+            $this->oneLoginClientPrivateKey,
+            $this->oneLoginClientPublicKey,
+        ] = OidcUtilities::generateKeyPair(
             [
                 'private_key_bits' => 2048,
                 'private_key_type' => OPENSSL_KEYTYPE_RSA,
             ]
         );
 
-        // AbstractKeyPairManager::fetchKeyPairFromSecretsManager()
+        /** @see AbstractKeyPairManager::fetchKeyPairFromSecretsManager() */
         $this->awsFixtures->append(
             function (Command $command): ResultInterface {
                 Assert::assertEquals('GetSecretValue', $command->getName());
@@ -89,7 +113,7 @@ class OidcContext implements Context
             }
         );
 
-        // AbstractKeyPairManager::fetchKeyPairFromSecretsManager()
+        /** @see AbstractKeyPairManager::fetchKeyPairFromSecretsManager() */
         $this->awsFixtures->append(
             function (Command $command): ResultInterface {
                 Assert::assertEquals('GetSecretValue', $command->getName());
@@ -99,7 +123,7 @@ class OidcContext implements Context
             }
         );
 
-        // AuthorisationClientManager::get()
+        /** @see AuthorisationClientManager::get() */
         $this->apiFixtures->append(
             function (RequestInterface $request): ResponseInterface {
                 Assert::assertEquals('/.well-known/openid-configuration', $request->getUri()->getPath());
@@ -144,6 +168,143 @@ class OidcContext implements Context
         return json_decode((string) $jws->getPayload(), true);
     }
 
+    #[Given('I have a local account')]
+    public function iHaveALocalAccount(): void
+    {
+        $this->localAccount = [
+            'Id'        => '0000-00-00-00-000',
+            'Identity'  => 'urn:fdc:gov.uk:2022:unique_id',
+            'Email'     => 'test@example.com',
+            'Password'  => 'password',
+            'LastLogin' => (new DateTimeImmutable('-1 day'))->format('c'),
+        ];
+    }
+
+    #[Given('I have a matching One Login identity')]
+    #[Given('the identity provided by One Login has a :type')]
+    public function iHaveAMatchingOneLoginIdentity(string $type = ''): void
+    {
+        $this->identityEmail   = 'test@example.com';
+        $this->identitySubject = 'urn:fdc:gov.uk:2022:unique_id';
+
+        switch ($type) {
+            case '':
+                $this->type = 0;
+                break;
+            case 'new email':
+                $this->identityEmail = 'new.email@example.com';
+                $this->type          = 0;
+                break;
+            case 'different subject than expected':
+                $this->identitySubject = 'urn:fdc:gov.uk:2022:new_unique_id';
+                $this->type            = 1;
+                break;
+            default:
+        }
+
+        $this->oneLoginIdentity = function (RequestInterface $request): ResponseInterface {
+            Assert::assertSame('/userinfo', $request->getUri()->getPath());
+            Assert::assertSame('Bearer ' . $this->accessToken, $request->getHeader('authorization')[0]);
+
+            return new Response(
+                StatusCodeInterface::STATUS_OK,
+                [],
+                json_encode(
+                    [
+                        'sub'                                             => $this->identitySubject,
+                        'email'                                           => $this->identityEmail,
+                        'email_verified'                                  => true,
+                        'phone'                                           => '01406946277',
+                        'phone_verified'                                  => true,
+                        'updated_at'                                      => time(),
+                        'https://vocab.account.gov.uk/v1/coreIdentityJWT' => $this->coreIdentityTokenSetup(),
+                    ],
+                ),
+            );
+        };
+    }
+
+    #[When('I complete a One Login sign-in process')]
+    public function iCompleteAOneLoginSignInProcess(): void
+    {
+        $this->oidcFixtureSetup();
+
+        /** @see  AuthorisationService::callback() */
+        $this->apiFixtures->append(
+            function (RequestInterface $request): ResponseInterface {
+                Assert::assertSame('/token', $request->getUri()->getPath());
+
+                $request->getBody()->rewind();
+                parse_str($request->getBody()->getContents(), $data);
+
+                Assert::assertSame('authorization_code', $data['grant_type']);
+                Assert::assertSame('1234', $data['code']);
+                Assert::assertSame('https://sut', $data['redirect_uri']);
+                Assert::assertSame(
+                    'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+                    $data['client_assertion_type'],
+                );
+
+                $this->verifyTokenSignature($data['client_assertion'], $this->oneLoginClientPrivateKey);
+
+                return new Response(
+                    StatusCodeInterface::STATUS_OK,
+                    [],
+                    json_encode(
+                        [
+                            'access_token' => $this->accessToken,
+                            'token_type'   => 'Bearer',
+                            'id_token'     => $this->identityTokenSetup(),
+                        ],
+                    ),
+                );
+            },
+        );
+
+        /**
+         * @see AuthorisationService::callback()
+         * Call to fetch issuer signing certificate for id_token
+         */
+        $this->apiFixtures->append(
+            function (RequestInterface $request): ResponseInterface {
+                Assert::assertSame('/.well-known/jwks', $request->getUri()->getPath());
+
+                return new Response(
+                    StatusCodeInterface::STATUS_OK,
+                    [],
+                    json_encode(
+                        [
+                            'keys' => [
+                                JWKFactory::createFromKey($this->oneLoginIssuerPublicKey),
+                            ],
+                        ],
+                    ),
+                );
+            },
+        );
+
+        /**
+         * @see AuthorisationService::callback()
+         * Call to fetch user identity
+         */
+        $this->apiFixtures->append($this->oneLoginIdentity);
+
+        switch ($this->type) {
+            case 0: // an identity exists and matches (email may differ)
+                $this->fetchByIdentityFixtures();
+                break;
+            case 1: // the identity does not exist (email may match, record may have different identity)
+                $this->fetchByEmailFixtures(false);
+                break;
+            default: // everything else
+                $this->newUserFixtures();
+                break;
+        }
+
+        /** @see  ActorUsers::recordSuccessfulLogin() */
+        $this->awsFixtures->append(new Result([]));
+    }
+
     #[Then('/^I am redirected to the one login service$/')]
     public function iAmRedirectedToTheOneLoginService(): void
     {
@@ -180,112 +341,9 @@ class OidcContext implements Context
         Assert::assertSame('en', $query['ui_locales']);
     }
 
-    #[When('/^I am returned to the use an lpa service$/')]
+    #[Then('/^I am returned to the use an lpa service$/')]
     public function iAmReturnedToTheUseAnLpaService(): void
     {
-        $this->oidcFixtureSetup();
-
-        /** @link AuthorisationService::callback() */
-        $this->apiFixtures->append(
-            function (RequestInterface $request): ResponseInterface {
-                Assert::assertSame('/token', $request->getUri()->getPath());
-
-                $request->getBody()->rewind();
-                parse_str($request->getBody()->getContents(), $data);
-
-                Assert::assertSame('authorization_code', $data['grant_type']);
-                Assert::assertSame('1234', $data['code']);
-                Assert::assertSame('https://sut', $data['redirect_uri']);
-                Assert::assertSame(
-                    'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
-                    $data['client_assertion_type'],
-                );
-
-                $this->verifyTokenSignature($data['client_assertion'], $this->oneLoginClientPrivateKey);
-
-                return new Response(
-                    StatusCodeInterface::STATUS_OK,
-                    [],
-                    json_encode(
-                        [
-                            'access_token' => $this->accessToken,
-                            'token_type'   => 'Bearer',
-                            'id_token'     => $this->identityTokenSetup(),
-                        ],
-                    ),
-                );
-            },
-        );
-
-        /** @link AuthorisationService::callback() */
-        // Call to fetch issuer signing certificate for id_token
-        $this->apiFixtures->append(
-            function (RequestInterface $request): ResponseInterface {
-                Assert::assertSame('/.well-known/jwks', $request->getUri()->getPath());
-
-                return new Response(
-                    StatusCodeInterface::STATUS_OK,
-                    [],
-                    json_encode(
-                        [
-                            'keys' => [
-                                JWKFactory::createFromKey($this->oneLoginIssuerPublicKey),
-                            ],
-                        ],
-                    ),
-                );
-            },
-        );
-
-        /**
-         * @link AuthorisationService::callback()
-         * Call to fetch user identity
-         */
-        $this->apiFixtures->append(
-            function (RequestInterface $request): ResponseInterface {
-                Assert::assertSame('/userinfo', $request->getUri()->getPath());
-                Assert::assertSame('Bearer ' . $this->accessToken, $request->getHeader('authorization')[0]);
-
-                return new Response(
-                    StatusCodeInterface::STATUS_OK,
-                    [],
-                    json_encode(
-                        [
-                            'sub'                                             => $this->sub,
-                            'email'                                           => $this->email,
-                            'email_verified'                                  => true,
-                            'phone'                                           => '01406946277',
-                            'phone_verified'                                  => true,
-                            'updated_at'                                      => time(),
-                            'https://vocab.account.gov.uk/v1/coreIdentityJWT' => $this->coreIdentityTokenSetup(),
-                        ],
-                    ),
-                );
-            },
-        );
-
-        /** @link ActorUsers::getByIdentity() */
-        $this->awsFixtures->append(
-            new Result(
-                [
-                    'Items' => [
-                        $this->marshalAwsResultData(
-                            [
-                                'Id'        => '0000-00-00-00-000',
-                                'Identity'  => $this->sub,
-                                'Email'     => $this->email,
-                                'Password'  => 'password',
-                                'LastLogin' => (new DateTimeImmutable('-1 day'))->format('c'),
-                            ]
-                        ),
-                    ],
-                ],
-            ),
-        );
-
-        /** @link ActorUsers::recordSuccessfulLogin() */
-        $this->awsFixtures->append(new Result([]));
-
         $this->apiPost(
             '/v1/auth/callback',
             [
@@ -312,8 +370,8 @@ class OidcContext implements Context
         Assert::assertArrayHasKey('redirect_uri', $response);
     }
 
-    #[Then('/^I am taken to my dashboard$/')]
-    public function iAmTakenToMyDashboard(): void
+    #[Then('/^the login process is a success$/')]
+    public function theLoginProcessIsASuccess(): void
     {
         $this->ui->assertSession()->statusCodeEquals(StatusCodeInterface::STATUS_OK);
 
@@ -330,20 +388,8 @@ class OidcContext implements Context
 
         Assert::assertArrayNotHasKey('Password', $user);
 
-        Assert::assertSame($user['Identity'], $this->sub);
-        Assert::assertSame($user['Email'], $this->email);
-    }
-
-    #[Given('/^I have an existing local account$/')]
-    public function iHaveAnExistingLocalAccount(): void
-    {
-        // Not needed in this context
-    }
-
-    #[Given('/^I have completed a successful one login sign\-in process$/')]
-    public function iHaveCompletedASuccessfulOneLoginSignInProcess(): void
-    {
-        // Not needed in this context
+        Assert::assertSame($user['Identity'], $this->identitySubject);
+        Assert::assertSame($user['Email'], $this->identityEmail);
     }
 
     #[When('/^I logout of the application$/')]
@@ -356,8 +402,8 @@ class OidcContext implements Context
             [
                 'user' => [
                     'Id'        => '0000-00-00-00-000',
-                    'Identity'  => $this->sub,
-                    'Email'     => $this->email,
+                    'Identity'  => $this->identitySubject,
+                    'Email'     => $this->identityEmail,
                     'LastLogin' => (new DateTimeImmutable('-1 day'))->format('c'),
                     'IdToken'   => $this->identityTokenSetup(),
                 ],
@@ -377,5 +423,82 @@ class OidcContext implements Context
     public function iWishToLoginToTheUseAnLpaService(): void
     {
         // Not needed in this context
+    }
+
+    private function fetchByEmailFixtures($hasIdentity = false): void
+    {
+        /** @see ActorUsers::getByIdentity() */
+        $this->awsFixtures->append(
+            new Result(
+                [
+                    'Items' => [],
+                ],
+            ),
+        );
+
+        if (!$hasIdentity) {
+            unset($this->localAccount['Identity']);
+
+            /** @see ActorUsers::getByEmail() */
+            $this->awsFixtures->append(
+                new Result(
+                    [
+                        'Items' => [
+                            $this->marshalAwsResultData(
+                                $this->localAccount
+                            ),
+                        ],
+                    ],
+                ),
+            );
+
+            /** @see ResolveOAuthUser::updateEmail() */
+            $this->awsFixtures->append(
+                function (Command $command): ResultInterface {
+                    Assert::assertEquals('TransactWriteItems', $command->getName());
+
+                    Assert::assertCount(2, $command['TransactItems']);
+
+                    return new Result([]);
+                }
+            );
+        }
+    }
+
+    private function fetchByIdentityFixtures(): void
+    {
+        /** @see ActorUsers::getByIdentity() */
+        $this->awsFixtures->append(
+            new Result(
+                [
+                    'Items' => [
+                        $this->marshalAwsResultData(
+                            $this->localAccount
+                        ),
+                    ],
+                ],
+            ),
+        );
+
+        // Email is different to expected.
+        if ($this->identityEmail !== $this->localAccount['Email']) {
+            /** @see ActorUsers::getByEmail() */
+            $this->awsFixtures->append(
+                new Result(['Items' => []]) // email not found
+            );
+
+            /** @see ResolveOAuthUser::updateEmail() */
+            $this->awsFixtures->append(
+                function (Command $command): ResultInterface {
+                    Assert::assertEquals('UpdateItem', $command->getName());
+
+                    return new Result([]);
+                }
+            );
+        }
+    }
+
+    private function newUserFixtures(): void
+    {
     }
 }

--- a/service-api/app/src/App/src/DataAccess/DynamoDb/ActorUsers.php
+++ b/service-api/app/src/App/src/DataAccess/DynamoDb/ActorUsers.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace App\DataAccess\DynamoDb;
 
 use App\DataAccess\Repository\ActorUsersInterface;
+use App\Exception\ConflictException;
 use App\Exception\CreationException;
 use App\Exception\NotFoundException;
 use Aws\DynamoDb\DynamoDbClient;
+use Aws\DynamoDb\Exception\DynamoDbException;
 use Aws\DynamoDb\Marshaler;
 use Fig\Http\Message\StatusCodeInterface;
 
@@ -21,49 +23,70 @@ class ActorUsers implements ActorUsersInterface
     ) {
     }
 
+    /**
+     * @throws ConflictException
+     * @throws CreationException
+     */
     public function add(
         string $id,
         string $email,
         string $identity,
         string $now,
+        bool $ignoreOrphanIdentity = false,
     ): void {
-        $result = $this->client->transactWriteItems([
-            'TransactItems' => [
-                [
-                    'Put' => [
-                        'TableName' => $this->actorUsersTable,
-                        'Item'      => [
-                            'Id'        => ['S' => $id],
-                            'Email'     => ['S' => $email],
-                            'Identity'  => ['S' => $identity],
-                            'CreatedAt' => ['S' => $now],
-                        ],
-                    ],
-                ],
-                [
-                    'Put' => [
-                        'TableName'           => $this->actorUsersTable,
-                        'ConditionExpression' => 'attribute_not_exists(Id)',
-                        'Item'                => [
-                            'Id' => ['S' => 'IDENTITY#' . $identity],
-                        ],
-                    ],
-                ],
-                [
-                    'Put' => [
-                        'TableName'           => $this->actorUsersTable,
-                        'ConditionExpression' => 'attribute_not_exists(Id)',
-                        'Item'                => [
-                            'Id' => ['S' => 'EMAIL#' . $email],
-                        ],
-                    ],
+        $identityPinning = [
+            'Put' => [
+                'TableName' => $this->actorUsersTable,
+                'Item'      => [
+                    'Id' => ['S' => 'IDENTITY#' . $identity],
                 ],
             ],
-        ]);
+        ];
 
-        $code = $result->get('@metadata')['statusCode'] ?? null;
-        if ($code !== StatusCodeInterface::STATUS_OK) {
-            throw new CreationException('Failed to create account with code', ['code' => $code]);
+        if (! $ignoreOrphanIdentity) {
+            $identityPinning['Put']['ConditionExpression'] = 'attribute_not_exists(Id)';
+        }
+
+        try {
+            $result = $this->client->transactWriteItems(
+                [
+                    'TransactItems' => [
+                        [
+                            'Put' => [
+                                'TableName' => $this->actorUsersTable,
+                                'Item'      => [
+                                    'Id'        => ['S' => $id],
+                                    'Email'     => ['S' => $email],
+                                    'Identity'  => ['S' => $identity],
+                                    'CreatedAt' => ['S' => $now],
+                                ],
+                            ],
+                        ],
+                        $identityPinning,
+                    ],
+                ]
+            );
+
+            $code = $result->get('@metadata')['statusCode'] ?? null;
+            if ($code !== StatusCodeInterface::STATUS_OK) {
+                throw new CreationException('Failed to create account with code', ['code' => $code]);
+            }
+        } catch (DynamoDbException $ex) {
+            if ($ex->getAwsErrorCode() !== 'TransactionCanceledException') {
+                $reasons = $ex->toArray()['CancellationReasons'];
+
+                // three transactions (from above) means the array will contain 2 items detailing the failures
+                // we can reliably hard code the keys here unless someone decides to change order of the transaction
+                if ($reasons[1]['Code'] === 'ConditionalCheckFailed') {
+                    throw new ConflictException(
+                        'User identity/subject pinning already exists',
+                        ['identity' => $identity],
+                        $ex,
+                    );
+                }
+            }
+
+            throw new CreationException('Failed to create account with code', [], $ex);
         }
     }
 
@@ -158,8 +181,8 @@ class ActorUsers implements ActorUsersInterface
                     'Update' => [
                         'TableName'                 => $this->actorUsersTable,
                         'Key'                       => ['Id' => ['S' => $user['Id']]],
-                        'UpdateExpression'          => 'SET #sub = :sub REMOVE ActivationToken, ExpiresTTL, PasswordResetToken, '
-                            . 'PasswordResetExpiry, NeedsReset',
+                        'UpdateExpression'          => 'SET #sub = :sub REMOVE ActivationToken, ExpiresTTL, '
+                            . 'PasswordResetToken, PasswordResetExpiry, NeedsReset',
                         'ExpressionAttributeValues' => $marshaler->marshalItem([':sub' => $identity]),
                         'ExpressionAttributeNames'  => [
                             '#sub' => 'Identity',
@@ -175,9 +198,6 @@ class ActorUsers implements ActorUsersInterface
                         ],
                     ],
                 ],
-                // But not EMAIL# as we will be inserting this for all existing
-                // accounts manually. That way we can be sure that no email will
-                // be used twice.
             ],
         ]);
 
@@ -206,38 +226,18 @@ class ActorUsers implements ActorUsersInterface
 
     public function changeEmail(string $id, string $oldEmail, string $newEmail): void
     {
-        $items = [
+        $this->client->updateItem(
             [
-                'Update' => [
-                    'TableName'                 => $this->actorUsersTable,
-                    'Key'                       => ['Id' => ['S' => $id]],
-                    'UpdateExpression'          => 'SET Email=:p REMOVE EmailResetToken, EmailResetExpiry, NewEmail',
-                    'ExpressionAttributeValues' => [
-                        ':p' => [
-                            'S' => $newEmail,
-                        ],
+                'TableName'                 => $this->actorUsersTable,
+                'Key'                       => ['Id' => ['S' => $id]],
+                'UpdateExpression'          => 'SET Email=:p REMOVE EmailResetToken, EmailResetExpiry, NewEmail',
+                'ExpressionAttributeValues' => [
+                    ':p' => [
+                        'S' => $newEmail,
                     ],
                 ],
             ],
-            [
-                'Delete' => [
-                    'TableName' => $this->actorUsersTable,
-                    'Key'       => [
-                        'Id' => ['S' => 'EMAIL#' . $oldEmail],
-                    ],
-                ],
-            ],
-            [
-                'Put' => [
-                    'TableName' => $this->actorUsersTable,
-                    'Item'      => [
-                        'Id' => ['S' => 'EMAIL#' . $newEmail],
-                    ],
-                ],
-            ],
-        ];
-
-        $this->client->transactWriteItems(['TransactItems' => $items]);
+        );
     }
 
     public function delete(string $accountId): array
@@ -249,12 +249,6 @@ class ActorUsers implements ActorUsersInterface
                 'Delete' => [
                     'TableName' => $this->actorUsersTable,
                     'Key'       => ['Id' => ['S' => $accountId]],
-                ],
-            ],
-            [
-                'Delete' => [
-                    'TableName' => $this->actorUsersTable,
-                    'Key'       => ['Id' => ['S' => 'EMAIL#' . $user['Email']]],
                 ],
             ],
         ];

--- a/service-api/app/src/App/src/DataAccess/DynamoDb/ActorUsers.php
+++ b/service-api/app/src/App/src/DataAccess/DynamoDb/ActorUsers.php
@@ -75,7 +75,7 @@ class ActorUsers implements ActorUsersInterface
             if ($ex->getAwsErrorCode() !== 'TransactionCanceledException') {
                 $reasons = $ex->toArray()['CancellationReasons'];
 
-                // three transactions (from above) means the array will contain 2 items detailing the failures
+                // two transactions (from above) means the array will contain 2 items detailing the failures
                 // we can reliably hard code the keys here unless someone decides to change order of the transaction
                 if ($reasons[1]['Code'] === 'ConditionalCheckFailed') {
                     throw new ConflictException(

--- a/service-api/app/src/App/src/DataAccess/Repository/ActorUsersInterface.php
+++ b/service-api/app/src/App/src/DataAccess/Repository/ActorUsersInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\DataAccess\Repository;
 
+use App\Exception\ConflictException;
 use App\Exception\CreationException;
 use App\Exception\NotFoundException;
 
@@ -31,13 +32,17 @@ interface ActorUsersInterface
     /**
      * Add an actor user
      *
+     * @param bool $ignoreOrphanIdentity Forces to the operation to succeed by ignoring an exisiting 'IDENTITY#' record.
+     *                                   Only intended to be used in cases where the record is known to be an orphan.
      * @throws CreationException
+     * @throws ConflictException
      */
     public function add(
         string $id,
         string $email,
         string $identity,
         string $now,
+        bool $ignoreOrphanIdentity = false,
     ): void;
 
     /**

--- a/service-api/app/src/App/src/Exception/ConflictException.php
+++ b/service-api/app/src/App/src/Exception/ConflictException.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace App\Exception;
 
+use App\Service\Log\Output\Email;
 use Fig\Http\Message\StatusCodeInterface;
 use Throwable;
 
-class ConflictException extends AbstractApiException
+class ConflictException extends AbstractApiException implements LoggableAdditionalDataInterface
 {
     public const string TITLE = 'Conflict';
     public const int    CODE  = StatusCodeInterface::STATUS_CONFLICT;
@@ -15,5 +16,16 @@ class ConflictException extends AbstractApiException
     public function __construct(?string $message = null, array $additionalData = [], ?Throwable $previous = null)
     {
         parent::__construct(self::TITLE, $message, self::CODE, $additionalData, $previous);
+    }
+
+    public function getAdditionalDataForLogging(): array
+    {
+        $data = $this->getAdditionalData();
+
+        // choose to be explicit about what is being logged to avoid leakage.
+        return array_filter([
+            'identity' => $data['identity'] ?? '',
+            'email'    => isset($data['email']) ? new Email($data['email']) : '',
+        ]);
     }
 }

--- a/service-api/app/src/App/src/Service/Log/EventCodes.php
+++ b/service-api/app/src/App/src/Service/Log/EventCodes.php
@@ -66,6 +66,18 @@ class EventCodes
     public const string AUTH_ONELOGIN_ACCOUNT_RECOVERED = 'AUTH_ONELOGIN_ACCOUNT_RECOVERED';
 
     /**
+     * During a login attempt an account was matched by email that did not contain the expected identity.
+     */
+    public const string AUTH_ONELOGIN_ACCOUNT_CONTAINS_IDENTITY = 'AUTH_ONE_LOGIN_ACCOUNT_CONTAINS_IDENTITY';
+
+    /**
+     * A one login authentication transaction resulted in a new local account being created but an orphan
+     * IDENTITY# record had to be ignored.
+     */
+    public const string AUTH_ONELOGIN_ACCOUNT_CREATED_WITH_ORPHAN_BYPASS
+        = 'AUTH_ONELOGIN_ACCOUNT_CREATED_WITH_ORPHAN_BYPASS';
+
+    /**
      * Whilst retrieving an LPA from upstream sources, using information that refers to it,
      * the LPA was not found.
      */

--- a/service-api/app/src/App/src/Service/User/ResolveOAuthUser.php
+++ b/service-api/app/src/App/src/Service/User/ResolveOAuthUser.php
@@ -97,7 +97,24 @@ class ResolveOAuthUser
     private function attemptToFetchUserByEmail(string $identity, string $email): ?array
     {
         try {
-            $user = $this->usersRepository->migrateToOAuth($this->userService->getByEmail($email), $identity);
+            $user = $this->userService->getByEmail($email);
+
+            // UML-4300 don't migrate accounts with existing OneLogin Identities.
+            // this is a change to behaviour and may need a revisit. As currently implemented
+            // in this class this will result in a new account being created.
+            if (isset($user['Identity'])) {
+                $this->logger->info(
+                    'User already has assigned identity {identity}, not migrating',
+                    [
+                        'identity'   => $user['Identity'],
+                        'email'      => new Email($email),
+                        'event_code' => EventCodes::AUTH_ONELOGIN_ACCOUNT_CONTAINS_IDENTITY,
+                    ]
+                );
+                return null;
+            }
+
+            $user = $this->usersRepository->migrateToOAuth($user, $identity);
 
             $this->logger->info(
                 'Migrated existing account with email {email} to OIDC login',
@@ -132,16 +149,31 @@ class ResolveOAuthUser
                     'event_code' => EventCodes::AUTH_ONELOGIN_ACCOUNT_CREATED,
                 ]
             );
-
-            return $user;
         } catch (ConflictException $e) {
-            $this->logger->notice(
-                'Creation of new OAuth account failed due to existing account with matching Identity field',
-                ['identity' => $identity]
-            );
+            /**
+             * if the exception contains an identity as a reason then it is an orphan identity and we can
+             * work around it. this should only be used assuming that we've already identified that an account
+             * doesn't already exist with this identity @see attemptToFetchUserByIdentity()
+             */
+            if (count($e->getAdditionalData()) === 1 && isset($e->getAdditionalData()['identity'])) {
+                $user = $this->userService->addWithOrphanIdentityBypass($email, $identity);
+            } else {
+                throw $e;
+            }
 
-            throw $e;
+            $this->logger->info(
+                'Created new OIDC login for account with email {email} with orphan bypass',
+                [
+                    'identity'   => $identity,
+                    'email'      => new Email($email),
+                    'event_code' => EventCodes::AUTH_ONELOGIN_ACCOUNT_CREATED_WITH_ORPHAN_BYPASS,
+                ]
+            );
         }
+
+
+
+        return $user;
     }
 
     /**

--- a/service-api/app/src/App/src/Service/User/ResolveOAuthUser.php
+++ b/service-api/app/src/App/src/Service/User/ResolveOAuthUser.php
@@ -171,8 +171,6 @@ class ResolveOAuthUser
             );
         }
 
-
-
         return $user;
     }
 

--- a/service-api/app/src/App/src/Service/User/UserService.php
+++ b/service-api/app/src/App/src/Service/User/UserService.php
@@ -9,7 +9,6 @@ use App\Exception\ConflictException;
 use App\Exception\CreationException;
 use App\Exception\NotFoundException;
 use App\Service\Log\Output\Email;
-use Aws\DynamoDb\Exception\DynamoDbException;
 use DateTimeInterface;
 use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
@@ -37,19 +36,13 @@ class UserService
         // Generate unique id for user
         $id = $this->generateUniqueId();
 
-        try {
-            $this->usersRepository->add($id, $email, $identity, $this->clock->now()->format(DateTimeInterface::ATOM));
-        } catch (DynamoDbException $ex) {
-            $reasons = $ex->toArray()['CancellationReasons'] ?? [];
-
-            foreach ($reasons as $reason) {
-                if ($reason['Code'] === 'ConditionalCheckFailed') {
-                    throw new ConflictException('User already exists with identity ' . $identity);
-                }
-            }
-
-            throw $ex;
-        }
+        $this->usersRepository->add(
+            $id,
+            $email,
+            $identity,
+            $this->clock->now()->format(DateTimeInterface::ATOM),
+            false,
+        );
 
         $this->logger->info(
             'Account with Id {id} created for identity {identity} using email {email}',
@@ -57,6 +50,40 @@ class UserService
                 'id'       => $id,
                 'email'    => new Email($email),
                 'identity' => $identity,
+            ]
+        );
+
+        return [
+            'Id'       => $id,
+            'Email'    => $email,
+            'Identity' => $identity,
+        ];
+    }
+
+    /**
+     * @psalm-return ActorUser The created user
+     * @throws CreationException
+     */
+    public function addWithOrphanIdentityBypass(string $email, string $identity): array
+    {
+        // Generate unique id for user
+        $id = $this->generateUniqueId();
+
+        $this->usersRepository->add(
+            $id,
+            $email,
+            $identity,
+            $this->clock->now()->format(DateTimeInterface::ATOM),
+            true,
+        );
+
+        $this->logger->info(
+            'Account with Id {id} created for identity {identity} using email {email} with identity bypass',
+            [
+                'id'       => $id,
+                'email'    => new Email($email),
+                'identity' => $identity,
+
             ]
         );
 

--- a/service-api/app/test/AppTest/DataAccess/DynamoDb/ActorUsersTest.php
+++ b/service-api/app/test/AppTest/DataAccess/DynamoDb/ActorUsersTest.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace AppTest\DataAccess\DynamoDb;
 
 use App\DataAccess\DynamoDb\ActorUsers;
+use App\Exception\ConflictException;
 use App\Exception\CreationException;
 use App\Exception\NotFoundException;
+use Aws\CommandInterface;
 use Aws\DynamoDb\DynamoDbClient;
+use Aws\DynamoDb\Exception\DynamoDbException;
 use DateTime;
 use DateTimeInterface;
 use PHPUnit\Framework\Attributes\Test;
@@ -121,6 +124,7 @@ class ActorUsersTest extends TestCase
         $email    = 'a@b.com';
         $identity = 'urn:fdc:one-login:2023:HASH=';
 
+        // status code is unexpected
         $this->dynamoDbClientProphecy->transactWriteItems(Argument::any())
             ->willReturn($this->createAWSResult(['@metadata' => ['statusCode' => 500]]));
 
@@ -128,6 +132,32 @@ class ActorUsersTest extends TestCase
 
         $this->expectException(CreationException::class);
         $this->expectExceptionMessage('Failed to create account with code');
+
+        $actorRepo->add($id, $email, $identity, 'now');
+    }
+
+    #[Test]
+    public function will_throw_exception_when_adding_a_new_user_that_doesnt_succeed_with_orphan(): void
+    {
+        $id       = '12345-1234-1234-1234-12345';
+        $email    = 'a@b.com';
+        $identity = 'urn:fdc:one-login:2023:HASH=';
+
+        $command = $this->prophesize(CommandInterface::class);
+
+        $this->dynamoDbClientProphecy->transactWriteItems(Argument::any())
+            ->willThrow(new DynamoDbException('', $command->reveal(), [
+                'body' => [
+                    'CancellationReasons' => [
+                        ['Code' => 'None'],
+                        ['Code' => 'ConditionalCheckFailed'],
+                    ],
+                ],
+            ]));
+
+        $actorRepo = new ActorUsers($this->dynamoDbClientProphecy->reveal(), self::TABLE_NAME);
+
+        $this->expectException(ConflictException::class);
 
         $actorRepo->add($id, $email, $identity, 'now');
     }

--- a/service-api/app/test/AppTest/DataAccess/DynamoDb/ActorUsersTest.php
+++ b/service-api/app/test/AppTest/DataAccess/DynamoDb/ActorUsersTest.php
@@ -23,6 +23,9 @@ class ActorUsersTest extends TestCase
 
     public const string TABLE_NAME = 'test-table-name';
 
+    /**
+     * @var ObjectProphecy<DynamoDbClient>
+     */
     private ObjectProphecy $dynamoDbClientProphecy;
 
     protected function setUp(): void
@@ -59,12 +62,43 @@ class ActorUsersTest extends TestCase
                     ],
                 ],
             ],
+        ];
+
+        $this->dynamoDbClientProphecy
+            ->transactWriteItems(['TransactItems' => $items])
+            ->shouldBeCalled()
+            ->willReturn($this->createAWSResult(['@metadata' => ['statusCode' => 200]]));
+
+        $actorRepo = new ActorUsers($this->dynamoDbClientProphecy->reveal(), self::TABLE_NAME);
+
+        $actorRepo->add($id, $email, $identity, $now);
+    }
+
+    #[Test]
+    public function will_add_a_new_user_whilst_ignoring_orphan_identity_records(): void
+    {
+        $id       = '12345-1234-1234-1234-12345';
+        $email    = 'a@b.com';
+        $identity = '67890-6789-6789-6789-67890';
+        $now      = '2020-12-12T12:12:12';
+
+        $items = [
             [
                 'Put' => [
-                    'TableName'           => self::TABLE_NAME,
-                    'ConditionExpression' => 'attribute_not_exists(Id)',
-                    'Item'                => [
-                        'Id' => ['S' => 'EMAIL#' . $email],
+                    'TableName' => self::TABLE_NAME,
+                    'Item'      => [
+                        'Id'        => ['S' => $id],
+                        'Email'     => ['S' => $email],
+                        'Identity'  => ['S' => $identity],
+                        'CreatedAt' => ['S' => $now],
+                    ],
+                ],
+            ],
+            [
+                'Put' => [
+                    'TableName' => self::TABLE_NAME,
+                    'Item'      => [
+                        'Id' => ['S' => 'IDENTITY#' . $identity],
                     ],
                 ],
             ],
@@ -77,7 +111,7 @@ class ActorUsersTest extends TestCase
 
         $actorRepo = new ActorUsers($this->dynamoDbClientProphecy->reveal(), self::TABLE_NAME);
 
-        $actorRepo->add($id, $email, $identity, $now);
+        $actorRepo->add($id, $email, $identity, $now, true);
     }
 
     #[Test]
@@ -364,12 +398,6 @@ class ActorUsersTest extends TestCase
                     [
                         'Delete' => [
                             'TableName' => self::TABLE_NAME,
-                            'Key'       => ['Id' => ['S' => 'EMAIL#' . $email]],
-                        ],
-                    ],
-                    [
-                        'Delete' => [
-                            'TableName' => self::TABLE_NAME,
                             'Key'       => ['Id' => ['S' => 'IDENTITY#' . $identity]],
                         ],
                     ],
@@ -407,12 +435,6 @@ class ActorUsersTest extends TestCase
                         'Delete' => [
                             'TableName' => self::TABLE_NAME,
                             'Key'       => ['Id' => ['S' => $id]],
-                        ],
-                    ],
-                    [
-                        'Delete' => [
-                            'TableName' => self::TABLE_NAME,
-                            'Key'       => ['Id' => ['S' => 'EMAIL#' . $email]],
                         ],
                     ],
                 ],
@@ -455,12 +477,6 @@ class ActorUsersTest extends TestCase
                     [
                         'Delete' => [
                             'TableName' => 'users-table',
-                            'Key'       => ['Id' => ['S' => 'EMAIL#' . $email]],
-                        ],
-                    ],
-                    [
-                        'Delete' => [
-                            'TableName' => 'users-table',
                             'Key'       => ['Id' => ['S' => 'IDENTITY#' . $identity]],
                         ],
                     ],
@@ -478,38 +494,18 @@ class ActorUsersTest extends TestCase
     public function will_change_a_users_email(): void
     {
         $this->dynamoDbClientProphecy
-            ->transactWriteItems([
-                'TransactItems' => [
-                    [
-                        'Update' => [
-                            'TableName'                 => self::TABLE_NAME,
-                            'Key'                       => ['Id' => ['S' => 'fakeId']],
-                            'UpdateExpression'          => 'SET Email=:p REMOVE EmailResetToken, EmailResetExpiry, NewEmail',
-                            'ExpressionAttributeValues' => [
-                                ':p' => [
-                                    'S' => 'newemail@example.com',
-                                ],
-                            ],
-                        ],
-                    ],
-                    [
-                        'Delete' => [
-                            'TableName' => self::TABLE_NAME,
-                            'Key'       => [
-                                'Id' => ['S' => 'EMAIL#oldemail@example.com'],
-                            ],
-                        ],
-                    ],
-                    [
-                        'Put' => [
-                            'TableName' => self::TABLE_NAME,
-                            'Item'      => [
-                                'Id' => ['S' => 'EMAIL#newemail@example.com'],
-                            ],
+            ->updateItem(
+                [
+                    'TableName'                 => self::TABLE_NAME,
+                    'Key'                       => ['Id' => ['S' => 'fakeId']],
+                    'UpdateExpression'          => 'SET Email=:p REMOVE EmailResetToken, EmailResetExpiry, NewEmail',
+                    'ExpressionAttributeValues' => [
+                        ':p' => [
+                            'S' => 'newemail@example.com',
                         ],
                     ],
                 ],
-            ])->shouldBeCalled();
+            )->shouldBeCalled();
 
         $sut = new ActorUsers($this->dynamoDbClientProphecy->reveal(), self::TABLE_NAME);
 

--- a/service-api/app/test/AppTest/Exception/BadRequestExceptionTest.php
+++ b/service-api/app/test/AppTest/Exception/BadRequestExceptionTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace AppTest\Exception;
 
 use App\Exception\BadRequestException;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class BadRequestExceptionTest extends TestCase
 {
-    public function testDataGets(): void
+    #[Test]
+    public function dataGets(): void
     {
         $message = 'bre message';
 

--- a/service-api/app/test/AppTest/Exception/ConflictExceptionTest.php
+++ b/service-api/app/test/AppTest/Exception/ConflictExceptionTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace AppTest\Exception;
 
 use App\Exception\ConflictException;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class ConflictExceptionTest extends TestCase
 {
-    public function testDataGets(): void
+    #[Test]
+    public function dataGets(): void
     {
         $message = 'ce message';
 

--- a/service-api/app/test/AppTest/Exception/ConflictExceptionTest.php
+++ b/service-api/app/test/AppTest/Exception/ConflictExceptionTest.php
@@ -28,4 +28,26 @@ class ConflictExceptionTest extends TestCase
         $this->assertEquals($message, $ce->getMessage());
         $this->assertEquals(409, $ce->getCode());
     }
+
+    #[Test]
+    public function it_narrows_scope_of_logged_data(): void
+    {
+        $additionalData = [
+            'identity' => 'identity',
+            'email'    => 'test@example.com',
+            'some'     => 'additional',
+            'data'     => 'here,',
+        ];
+
+        $sut = new ConflictException('', $additionalData);
+
+        $this->assertCount(2, $sut->getAdditionalDataForLogging());
+        $this->assertArrayHasKey('identity', $sut->getAdditionalDataForLogging());
+        $this->assertEquals('identity', $sut->getAdditionalDataForLogging()['identity']);
+        $this->assertArrayHasKey('email', $sut->getAdditionalDataForLogging());
+        $this->assertEquals(
+            '973dfe463ec85785f5f95af5ba3906eedb2d931c24e69824a89ea65dba4e813b', // pragma: allowlist secret
+            (string) $sut->getAdditionalDataForLogging()['email']
+        );
+    }
 }

--- a/service-api/app/test/AppTest/Exception/GoneExceptionTest.php
+++ b/service-api/app/test/AppTest/Exception/GoneExceptionTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace AppTest\Exception;
 
 use App\Exception\GoneException;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class GoneExceptionTest extends TestCase
 {
-    public function testDataGets(): void
+    #[Test]
+    public function dataGets(): void
     {
         $message = 'ge message';
 

--- a/service-api/app/test/AppTest/Exception/NotFoundExceptionTest.php
+++ b/service-api/app/test/AppTest/Exception/NotFoundExceptionTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace AppTest\Exception;
 
 use App\Exception\NotFoundException;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class NotFoundExceptionTest extends TestCase
 {
-    public function testDataGets(): void
+    #[Test]
+    public function dataGets(): void
     {
         $message = 'nfe message';
 

--- a/service-api/app/test/AppTest/Exception/UnauthorizedExceptionTest.php
+++ b/service-api/app/test/AppTest/Exception/UnauthorizedExceptionTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace AppTest\Exception;
 
 use App\Exception\UnauthorizedException;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class UnauthorizedExceptionTest extends TestCase
 {
-    public function testDataGets(): void
+    #[Test]
+    public function dataGets(): void
     {
         $message = 'ue message';
 

--- a/service-api/app/test/AppTest/Service/User/ResolveOAuthUserTest.php
+++ b/service-api/app/test/AppTest/Service/User/ResolveOAuthUserTest.php
@@ -322,6 +322,111 @@ class ResolveOAuthUserTest extends TestCase
     }
 
     #[Test]
+    public function known_email_has_unexpected_one_login_subject(): void
+    {
+        $actorUsersInterfaceProphecy = $this->prophesize(ActorUsersInterface::class);
+        $actorUsersInterfaceProphecy
+            ->recordSuccessfulLogin('fakeId', Argument::cetera())
+            ->shouldBeCalled();
+
+        $userServiceProphecy = $this->prophesize(UserService::class);
+        $userServiceProphecy
+            ->getByIdentity('fakeSub')
+            ->willThrow(NotFoundException::class);
+        $userServiceProphecy
+            ->getByEmail('fakeEmail')
+            ->willReturn(
+                [
+                    'Id'       => 'fakeId',
+                    'Identity' => 'fakeSub',
+                ]
+            );
+        $userServiceProphecy
+            ->add('fakeEmail', 'fakeSub')
+            ->willReturn(
+                [
+                    'Id'       => 'fakeId',
+                    'Email'    => 'fakeEmail',
+                    'Identity' => 'fakeSub',
+                ]
+            );
+
+        $clockProphecy = $this->prophesize(ClockInterface::class);
+        $clockProphecy->now()->willReturn(new DateTimeImmutable('now'));
+
+        $sut = new ResolveOAuthUser(
+            $actorUsersInterfaceProphecy->reveal(),
+            $userServiceProphecy->reveal(),
+            $this->prophesize(RecoverAccount::class)->reveal(),
+            $clockProphecy->reveal(),
+            $this->prophesize(LoggerInterface::class)->reveal(),
+        );
+
+        $user = ($sut)('fakeSub', 'fakeEmail');
+
+        $this->assertArrayHasKey('Identity', $user);
+        $this->assertEquals('fakeSub', $user['Identity']);
+        $this->assertArrayHasKey('Email', $user);
+        $this->assertEquals('fakeEmail', $user['Email']);
+
+        $this->assertArrayNotHasKey('Password', $user);
+    }
+
+    #[Test]
+    public function known_email_has_unexpected_one_login_subject_that_is_orphan(): void
+    {
+        $actorUsersInterfaceProphecy = $this->prophesize(ActorUsersInterface::class);
+        $actorUsersInterfaceProphecy
+            ->recordSuccessfulLogin('fakeId', Argument::cetera())
+            ->shouldBeCalled();
+
+        $userServiceProphecy = $this->prophesize(UserService::class);
+        $userServiceProphecy
+            ->getByIdentity('fakeSub')
+            ->willThrow(NotFoundException::class);
+        $userServiceProphecy
+            ->getByEmail('fakeEmail')
+            ->willReturn(
+                [
+                    'Id'       => 'fakeId',
+                    'Identity' => 'fakeSub',
+                ]
+            );
+        $userServiceProphecy
+            ->add('fakeEmail', 'fakeSub')
+            ->willThrow(new ConflictException('', ['identity' => 'fakeSub']));
+        $userServiceProphecy
+            ->addWithOrphanIdentityBypass('fakeEmail', 'fakeSub')
+            ->willReturn(
+                [
+                    'Id'       => 'fakeId',
+                    'Email'    => 'fakeEmail',
+                    'Identity' => 'fakeSub',
+                ]
+            );
+
+        $clockProphecy = $this->prophesize(ClockInterface::class);
+        $clockProphecy->now()->willReturn(new DateTimeImmutable('now'));
+
+        $sut = new ResolveOAuthUser(
+            $actorUsersInterfaceProphecy->reveal(),
+            $userServiceProphecy->reveal(),
+            $this->prophesize(RecoverAccount::class)->reveal(),
+            $clockProphecy->reveal(),
+            $this->prophesize(LoggerInterface::class)->reveal(),
+        );
+
+        $user = ($sut)('fakeSub', 'fakeEmail');
+
+        $this->assertArrayHasKey('Identity', $user);
+        $this->assertEquals('fakeSub', $user['Identity']);
+        $this->assertArrayHasKey('Email', $user);
+        $this->assertEquals('fakeEmail', $user['Email']);
+
+        $this->assertArrayNotHasKey('Password', $user);
+    }
+
+    #[Test]
     public function new_onelogin_user_returns_brand_new_user(): void
     {
         $actorUsersInterfaceProphecy = $this->prophesize(ActorUsersInterface::class);

--- a/service-api/app/test/AppTest/Service/User/UserServiceTest.php
+++ b/service-api/app/test/AppTest/Service/User/UserServiceTest.php
@@ -6,6 +6,7 @@ namespace AppTest\Service\User;
 
 use App\DataAccess\Repository\ActorUsersInterface;
 use App\Exception\ConflictException;
+use App\Exception\CreationException;
 use App\Exception\NotFoundException;
 use App\Service\User\UserService;
 use Aws\CommandInterface;
@@ -16,6 +17,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
@@ -35,6 +37,7 @@ class UserServiceTest extends TestCase
         $identity = 'urn:fdc:one-login:2023:HASH=';
         $now      = new DateTimeImmutable();
 
+        /** @var ObjectProphecy<ActorUsersInterface> $repoProphecy */
         $repoProphecy = $this->prophesize(ActorUsersInterface::class);
         $repoProphecy->add(
             Argument::that(function (string $data) {
@@ -44,6 +47,7 @@ class UserServiceTest extends TestCase
             $email,
             $identity,
             $now->format(DateTimeInterface::ATOM),
+            false,
         );
 
         $clock = $this->prophesize(ClockInterface::class);
@@ -68,20 +72,54 @@ class UserServiceTest extends TestCase
     }
 
     #[Test]
+    public function can_add_a_new_user_with_ignored_orphan_identity(): void
+    {
+        $email    = 'a@b.com';
+        $identity = 'urn:fdc:one-login:2023:HASH=';
+        $now      = new DateTimeImmutable();
+
+        /** @var ObjectProphecy<ActorUsersInterface> $repoProphecy */
+        $repoProphecy = $this->prophesize(ActorUsersInterface::class);
+        $repoProphecy->add(
+            Argument::that(function (string $data) {
+                $this->id = $data;
+                return Uuid::isValid($data);
+            }),
+            $email,
+            $identity,
+            $now->format(DateTimeInterface::ATOM),
+            true,
+        );
+
+        $clock = $this->prophesize(ClockInterface::class);
+        $clock->now()->willReturn($now);
+
+        $us = new UserService(
+            $repoProphecy->reveal(),
+            $clock->reveal(),
+            $this->prophesize(LoggerInterface::class)->reveal()
+        );
+
+        $return = $us->addWithOrphanIdentityBypass($email, $identity);
+
+        $this->assertEquals(
+            [
+                'Id'       => $this->id,
+                'Email'    => $email,
+                'Identity' => $identity,
+            ],
+            $return
+        );
+    }
+
+    #[Test]
     public function wont_add_a_user_that_already_exists(): void
     {
         $command = $this->prophesize(CommandInterface::class);
 
         $repoProphecy = $this->prophesize(ActorUsersInterface::class);
         $repoProphecy->add(Argument::cetera())
-            ->willThrow(new DynamoDbException('', $command->reveal(), [
-                'body' => [
-                    'CancellationReasons' => [
-                        ['Code' => 'None'],
-                        ['Code' => 'ConditionalCheckFailed'],
-                    ],
-                ],
-            ]));
+            ->willThrow(ConflictException::class);
 
         $clock = $this->prophesize(ClockInterface::class);
         $clock->now()->willReturn(new DateTimeImmutable());
@@ -93,7 +131,27 @@ class UserServiceTest extends TestCase
         );
 
         $this->expectException(ConflictException::class);
-        $us->add('', '');
+        $us->add('test@example.com', 'identity');
+    }
+
+    #[Test]
+    public function wont_add_a_user_that_already_exists_with_ignored_orphan_identity(): void
+    {
+        $repoProphecy = $this->prophesize(ActorUsersInterface::class);
+        $repoProphecy->add(Argument::cetera())
+            ->willThrow(CreationException::class);
+
+        $clock = $this->prophesize(ClockInterface::class);
+        $clock->now()->willReturn(new DateTimeImmutable());
+
+        $us = new UserService(
+            $repoProphecy->reveal(),
+            $clock->reveal(),
+            $this->prophesize(LoggerInterface::class)->reveal()
+        );
+
+        $this->expectException(CreationException::class);
+        $us->addWithOrphanIdentityBypass('test@example.com', 'identity');
     }
 
     #[Test]


### PR DESCRIPTION
# Purpose

This is an attempt to fix our issues around duplicate account protection breaking some users who've manipulated their OneLogin accounts in ways we don't quite expect. Typically this is by deleting and re-creating with the same email.

Fixes UML-4300

## Approach

Remove EMAIL# records from consideration. Do not attempt to migrate accounts with existing Identities and in cases where orphan identities exist ignore them when attempting to create a new account. 

## Learning

The testing in this area is not... ideal.

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [x] I have performed a self-review of my own code
* [x] I have added tests to prove my work
* [x] I have added relevant and appropriately leveled logging, **without PII**, to my code
* [x] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* ~I have updated documentation (Confluence/GitHub wiki/tech debt doc)~
* ~I have added welsh translation tags and updated translation files~
* ~I have run an accessibility tool on any pages I have made changes to and fixed any issues found~
* ~I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made~
* [ ] The product team have tested these changes
