### PR TITLE
UML-4439:Download button disabling for 5 sec

### DIFF
--- a/service-front/app/src/Common/templates/partials/full-lpa-display-combined-lpa.html.twig
+++ b/service-front/app/src/Common/templates/partials/full-lpa-display-combined-lpa.html.twig
@@ -27,21 +27,21 @@
                         {% endif %}
                     </h1>
                     <div class="govuk-panel__body">
-{#                        <p class="govuk-!-font-size-24">#}
-{#                            {% if lpa.lpaType.propertyAndAffairs %}#}
-{#                                {% if lpa.whenTheLpaCanBeUsed.whenCapacityLost %}#}
-{#                                    {% trans %}This <abbr title="lasting power of attorney">LPA</abbr> can only be used when the donor has lost capacity{% endtrans %}#}
-{#                                {% elseif lpa.whenTheLpaCanBeUsed.unknown %}#}
-{#                                    {% trans %}This <abbr title="lasting power of attorney">LPA</abbr> can be used as soon as it's registered unless instructions say otherwise{% endtrans %}#}
-{#                                {% endif %}#}
-{#                            {% else %}#}
-{#                                {% if lpa.lifeSustainingTreatment.OptionA %}#}
-{#                                    {% trans %}The attorneys have the authority to make decisions about life-sustaining treatment{% endtrans %}#}
-{#                                {% elseif lpa.lifeSustainingTreatment.OptionB %}#}
-{#                                    {% trans %}The attorneys do NOT have the authority to make decisions about life-sustaining treatment{% endtrans %}#}
-{#                                {% endif %}#}
-{#                            {% endif %}#}
-{#                        </p>#}
+                        <p class="govuk-!-font-size-24">
+                            {% if lpa.lpaType.propertyAndAffairs %}
+                                {% if lpa.whenTheLpaCanBeUsed.whenCapacityLost %}
+                                    {% trans %}This <abbr title="lasting power of attorney">LPA</abbr> can only be used when the donor has lost capacity{% endtrans %}
+                                {% elseif lpa.whenTheLpaCanBeUsed.unknown %}
+                                    {% trans %}This <abbr title="lasting power of attorney">LPA</abbr> can be used as soon as it's registered unless instructions say otherwise{% endtrans %}
+                                {% endif %}
+                            {% else %}
+                                {% if lpa.lifeSustainingTreatment.OptionA %}
+                                    {% trans %}The attorneys have the authority to make decisions about life-sustaining treatment{% endtrans %}
+                                {% elseif lpa.lifeSustainingTreatment.OptionB %}
+                                    {% trans %}The attorneys do NOT have the authority to make decisions about life-sustaining treatment{% endtrans %}
+                                {% endif %}
+                            {% endif %}
+                        </p>
                         {% endif %}
 
                         {% if lpa.applicationHasGuidance or lpa.applicationHasRestrictions %}

--- a/service-front/app/src/Common/templates/partials/full-lpa-display-combined-lpa.html.twig
+++ b/service-front/app/src/Common/templates/partials/full-lpa-display-combined-lpa.html.twig
@@ -76,7 +76,7 @@
                         </div>
 
                         <form action={{ path('download-lpa') }}>
-                            <button class="govuk-button" type="submit">
+                            <button class="govuk-button" data-prevent-double-click="true" data-reenable-after="5000" type="submit">
                                 {% trans %}Download this LPA summary{% endtrans %}
                             </button>
                         </form>

--- a/service-front/app/src/Common/templates/partials/full-lpa-display-combined-lpa.html.twig
+++ b/service-front/app/src/Common/templates/partials/full-lpa-display-combined-lpa.html.twig
@@ -27,21 +27,21 @@
                         {% endif %}
                     </h1>
                     <div class="govuk-panel__body">
-                        <p class="govuk-!-font-size-24">
-                            {% if lpa.lpaType.propertyAndAffairs %}
-                                {% if lpa.whenTheLpaCanBeUsed.whenCapacityLost %}
-                                    {% trans %}This <abbr title="lasting power of attorney">LPA</abbr> can only be used when the donor has lost capacity{% endtrans %}
-                                {% elseif lpa.whenTheLpaCanBeUsed.unknown %}
-                                    {% trans %}This <abbr title="lasting power of attorney">LPA</abbr> can be used as soon as it's registered unless instructions say otherwise{% endtrans %}
-                                {% endif %}
-                            {% else %}
-                                {% if lpa.lifeSustainingTreatment.OptionA %}
-                                    {% trans %}The attorneys have the authority to make decisions about life-sustaining treatment{% endtrans %}
-                                {% elseif lpa.lifeSustainingTreatment.OptionB %}
-                                    {% trans %}The attorneys do NOT have the authority to make decisions about life-sustaining treatment{% endtrans %}
-                                {% endif %}
-                            {% endif %}
-                        </p>
+{#                        <p class="govuk-!-font-size-24">#}
+{#                            {% if lpa.lpaType.propertyAndAffairs %}#}
+{#                                {% if lpa.whenTheLpaCanBeUsed.whenCapacityLost %}#}
+{#                                    {% trans %}This <abbr title="lasting power of attorney">LPA</abbr> can only be used when the donor has lost capacity{% endtrans %}#}
+{#                                {% elseif lpa.whenTheLpaCanBeUsed.unknown %}#}
+{#                                    {% trans %}This <abbr title="lasting power of attorney">LPA</abbr> can be used as soon as it's registered unless instructions say otherwise{% endtrans %}#}
+{#                                {% endif %}#}
+{#                            {% else %}#}
+{#                                {% if lpa.lifeSustainingTreatment.OptionA %}#}
+{#                                    {% trans %}The attorneys have the authority to make decisions about life-sustaining treatment{% endtrans %}#}
+{#                                {% elseif lpa.lifeSustainingTreatment.OptionB %}#}
+{#                                    {% trans %}The attorneys do NOT have the authority to make decisions about life-sustaining treatment{% endtrans %}#}
+{#                                {% endif %}#}
+{#                            {% endif %}#}
+{#                        </p>#}
                         {% endif %}
 
                         {% if lpa.applicationHasGuidance or lpa.applicationHasRestrictions %}
@@ -139,7 +139,7 @@
                 <div class="govuk-grid-row">
                     <div class="govuk-grid-column-two-thirds">
                         <form action={{ path('download-lpa') }}>
-                            <button class="govuk-button"
+                            <button class="govuk-button" data-prevent-double-click="true" data-reenable-after="5000"
                                     type="submit">{% trans %}Download this LPA summary{% endtrans %}
                             </button>
                         </form>

--- a/service-front/app/src/Common/templates/partials/full-lpa-display.html.twig
+++ b/service-front/app/src/Common/templates/partials/full-lpa-display.html.twig
@@ -139,8 +139,8 @@
                 <div class="govuk-grid-row">
                     <div class="govuk-grid-column-two-thirds">
                         <form action={{ path('download-lpa') }}>
-                            <button class="govuk-button"
-                                    type="submit">{% trans %}Download this LPA summary{% endtrans %}
+                            <button class="govuk-button" data-prevent-double-click="true" data-reenable-after="5000"
+                                type="submit">{% trans %}Download this LPA summary{% endtrans %}
                             </button>
                         </form>
                         <p class="govuk-body">

--- a/service-front/app/src/Common/templates/partials/full-lpa-display.html.twig
+++ b/service-front/app/src/Common/templates/partials/full-lpa-display.html.twig
@@ -76,7 +76,7 @@
                         </div>
 
                         <form action={{ path('download-lpa') }}>
-                            <button class="govuk-button" type="submit">
+                            <button class="govuk-button" data-prevent-double-click="true" data-reenable-after="5000" type="submit">
                                 {% trans %}Download this LPA summary{% endtrans %}
                             </button>
                         </form>

--- a/service-front/web/src/javascript/disableButtonOnClick.js
+++ b/service-front/web/src/javascript/disableButtonOnClick.js
@@ -4,7 +4,7 @@ const disableButtonOnClick = (form) => {
       if (e.target.nodeName == 'BUTTON' && e.target.getAttribute('data-prevent-double-click') && !(e.target.disabled)) {
         e.target.disabled = true;
 
-        const timeout = e.target.dataset.reenableAfter;
+        const timeout = e.target.getAttribute('data-reenable-after');
 
         if (timeout) {
           setTimeout(() => {

--- a/service-front/web/src/javascript/disableButtonOnClick.js
+++ b/service-front/web/src/javascript/disableButtonOnClick.js
@@ -4,6 +4,14 @@ const disableButtonOnClick = (form) => {
       if (e.target.nodeName == 'BUTTON' && e.target.getAttribute('data-prevent-double-click') && !(e.target.disabled)) {
         e.target.disabled = true;
 
+        const timeout = e.target.dataset.reenableAfter;
+
+        if (timeout) {
+          setTimeout(() => {
+            e.target.disabled = false;
+          }, Number(timeout));
+        }
+
         form[i].submit();
       }
     });

--- a/service-front/web/src/javascript/disableButtonOnClick.test.js
+++ b/service-front/web/src/javascript/disableButtonOnClick.test.js
@@ -61,7 +61,7 @@ describe('disableButtonOnClick', () => {
 
       expect(button.disabled).toBe(false);
 
-      est.useRealTimers();
+      jest.useRealTimers();
 
     });
   });

--- a/service-front/web/src/javascript/disableButtonOnClick.test.js
+++ b/service-front/web/src/javascript/disableButtonOnClick.test.js
@@ -39,4 +39,29 @@ describe('disableButtonOnClick', () => {
       expect(button.disabled).toBe(true);
     });
   });
+
+  describe('with button reenable attribute', () => {
+    test('clicking the download button should disable it and reenable after 5s', () => {
+
+      jest.useFakeTimers();
+
+      document.body.innerHTML =
+        <form name="test" onsubmit="return false">
+          <button type="submit" data-prevent-double-click="true" data-reenable-after="5000">Click</button>
+        </form>
+
+      disableButtonOnClick(document.getElementsByTagName('form'));
+      const button = document.querySelector('button');
+      button.click();
+
+      expect(button.disabled).toBe(true);
+
+      jest.advanceTimersByTime(5000);
+
+      expect(button.disabled).toBe(false);
+
+      est.useRealTimers();
+
+    });
+  });
 });

--- a/service-front/web/src/javascript/disableButtonOnClick.test.js
+++ b/service-front/web/src/javascript/disableButtonOnClick.test.js
@@ -45,10 +45,11 @@ describe('disableButtonOnClick', () => {
 
       jest.useFakeTimers();
 
-      document.body.innerHTML =
-        <form name="test" onsubmit="return false">
-          <button type="submit" data-prevent-double-click="true" data-reenable-after="5000">Click</button>
-        </form>
+      document.body.innerHTML = `
+      <form name="test" onsubmit="return false">
+        <button type="submit" data-prevent-double-click="true" data-reenable-after="5000">Click</button>
+      </form>
+    `;
 
       disableButtonOnClick(document.getElementsByTagName('form'));
       const button = document.querySelector('button');


### PR DESCRIPTION
# Purpose

Stop usage of "Download LPA" button for a brief time after clicking.

Fixes UML-4439

## Approach

Addition of reenableAfter arg which can automatically re-enable the button after a specified delay

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the Use a Lasting Power of Attorney service_

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [X] I have performed a self-review of my own code
* [ ] I have added tests to prove my work
* [ ] I have added relevant and appropriately leveled logging, **without PII**, to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc)
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
