### PR TITLE
Update libcap in upload-statistics lambda to fix CVE

### DIFF
--- a/lambda-functions/upload-statistics/Dockerfile
+++ b/lambda-functions/upload-statistics/Dockerfile
@@ -12,7 +12,7 @@ FROM python:3.14-slim@sha256:6a27522252aef8432841f224d9baaa6e9fce07b07584154fa0b
 
 # Update openssl to non-vulnerable version
 RUN apt-get update && \
-    apt-get install openssl=3.5.5-1~deb13u2 libssl3t64=3.5.5-1~deb13u2 openssl-provider-legacy=3.5.5-1~deb13u2 -y --no-install-recommends && \
+    apt-get install openssl=3.5.5-1~deb13u2 libssl3t64=3.5.5-1~deb13u2 openssl-provider-legacy=3.5.5-1~deb13u2 libcap2=1:2.75-10+deb13u1 -y --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 
 # Set working directory to function root directory

--- a/lambda-functions/upload-statistics/Dockerfile
+++ b/lambda-functions/upload-statistics/Dockerfile
@@ -11,8 +11,13 @@ RUN pip install --no-cache-dir --target /app -r /app/requirements.txt
 FROM python:3.14-slim@sha256:6a27522252aef8432841f224d9baaa6e9fce07b07584154fa0b9a96603af7456
 
 # Update openssl to non-vulnerable version
-RUN apt-get update && \
-    apt-get install openssl=3.5.5-1~deb13u2 libssl3t64=3.5.5-1~deb13u2 openssl-provider-legacy=3.5.5-1~deb13u2 libcap2=1:2.75-10+deb13u1 -y --no-install-recommends && \
+RUN apt update && \
+    apt install \
+        openssl=3.5.5-1~deb13u2 \
+        libssl3t64=3.5.5-1~deb13u2 \
+        openssl-provider-legacy=3.5.5-1~deb13u2 \
+        libcap2=1:2.75-10+deb13u1+b1 \
+        -y --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 
 # Set working directory to function root directory


### PR DESCRIPTION
# Purpose

Pipeline is currently not building because of this one.

## Approach

Upgrade as per CVE instructions
## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [x] I have performed a self-review of my own code
* I have added tests to prove my work
* I have added relevant and appropriately leveled logging, **without PII**, to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* I have updated documentation (Confluence/GitHub wiki/tech debt doc)
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* The product team have tested these changes
