### PR TITLE
Composer github authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,10 +21,8 @@ query/s3_objects/**
 query/results/*.csv
 terraform/**/modules/**.terraform.lock.hcl
 
-.structurizr
-docs/diagrams/dsl/**/workspace.json
-
 *.pem
 tests/vendor
 
+auth.json
 docker-compose.override.yml

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -165,7 +165,7 @@
         "filename": "docker-compose.yml",
         "hashed_secret": "e04e85b6c64a463fd4f449b7d7164cdf2e4da35d",
         "is_verified": false,
-        "line_number": 56
+        "line_number": 58
       }
     ],
     "mock-integrations/opg-data-lpa/mock-openapi.yaml": [
@@ -462,5 +462,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-03T08:36:42Z"
+  "generated_at": "2026-07-03T11:06:45Z"
 }

--- a/Makefile
+++ b/Makefile
@@ -51,12 +51,12 @@ build_frontend_assets:
 
 rebuild:
 	$(COMPOSE) build --no-cache $(filter-out $@,$(MAKECMDGOALS))
+	$(COMPOSE) --profile tools build --no-cache
 .PHONY: rebuild
 
 reset:
 	rm -R service-front/app/vendor service-api/app/vendor tests/smoke/vendor || true
 	$(MAKE) rebuild
-	$(COMPOSE) --profile tools build --no-cache
 	$(MAKE) pull
 	$(MAKE) composer_install
 .PHONY: reset
@@ -125,37 +125,37 @@ development_mode: enable_development_mode clear_config_cache
 .PHONY: development_mode
 
 composer_install:
-	$(COMPOSE) run --rm front-composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader
-	$(COMPOSE) run --rm api-composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader
-	$(COMPOSE) -f tests/smoke/docker-compose.smoke.yml run --rm smoke-tests composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader
+	$(COMPOSE) run --rm front-composer -- install --prefer-dist --no-interaction --no-scripts --optimize-autoloader
+	$(COMPOSE) run --rm api-composer -- install --prefer-dist --no-interaction --no-scripts --optimize-autoloader
+	$(COMPOSE) -f tests/smoke/docker-compose.smoke.yml run --rm smoke-tests -- composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader
 .PHONY: composer_install
 
 run_front_composer:
-	$(COMPOSE) run --rm front-composer $(filter-out $@,$(MAKECMDGOALS))
+	$(COMPOSE) run --rm front-composer -- $(filter-out $@,$(MAKECMDGOALS))
 .PHONY: run_front_composer
 
 run_api_composer:
-	$(COMPOSE) run --rm api-composer $(filter-out $@,$(MAKECMDGOALS))
+	$(COMPOSE) run --rm api-composer -- $(filter-out $@,$(MAKECMDGOALS))
 .PHONY: run_api_composer
 
 run_smoke_composer:
-	$(COMPOSE) -f tests/smoke/docker-compose.smoke.yml run --rm smoke-tests composer $(filter-out $@,$(MAKECMDGOALS))
+	$(COMPOSE) -f tests/smoke/docker-compose.smoke.yml run --rm smoke-tests composer -- $(filter-out $@,$(MAKECMDGOALS))
 .PHONY: run_smoke_composer
 
 run_front_composer_update:
-	$(COMPOSE) run --rm front-composer update
+	$(COMPOSE) run --rm front-composer -- update
 .PHONY: run_front_composer_update
 
 run_front_npm_update:
-	$(COMPOSE) run --rm npm update
+	$(COMPOSE) run --rm npm -- update
 .PHONY: run_front_npm_update
 
 run_api_composer_update:
-	$(COMPOSE) run --rm api-composer update
+	$(COMPOSE) run --rm api-composer -- update
 .PHONY: run_api_composer_update
 
 run_smoke_composer_update:
