### PR TITLE
Update urllib3 to 2.7.0

### DIFF
--- a/lambda-functions/upload-statistics/requirements-tests.txt
+++ b/lambda-functions/upload-statistics/requirements-tests.txt
@@ -49,7 +49,7 @@ s3transfer==0.16.0
     # via boto3
 six==1.17.0
     # via python-dateutil
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   botocore
     #   requests

--- a/lambda-functions/upload-statistics/requirements.txt
+++ b/lambda-functions/upload-statistics/requirements.txt
@@ -22,5 +22,5 @@ six==1.17.0
     # via python-dateutil
 snapshot-restore-py==1.0.0
     # via awslambdaric
-urllib3==2.6.3
+urllib3==2.7.0
     # via botocore

--- a/query/requirements.txt
+++ b/query/requirements.txt
@@ -20,5 +20,5 @@ six==1.17.0
     # via
     #   json-lines
     #   python-dateutil
-urllib3==2.6.3
+urllib3==2.7.0
     # via botocore

--- a/scripts/call-api-gateway/requirements.txt
+++ b/scripts/call-api-gateway/requirements.txt
@@ -26,7 +26,7 @@ s3transfer==0.16.0
     # via boto3
 six==1.17.0
     # via python-dateutil
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   botocore
     #   requests

--- a/scripts/pipeline/ci_ingress/requirements.txt
+++ b/scripts/pipeline/ci_ingress/requirements.txt
@@ -16,5 +16,5 @@ s3transfer==0.16.0
     # via boto3
 six==1.17.0
     # via python-dateutil
-urllib3==2.6.3
+urllib3==2.7.0
     # via botocore

--- a/scripts/pipeline/generate_snyk_report/requirements.txt
+++ b/scripts/pipeline/generate_snyk_report/requirements.txt
@@ -7,6 +7,6 @@ charset-normalizer==3.4.7
 idna==3.11
     # via requests
 requests==2.33.0
-    # via -r requirements.in
-urllib3==2.6.3
+    # via -r scripts/pipeline/generate_snyk_report/requirements.in
+urllib3==2.7.0
     # via requests

--- a/scripts/pipeline/requirements.txt
+++ b/scripts/pipeline/requirements.txt
@@ -29,7 +29,7 @@ s3transfer==0.16.0
     # via boto3
 six==1.17.0
     # via python-dateutil
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   botocore
     #   requests

--- a/scripts/remove_default_sg_rules/requirements.txt
+++ b/scripts/remove_default_sg_rules/requirements.txt
@@ -16,5 +16,5 @@ s3transfer==0.16.0
     # via boto3
 six==1.17.0
     # via python-dateutil
-urllib3==2.6.3
+urllib3==2.7.0
     # via botocore

--- a/service-api/seeding/requirements.txt
+++ b/service-api/seeding/requirements.txt
@@ -47,7 +47,7 @@ simplejson==3.20.2
     # via -r service-api/seeding/requirements.in
 six==1.17.0
     # via python-dateutil
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   botocore
     #   requests


### PR DESCRIPTION
# Purpose

v2.6.3 has a high-severity vulnerability

## Approach

By running `uv pip compile (...) --upgrade-package urllib3`

## Learning

Dependabot runs uv inside its directory, so changes all the "generated by command" comments. This doesn't really matter, but I chose a manual approach to avoid creating loads of separate PRs.