### PR TITLE
UML-4486 - Enable permissions boundaries in preproduction

### DIFF
--- a/terraform/account/terraform.tfvars.json
+++ b/terraform/account/terraform.tfvars.json
@@ -63,6 +63,7 @@
       "retention_in_days": 7,
       "pagerduty_service_name": "Use a Lasting Power of Attorney Non-Production",
       "pagerduty_service_id": "PCM4EZI",
+      "permissions_boundary_enabled": true,
       "dns_firewall": {
         "enabled": true,
         "domains_allowed": [

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -388,6 +388,7 @@
       "lpa_data_store_endpoint": "https://preproduction.lpa-store.api.opg.service.justice.gov.uk",
       "lpa_data_store_secret_name": "lpa-data-store-secret",
       "pagerduty_service_name": "Use a Lasting Power of Attorney Non-Production",
+      "permissions_boundary_enabled": true,
       "mock_onelogin_enabled": true,
       "pagerduty_service_id": "PCM4EZI",
       "session_expires_use": 20,


### PR DESCRIPTION
Use the boundaried ci role and add permissions boundaries to non-ci roles in preproduction
