### PR TITLE
Remove extra empty log group created by lambda module

### DIFF
--- a/terraform/environment/lambda.tf
+++ b/terraform/environment/lambda.tf
@@ -9,7 +9,6 @@ module "lambda_update_statistics" {
   image_uri   = "${data.aws_ecr_repository.use_an_lpa_upload_statistics.repository_url}:${var.container_version}"
   ecr_arn     = data.aws_ecr_repository.use_an_lpa_upload_statistics.arn
   environment = local.environment_name
-  kms_key     = data.aws_kms_alias.cloudwatch_encryption.target_key_arn
   timeout     = 900
   memory      = 1024
 }
@@ -114,7 +113,6 @@ module "event_receiver" {
   image_uri   = "${data.aws_ecr_repository.use_an_lpa_event_receiver.repository_url}:${var.container_version}"
   ecr_arn     = data.aws_ecr_repository.use_an_lpa_event_receiver.arn
   environment = local.environment_name
-  kms_key     = data.aws_kms_alias.cloudwatch_encryption.target_key_arn
   timeout     = 900
   memory      = 128
 }

--- a/terraform/environment/modules/lambda/iam.tf
+++ b/terraform/environment/modules/lambda/iam.tf
@@ -42,17 +42,6 @@ resource "aws_iam_role_policy" "lambda" {
 
 data "aws_iam_policy_document" "lambda" {
   statement {
-    sid       = "allowLogging"
-    effect    = "Allow"
-    resources = [aws_cloudwatch_log_group.lambda.arn]
-    actions = [
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-      "logs:DescribeLogStreams"
-    ]
-  }
-
-  statement {
     sid       = "AllowECRAccess"
     effect    = "Allow"
     resources = [var.ecr_arn]

--- a/terraform/environment/modules/lambda/main.tf
+++ b/terraform/environment/modules/lambda/main.tf
@@ -1,8 +1,3 @@
-resource "aws_cloudwatch_log_group" "lambda" {
-  name       = "/aws/lambda/${var.environment}-${var.lambda_name}"
-  kms_key_id = var.kms_key
-}
-
 resource "aws_lambda_function" "lambda_function" {
   function_name = "${var.lambda_name}-${var.environment}"
   image_uri     = var.image_uri
@@ -10,7 +5,6 @@ resource "aws_lambda_function" "lambda_function" {
   role          = aws_iam_role.lambda_role.arn
   timeout       = var.timeout
   memory_size   = var.memory
-  depends_on    = [aws_cloudwatch_log_group.lambda]
 
   tracing_config {
     mode = "Active"

--- a/terraform/environment/modules/lambda/outputs.tf
+++ b/terraform/environment/modules/lambda/outputs.tf
@@ -3,11 +3,6 @@ output "lambda" {
   value       = aws_lambda_function.lambda_function
 }
 
-output "lambda_log" {
-  description = "The lambda logs"
-  value       = aws_cloudwatch_log_group.lambda
-}
-
 output "lambda_role" {
   description = "The lambda role"
   value       = aws_iam_role.lambda_role

--- a/terraform/environment/modules/lambda/variables.tf
+++ b/terraform/environment/modules/lambda/variables.tf
@@ -43,8 +43,3 @@ variable "ecr_arn" {
   type        = string
   default     = null
 }
-
-variable "kms_key" {
-  description = "ARN of KMS key for the lambda log group"
-  type        = string
-}

--- a/terraform/environment/shared_data_sources.tf
+++ b/terraform/environment/shared_data_sources.tf
@@ -1,7 +1,3 @@
-data "aws_kms_alias" "cloudwatch_encryption" {
-  name = "alias/cloudwatch-encryption-mrk"
-}
-
 data "aws_kms_alias" "event_receiver" {
   name = "alias/event-receiver-mrk"
 }


### PR DESCRIPTION
The lambda module will currently create two log groups:

- `{env}-{lambda_name}` - this one is unused and empty
- `{lambda_name}-{env}` - this one is used

This PR stops creating the unused one.

I imagine this will complain when merged to production, and these log groups will have to be removed manually...