### PR TITLE
UML-4440 - Autoscale based on averages instead of maximum metrics

### DIFF
--- a/terraform/environment/region/cloudwatch_alarms.tf
+++ b/terraform/environment/region/cloudwatch_alarms.tf
@@ -233,3 +233,58 @@ moved {
   from = aws_cloudwatch_metric_alarm.admin_ddos_attack_external[0]
   to   = aws_cloudwatch_metric_alarm.admin_ddos_attack_external
 }
+
+# ECS Task Monitoring Alarms - PDF Service
+resource "aws_cloudwatch_metric_alarm" "pdf_high_task_cpu" {
+  alarm_name          = "${var.environment_name}-pdf-high-task-cpu"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 3
+  threshold           = 90
+  alarm_description   = "A single ECS task for the pdf service is sustaining very high CPU utilisation"
+
+  metric_query {
+    id          = "max_cpu"
+    return_data = true
+    metric {
+      metric_name = "CPUUtilization"
+      namespace   = "AWS/ECS"
+      period      = 60
+      stat        = "Maximum"
+      dimensions = {
+        ServiceName = aws_ecs_service.pdf.name
+        ClusterName = aws_ecs_cluster.use_an_lpa.name
+      }
+    }
+  }
+
+  alarm_actions             = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
+  insufficient_data_actions = []
+  provider                  = aws.region
+}
+
+resource "aws_cloudwatch_metric_alarm" "pdf_high_task_memory" {
+  alarm_name          = "${var.environment_name}-pdf-high-task-memory"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 3
+  threshold           = 90
+  alarm_description   = "A single ECS task for the pdf service is sustaining very high memory utilisation"
+
+  metric_query {
+    id          = "max_mem"
+    return_data = true
+    metric {
+      metric_name = "MemoryUtilization"
+      namespace   = "AWS/ECS"
+      period      = 60
+      stat        = "Maximum"
+      dimensions = {
+        ServiceName = aws_ecs_service.pdf.name
+        ClusterName = aws_ecs_cluster.use_an_lpa.name
+      }
+    }
+  }
+
+  alarm_actions             = [aws_sns_topic.cloudwatch_to_pagerduty.arn]
+  insufficient_data_actions = []
+  provider                  = aws.region
+}

--- a/terraform/environment/region/modules/ecs_autoscaling/main.tf
+++ b/terraform/environment/region/modules/ecs_autoscaling/main.tf
@@ -77,7 +77,7 @@ resource "aws_cloudwatch_metric_alarm" "scale_up" {
       metric_name = "CPUUtilization"
       namespace   = "AWS/ECS"
       period      = "60"
-      stat        = "Maximum"
+      stat        = "Average"
 
       dimensions = {
         ServiceName = var.aws_ecs_service_name
@@ -145,7 +145,7 @@ resource "aws_cloudwatch_metric_alarm" "scale_down" {
       metric_name = "CPUUtilization"
       namespace   = "AWS/ECS"
       period      = "60"
-      stat        = "Maximum"
+      stat        = "Average"
 
       dimensions = {
         ServiceName = var.aws_ecs_service_name

--- a/terraform/environment/region/modules/ecs_autoscaling/main.tf
+++ b/terraform/environment/region/modules/ecs_autoscaling/main.tf
@@ -65,7 +65,7 @@ resource "aws_cloudwatch_metric_alarm" "scale_up" {
 
   metric_query {
     id          = "up"
-    expression  = "IF((cpu > ${var.autoscaling_metric_max_cpu_target} OR mem > ${var.autoscaling_metric_max_memory_target}) AND tc < ${var.ecs_task_autoscaling_maximum}, 1, 0)"
+    expression  = "IF((cpu > ${var.autoscaling_scale_up_cpu_threshold} OR mem > ${var.autoscaling_scale_up_memory_threshold}) AND tc < ${var.ecs_task_autoscaling_maximum}, 1, 0)"
     label       = "ContainerScaleUp"
     return_data = "true"
   }
@@ -133,7 +133,7 @@ resource "aws_cloudwatch_metric_alarm" "scale_down" {
 
   metric_query {
     id          = "down"
-    expression  = "IF((cpu < ${var.autoscaling_metric_min_cpu_target} AND mem < ${var.autoscaling_metric_min_memory_target}) AND tc > ${var.ecs_task_autoscaling_minimum}, 1, 0)"
+    expression  = "IF((cpu < ${var.autoscaling_scale_down_cpu_threshold} AND mem < ${var.autoscaling_scale_down_memory_threshold}) AND tc > ${var.ecs_task_autoscaling_minimum}, 1, 0)"
     label       = "ContainerScaleDown"
     return_data = "true"
   }

--- a/terraform/environment/region/modules/ecs_autoscaling/variables.tf
+++ b/terraform/environment/region/modules/ecs_autoscaling/variables.tf
@@ -30,28 +30,28 @@ variable "ecs_task_autoscaling_maximum" {
 
 
 
-variable "autoscaling_metric_max_cpu_target" {
-  description = "The target value for the CPU metric."
+variable "autoscaling_scale_up_cpu_threshold" {
+  description = "Average CPU utilization threshold to trigger scale-up action."
   type        = number
-  default     = 80
+  default     = 70
 }
 
-variable "autoscaling_metric_max_memory_target" {
-  description = "The target value for the memory metric."
+variable "autoscaling_scale_up_memory_threshold" {
+  description = "Average memory utilization threshold to trigger scale-up action."
   type        = number
-  default     = 80
+  default     = 70
 }
 
-variable "autoscaling_metric_min_cpu_target" {
-  description = "The target value for the CPU metric."
+variable "autoscaling_scale_down_cpu_threshold" {
+  description = "Average CPU utilization threshold to trigger scale-down action."
   type        = number
-  default     = 50
+  default     = 40
 }
 
-variable "autoscaling_metric_min_memory_target" {
-  description = "The target value for the memory metric."
+variable "autoscaling_scale_down_memory_threshold" {
+  description = "Average memory utilization threshold to trigger scale-down action."
   type        = number
-  default     = 60
+  default     = 40
 }
 
 variable "ecs_task_autoscaling_minimum" {


### PR DESCRIPTION
# Purpose

Fix ECS autoscaling to use average CPU and memory metrics rather than maximum, preventing continuous scale-up in the event of a single runaway task. Add two new alarms that use Maximum to alert when a single task in the pdf service is sustaining high CPU or memory utilisation.

Fixes UML-4440
