### PR TITLE
UML-4474: use region in ecr data source

### DIFF
--- a/terraform/environment/config_file.tf
+++ b/terraform/environment/config_file.tf
@@ -7,7 +7,7 @@ locals {
 
   active_region                                           = [for k, v in local.environment.regions : k if v["is_active"] == true][0]
   mock_onelogin_load_balancer_security_group_name_enabled = local.active_region == "eu-west-1" ? module.eu_west_1[0].security_group_names.mock_onelogin_loadbalancer : module.eu_west_2[0].security_group_names.mock_onelogin_loadbalancer
-  mock_onelogin_load_balancer_security_group_id_enabled   = local.active_region == "eu-west-1" ? module.eu_west_1[0].security_group_ids.mock_onelogin_loadbalancer : module.eu_west_2[0].security_group_id.mock_onelogin_loadbalancer
+  mock_onelogin_load_balancer_security_group_id_enabled   = local.active_region == "eu-west-1" ? module.eu_west_1[0].security_group_ids.mock_onelogin_loadbalancer : module.eu_west_2[0].security_group_ids.mock_onelogin_loadbalancer
 
 
 
@@ -29,8 +29,8 @@ locals {
     viewer_load_balancer_security_group_name        = local.active_region == "eu-west-1" ? module.eu_west_1[0].security_group_names.viewer_loadbalancer : module.eu_west_2[0].security_group_names.viewer_loadbalancer
     actor_load_balancer_security_group_name         = local.active_region == "eu-west-1" ? module.eu_west_1[0].security_group_names.actor_loadbalancer : module.eu_west_2[0].security_group_names.actor_loadbalancer
     mock_onelogin_load_balancer_security_group_name = local.environment.mock_onelogin_enabled ? local.mock_onelogin_load_balancer_security_group_name_enabled : null
-    viewer_load_balancer_security_group_id          = local.active_region == "eu-west-1" ? module.eu_west_1[0].security_group_ids.viewer_loadbalancer : module.eu_west_2[0].security_group_id.viewer_loadbalancer
-    actor_load_balancer_security_group_id           = local.active_region == "eu-west-1" ? module.eu_west_1[0].security_group_ids.actor_loadbalancer : module.eu_west_2[0].security_group_id.actor_loadbalancer
+    viewer_load_balancer_security_group_id          = local.active_region == "eu-west-1" ? module.eu_west_1[0].security_group_ids.viewer_loadbalancer : module.eu_west_2[0].security_group_ids.viewer_loadbalancer
+    actor_load_balancer_security_group_id           = local.active_region == "eu-west-1" ? module.eu_west_1[0].security_group_ids.actor_loadbalancer : module.eu_west_2[0].security_group_ids.actor_loadbalancer
     mock_onelogin_load_balancer_security_group_id   = local.environment.mock_onelogin_enabled ? local.mock_onelogin_load_balancer_security_group_id_enabled : null
     active_region                                   = local.active_region
     vpc_id                                          = local.active_region == "eu-west-1" ? module.eu_west_1[0].vpc_id : module.eu_west_2[0].vpc_id

--- a/terraform/environment/region/data_sources.tf
+++ b/terraform/environment/region/data_sources.tf
@@ -46,6 +46,7 @@ data "aws_kms_alias" "cloudwatch_encryption" {
 data "aws_ecr_repository" "use_an_lpa_front_web" {
   provider = aws.management
   name     = "use_an_lpa/front_web"
+  region   = data.aws_region.current.name
 }
 
 data "aws_ecr_image" "use_an_lpa_front_web" {
@@ -57,6 +58,7 @@ data "aws_ecr_image" "use_an_lpa_front_web" {
 data "aws_ecr_repository" "use_an_lpa_front_app" {
   provider = aws.management
   name     = "use_an_lpa/front_app"
+  region   = data.aws_region.current.name
 }
 
 data "aws_ecr_image" "use_an_lpa_front_app" {
@@ -68,6 +70,7 @@ data "aws_ecr_image" "use_an_lpa_front_app" {
 data "aws_ecr_repository" "use_an_lpa_api_web" {
   provider = aws.management
   name     = "use_an_lpa/api_web"
+  region   = data.aws_region.current.name
 }
 
 data "aws_ecr_image" "use_an_lpa_api_web" {
@@ -79,6 +82,7 @@ data "aws_ecr_image" "use_an_lpa_api_web" {
 data "aws_ecr_repository" "use_an_lpa_api_app" {
   provider = aws.management
   name     = "use_an_lpa/api_app"
+  region   = data.aws_region.current.name
 }
 
 data "aws_ecr_image" "use_an_lpa_api_app" {
@@ -90,6 +94,7 @@ data "aws_ecr_image" "use_an_lpa_api_app" {
 data "aws_ecr_repository" "use_an_lpa_pdf" {
   provider = aws.management
   name     = "pdf-service"
+  region   = data.aws_region.current.name
 }
 
 data "aws_ecr_image" "pdf_service" {
@@ -102,6 +107,7 @@ data "aws_ecr_image" "pdf_service" {
 data "aws_ecr_repository" "use_an_lpa_admin_app" {
   provider = aws.management
   name     = "use_an_lpa/admin_app"
+  region   = data.aws_region.current.name
 }
 
 data "aws_ecr_image" "use_an_lpa_admin_app" {


### PR DESCRIPTION
# Purpose

Gives the ECR data sources the region var, so when we failover to eu-west-2 we have images to pull.

Fixes UML-4474

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [ ] I have performed a self-review of my own code
* [ ] I have added tests to prove my work
* [ ] I have added relevant and appropriately leveled logging, **without PII**, to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc)
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
