### PR TITLE
UML-4371 - upgrade firewalled network module

### DIFF
--- a/terraform/account/region/firewalled_network.tf
+++ b/terraform/account/region/firewalled_network.tf
@@ -1,11 +1,12 @@
 module "network" {
-  source                              = "github.com/ministryofjustice/opg-terraform-aws-firewalled-network?ref=v0.2.15"
+  source                              = "github.com/ministryofjustice/opg-terraform-aws-firewalled-network?ref=v1.3.1"
   cidr                                = var.network_cidr_block
   enable_dns_hostnames                = true
   enable_dns_support                  = true
   default_security_group_ingress      = []
   default_security_group_egress       = []
   aws_networkfirewall_firewall_policy = aws_networkfirewall_firewall_policy.main
+  network_firewall_enabled            = true
   providers = {
     aws = aws.region
   }

--- a/terraform/account/region/modules/dns_firewall/data_sources.tf
+++ b/terraform/account/region/modules/dns_firewall/data_sources.tf
@@ -25,7 +25,7 @@ data "aws_vpc" "main" {
     values = [data.aws_default_tags.current.tags.application]
   }
   filter {
-    name   = "tag:name"
+    name   = "tag:Name"
     values = ["${data.aws_default_tags.current.tags.application}-${data.aws_default_tags.current.tags.environment-name}-vpc"]
   }
   provider = aws.region

--- a/terraform/environment/region/network.tf
+++ b/terraform/environment/region/network.tf
@@ -9,7 +9,7 @@ data "aws_vpc" "main" {
     values = [data.aws_default_tags.current.tags.application]
   }
   filter {
-    name   = "tag:name"
+    name   = "tag:Name"
     values = ["${data.aws_default_tags.current.tags.application}-${data.aws_default_tags.current.tags.account-name}-vpc"]
   }
   provider = aws.region


### PR DESCRIPTION
# Purpose

Prepare for migration to the share network firewall

Fixes UML-4371

## Approach

- set version to > `1.0.0`, and set `network_firewall_enabled` to `false`
- apply module
- set version to > `1.3.1`, and set `network_firewall_enabled` to `false`
- apply module
- set `network_firewall_enabled` to `true`
- apply module

repeat for preproduction and production

## Learning 

- https://github.com/ministryofjustice/opg-terraform-aws-firewalled-network/releases/tag/v1.0.0