### PR TITLE
UML-4371 - Migrate to shared network firewall

### DIFF
--- a/terraform/account/region/firewalled_network.tf
+++ b/terraform/account/region/firewalled_network.tf
@@ -6,7 +6,11 @@ module "network" {
   default_security_group_ingress      = []
   default_security_group_egress       = []
   aws_networkfirewall_firewall_policy = aws_networkfirewall_firewall_policy.main
-  network_firewall_enabled            = true
+  network_firewall_enabled            = var.account.network_firewall_enabled
+  shared_firewall_configuration = var.account.shared_firewall_configuration.enabled != true ? null : {
+    account_id   = var.account.shared_firewall_configuration.account_id
+    account_name = var.account.shared_firewall_configuration.account_name
+  }
   providers = {
     aws = aws.region
   }

--- a/terraform/account/region/variables.tf
+++ b/terraform/account/region/variables.tf
@@ -22,6 +22,12 @@ variable "account" {
       trail_name_suffix  = string
       bucket_name_suffix = string
     })
+    network_firewall_enabled = bool
+    shared_firewall_configuration = object({
+      enabled      = bool
+      account_id   = string
+      account_name = string
+    })
     s3_access_log_bucket_name = string
   })
 }

--- a/terraform/account/terraform.tfvars.json
+++ b/terraform/account/terraform.tfvars.json
@@ -30,6 +30,12 @@
         "trail_name_suffix": "development-ual",
         "bucket_name_suffix": "dev.ual.opg.service.justice.gov.uk"
       },
+      "network_firewall_enabled": true,
+      "shared_firewall_configuration": {
+        "enabled": true,
+        "account_id": "679638075911",
+        "account_name": "development"
+      },
       "permitted_s3_buckets": [
         "arn:aws:s3:::lpa-iap-demo/*",
         "arn:aws:s3:::lpa-iap-development/*",
@@ -75,6 +81,12 @@
         "trail_name_suffix": "preproduction-ual",
         "bucket_name_suffix": "preprod.ual.opg.service.justice.gov.uk"
       },
+      "network_firewall_enabled": true,
+      "shared_firewall_configuration": {
+        "enabled": true,
+        "account_id": "679638075911",
+        "account_name": "development"
+      },
       "permitted_s3_buckets": [
         "arn:aws:s3:::lpa-iap-preproduction/*",
         "arn:aws:s3:::opg-lpa-store-static-preproduction-eu-west-1/*",
@@ -114,6 +126,12 @@
         "enabled": true,
         "trail_name_suffix": "production-ual",
         "bucket_name_suffix": "prod.ual.opg.service.justice.gov.uk"
+      },
+      "network_firewall_enabled": true,
+      "shared_firewall_configuration": {
+        "enabled": true,
+        "account_id": "997462338508",
+        "account_name": "production"
       },
       "permitted_s3_buckets": [
         "arn:aws:s3:::lpa-iap-production/*",

--- a/terraform/account/variables.tf
+++ b/terraform/account/variables.tf
@@ -38,6 +38,12 @@ variable "accounts" {
         trail_name_suffix  = string
         bucket_name_suffix = string
       })
+      network_firewall_enabled = bool
+      shared_firewall_configuration = object({
+        enabled      = bool
+        account_id   = string
+        account_name = string
+      })
       permitted_s3_buckets      = list(string)
       s3_access_log_bucket_name = string
       regions = map(


### PR DESCRIPTION
# Purpose

Add controls for enabling and disabling the network firewall per account and switching between shared and in-account firewall.  Followed the same approach as Make.
To be merged once the migration has been applied locally in all accounts. 

Fixes UML-4371