-	$(COMPOSE) -f tests/smoke/docker-compose.smoke.yml run --rm smoke-tests-composer update
+	$(COMPOSE) -f tests/smoke/docker-compose.smoke.yml run --rm smoke-tests-composer -- update
 .PHONY: run_smoke_composer_update
 
 run_update: run_front_composer_update run_front_npm_update run_api_composer_update run_smoke_composer_update

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ To maintain repo standards and avoid commiting secrets [install pre-commit](http
 pre-commit install
 ```
 
+Configure a [fine grained Github access token](https://github.com/settings/personal-access-tokens) and replace
+the placeholder in the `auth.json` file with it. It *only* needs public access permissions and is purely an
+exercise in allowing better rate limits than unauthenticated Github access allows.
+
 ### Makefile
 
 A Makefile is maintained that aliases the most useful docker-compose commands.

--- a/auth.json
+++ b/auth.json
@@ -1,0 +1,5 @@
+{
+  "github-oauth": {
+    "github.com": "<INSERT_GITHUB_FINEGRAINED_TOKEN_HERE>"
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
       target: development
       context: .
       dockerfile: service-front/docker/app/Dockerfile
+      secrets:
+        - composer-auth
     volumes:
       - ./service-front/app:/app
       - esbuild:/app/assets
@@ -89,6 +91,8 @@ services:
       target: development
       context: .
       dockerfile: service-front/docker/app/Dockerfile
+      secrets:
+        - composer-auth
     volumes:
       - ./service-front/app:/app
       - esbuild:/app/assets
@@ -129,10 +133,17 @@ services:
       target: development
       context: .
       dockerfile: service-front/docker/app/Dockerfile
+      secrets:
+        - composer-auth
     volumes:
       - ./service-front/app:/app
-    entrypoint:
-      - /usr/bin/composer
+    secrets:
+      - composer-auth
+    entrypoint: >
+      /bin/sh -c "
+        ln -sf /run/secrets/composer-auth auth.json \
+        /usr/bin/composer $${@}
+      "
     command:
       - install
       - --prefer-dist
@@ -165,6 +176,8 @@ services:
       target: development
       context: .
       dockerfile: service-api/docker/app/Dockerfile
+      secrets:
+        - composer-auth
     volumes:
       - ./service-api/app:/app
     environment:
@@ -209,10 +222,17 @@ services:
       target: development
       context: .
       dockerfile: service-api/docker/app/Dockerfile
+      secrets:
+        - composer-auth
     volumes:
       - ./service-api/app:/app
-    entrypoint:
-      - /usr/bin/composer
+    secrets:
+      - composer-auth
+    entrypoint: >
+      /bin/sh -c "
+        ln -sf /run/secrets/composer-auth auth.json \
+        /usr/bin/composer $${@}
+      "
     command:
       - install
       - --prefer-dist
@@ -276,3 +296,7 @@ services:
 
   golang:
     image: golang:1.25.11-alpine@sha256:c05ba4b73604069d376c4f41346b05374335b5ca0c46fb6dfede5a59f5196931
+
+secrets:
+  composer-auth:
+    file: ./auth.json

--- a/service-api/docker/app/Dockerfile
+++ b/service-api/docker/app/Dockerfile
@@ -30,7 +30,8 @@ FROM php-base AS dependency
 COPY --from=composer /composer /usr/bin/
 COPY service-api/app/composer.json service-api/app/composer.lock /app/
 
-RUN composer install --prefer-dist --no-dev --no-interaction --no-scripts --optimize-autoloader && \
+RUN --mount=type=secret,id=composer-auth COMPOSER_AUTH=$(cat /run/secrets/composer-auth) \
+    composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --no-dev && \
     composer check-platform-reqs
 
 #
@@ -56,7 +57,8 @@ RUN set -xe \
   && install-php-extensions xdebug-stable ffi \
   && echo "ffi.enable=true" >> /usr/local/etc/php/conf.d/docker-php-ext-ffi.ini
 
-RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs && \
+RUN --mount=type=secret,id=composer-auth COMPOSER_AUTH=$(cat /run/secrets/composer-auth) \
+    composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs && \
     composer check-platform-reqs
 
 CMD ["php-fpm"]

--- a/service-front/docker/app/Dockerfile
+++ b/service-front/docker/app/Dockerfile
@@ -30,7 +30,8 @@ FROM php-base AS dependency
 COPY --from=composer /composer /usr/bin/
 COPY service-front/app/composer.json service-front/app/composer.lock /app/
 
-RUN composer install --prefer-dist --no-dev --no-interaction --no-scripts --optimize-autoloader && \
+RUN --mount=type=secret,id=composer-auth COMPOSER_AUTH=$(cat /run/secrets/composer-auth) \
+    composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --no-dev && \
     composer check-platform-reqs
 
 #
@@ -53,7 +54,8 @@ COPY service-front/docker/app/app-php-development.ini /usr/local/etc/php/conf.d/
 RUN set -xe \
   && install-php-extensions xdebug-stable
 
-RUN composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs && \
+RUN --mount=type=secret,id=composer-auth COMPOSER_AUTH=$(cat /run/secrets/composer-auth) \
+    composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader --ignore-platform-reqs && \
     composer check-platform-reqs
 
 CMD ["php-fpm"]


### PR DESCRIPTION
# Purpose

Lately a number of us have been hitting ratelimits imposed by github that stop us being able to build or use composer. 

Adds the usage of a github authentication token to allow composer to do its job better with greater limits

## Approach

docker compose secrets 

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [x] I have performed a self-review of my own code
* I have added tests to prove my work
* I have added relevant and appropriately leveled logging, **without PII**, to my code
* New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc)
* I have added welsh translation tags and updated translation files
* I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* The product team have tested these changes
