### PR TITLE
UML-4462 - fix lambda logging

### DIFF
--- a/terraform/environment/modules/lambda/main.tf
+++ b/terraform/environment/modules/lambda/main.tf
@@ -4,7 +4,7 @@ resource "aws_cloudwatch_log_group" "lambda" {
 }
 
 resource "aws_lambda_function" "lambda_function" {
-  function_name = "${var.lambda_name}-${var.environment}"
+  function_name = "${var.environment}-${var.lambda_name}"
   image_uri     = var.image_uri
   package_type  = var.package_type
   role          = aws_iam_role.lambda_role.arn


### PR DESCRIPTION
# Purpose

Lambda log group name didn't match the function name, so the default aws log group was being used instead of our custom one

Fixes UML-4462
