### PR TITLE
Upgrade nginx versions

### DIFF
--- a/service-api/docker/web/Dockerfile
+++ b/service-api/docker/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginxinc/nginx-unprivileged:stable-alpine@sha256:2c5a98dcd9bfb568fd6a305e0637f0410beafdbf644443112ab47d6a713ba43e
+FROM nginxinc/nginx-unprivileged:stable-alpine@sha256:44e36330f74d4f3a1d4e222acca9e23b401fb87811a7597024502bb759c4dd49
 USER root
 
 COPY service-api/docker/web/default.conf.template /etc/nginx/templates/default.conf.template

--- a/service-front/docker/web/Dockerfile
+++ b/service-front/docker/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginxinc/nginx-unprivileged:stable-alpine@sha256:2c5a98dcd9bfb568fd6a305e0637f0410beafdbf644443112ab47d6a713ba43e
+FROM nginxinc/nginx-unprivileged:stable-alpine@sha256:44e36330f74d4f3a1d4e222acca9e23b401fb87811a7597024502bb759c4dd49
 USER root
 
 COPY service-front/docker/web/default.conf.template /etc/nginx/templates/default.conf.template


### PR DESCRIPTION
Upgrades nginx-unprivileged:stable-alpine images to use nginx 1.30.4

Patches a remote code execution vulnerability:
https://cyberstan.co.uk/nginx-rce/
