### PR TITLE
UML-4406 - Add WAF rule to block requests to suspicious uris

### DIFF
--- a/lambda-functions/upload-statistics/Dockerfile
+++ b/lambda-functions/upload-statistics/Dockerfile
@@ -12,7 +12,7 @@ FROM python:3.14-slim@sha256:6a27522252aef8432841f224d9baaa6e9fce07b07584154fa0b
 
 # Update openssl to non-vulnerable version
 RUN apt-get update && \
-    apt-get install openssl=3.5.5-1~deb13u2 -y --no-install-recommends && \
+    apt-get install openssl=3.5.5-1~deb13u2 libssl3t64=3.5.5-1~deb13u2 openssl-provider-legacy=3.5.5-1~deb13u2 -y --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 
 # Set working directory to function root directory

--- a/terraform/account/region/waf.tf
+++ b/terraform/account/region/waf.tf
@@ -110,7 +110,7 @@ resource "aws_wafv2_web_acl" "main" {
 
     statement {
       rate_based_statement {
-        limit              = 5
+        limit              = 10
         aggregate_key_type = "IP"
 
         scope_down_statement {
@@ -281,6 +281,8 @@ resource "aws_wafv2_regex_pattern_set" "suspicious_uri_patterns" {
   regular_expression {
     regex_string = "(?i)\\.(env|git|sql|bak|php|asp|aspx|cgi|sh|exe|tar|gz|tgz|zip|rar|7z|z|bz2|lz|xz|db|sqlite|sqlitedb|war|jar|config|conf|ini|log|pem|key|p12|pfx|crt|ovpn|htaccess|htpasswd|DS_Store|swp)$"
   }
+
+  provider = aws.region
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "main" {

--- a/terraform/account/region/waf.tf
+++ b/terraform/account/region/waf.tf
@@ -72,8 +72,71 @@ resource "aws_wafv2_web_acl" "main" {
     }
   }
   rule {
-    name     = "AWS-AWSManagedRulesBotControlRuleSet"
+    name     = "BlockSuspiciousURIPatterns"
     priority = 3
+
+    action {
+      block {}
+    }
+
+    statement {
+      regex_pattern_set_reference_statement {
+        arn = aws_wafv2_regex_pattern_set.suspicious_uri_patterns.arn
+
+        field_to_match {
+          uri_path {}
+        }
+
+        text_transformation {
+          priority = 0
+          type     = "LOWERCASE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "BlockSuspiciousURIPatterns"
+      sampled_requests_enabled   = true
+    }
+  }
+  rule {
+    name     = "RateLimitSuspiciousURIPatterns"
+    priority = 4
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 5
+        aggregate_key_type = "IP"
+
+        scope_down_statement {
+          regex_pattern_set_reference_statement {
+            arn = aws_wafv2_regex_pattern_set.suspicious_uri_patterns.arn
+            field_to_match {
+              uri_path {}
+            }
+            text_transformation {
+              priority = 0
+              type     = "LOWERCASE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "RateLimitSuspiciousURIPatterns"
+      sampled_requests_enabled   = true
+    }
+  }
+  rule {
+    name     = "AWS-AWSManagedRulesBotControlRuleSet"
+    priority = 5
 
     override_action {
       count {} # start in count mode
@@ -100,7 +163,7 @@ resource "aws_wafv2_web_acl" "main" {
   }
   rule {
     name     = "AWS-AWSManagedRulesCommonRuleSet"
-    priority = 4
+    priority = 6
 
     override_action {
       none {}
@@ -131,7 +194,7 @@ resource "aws_wafv2_web_acl" "main" {
 
   rule {
     name     = "RateLimitSessionCheck"
-    priority = 5
+    priority = 7
 
     action {
       block {}
@@ -180,7 +243,7 @@ resource "aws_wafv2_web_acl" "main" {
 
   rule {
     name     = "RateLimitByIP"
-    priority = 6
+    priority = 8
 
     action {
       block {}
@@ -208,6 +271,16 @@ resource "aws_wafv2_web_acl" "main" {
   }
 
   provider = aws.region
+}
+
+resource "aws_wafv2_regex_pattern_set" "suspicious_uri_patterns" {
+  name        = "suspicious-uri-patterns"
+  description = "Regex pattern set for suspicious URI patterns"
+  scope       = "REGIONAL"
+
+  regular_expression {
+    regex_string = "(?i)\\.(env|git|sql|bak|php|asp|aspx|cgi|sh|exe|tar|gz|tgz|zip|rar|7z|z|bz2|lz|xz|db|sqlite|sqlitedb|war|jar|config|conf|ini|log|pem|key|p12|pfx|crt|ovpn|htaccess|htpasswd|DS_Store|swp)$"
+  }
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "main" {


### PR DESCRIPTION
**Block scanner/probing traffic at WAF level:**

Looking into the 4xx anomaly alarms found the main cause to be scanner traffic probing invalid URIs (.env, .php, .sql etc) in short bursts and not caught by existing rules.

This PR introduces:
- A regex pattern set matching suspicious URI extensions not valid on this service
- A block rule rejecting any matching request
- A rate-based rule which blocks an IP after 5 matching requests

Requests blocked at the WAF don't reach the ALB, so will no longer trigger 4xx error alarms.