### PR TITLE
UML-4459 - Add new service-area tag

### DIFF
--- a/terraform/account/dynamodb_data_plane_cloudtrail.tf
+++ b/terraform/account/dynamodb_data_plane_cloudtrail.tf
@@ -3,6 +3,7 @@ module "production_dynamodb_cloudtrail" {
   count                         = local.account.dynamodb_cloudtrail.enabled ? 1 : 0
   trail_name_suffix             = local.account.dynamodb_cloudtrail.trail_name_suffix
   bucket_name_suffix            = local.account.dynamodb_cloudtrail.bucket_name_suffix
-  s3_access_logging_bucket_name = "${local.account.s3_access_log_bucket_name}-${data.aws_region.current.region}"
+  s3_access_logging_bucket_name = "${local.account.s3_access_log_bucket_name}-${local.region}"
   default_boundary              = data.aws_iam_policy.default_boundary.arn
+  region_name                   = local.region
 }

--- a/terraform/account/kms.tf
+++ b/terraform/account/kms.tf
@@ -106,7 +106,7 @@ data "aws_iam_policy_document" "cloudwatch_kms" {
     principals {
       type = "Service"
       identifiers = [
-        "logs.${data.aws_region.current.region}.amazonaws.com",
+        "logs.${local.region}.amazonaws.com",
         "logs.eu-west-2.amazonaws.com",
         "events.amazonaws.com"
       ]

--- a/terraform/account/locals.tf
+++ b/terraform/account/locals.tf
@@ -11,6 +11,7 @@ locals {
     environment-name = local.environment
     owner            = "Sarah Mills: sarah.mills@digital.justice.gov.uk"
     is-production    = local.account.is_production
+    service-area     = "POAS"
   }
 
   optional_tags = {

--- a/terraform/account/locals.tf
+++ b/terraform/account/locals.tf
@@ -2,6 +2,7 @@ locals {
   account_name = lookup(var.account_mapping, terraform.workspace, "development")
   account      = var.accounts[local.account_name]
   environment  = lower(terraform.workspace)
+  region       = data.aws_region.current.region
 
 
   mandatory_moj_tags = {

--- a/terraform/account/modules/dynamodb_cloudtrail/cloudtrail.tf
+++ b/terraform/account/modules/dynamodb_cloudtrail/cloudtrail.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudtrail" "cloudtrail" {
-  name                          = "ddb-cloudtrail-${var.region}-${var.trail_name_suffix}"
+  name                          = "ddb-cloudtrail-${var.region_name}-${var.trail_name_suffix}"
   cloud_watch_logs_group_arn    = "${aws_cloudwatch_log_group.cloudtrail.arn}:*"
   cloud_watch_logs_role_arn     = aws_iam_role.cloudtrail.arn
   enable_log_file_validation    = true
@@ -20,13 +20,13 @@ resource "aws_cloudtrail" "cloudtrail" {
 }
 
 resource "aws_cloudwatch_log_group" "cloudtrail" {
-  name              = "ddb-cloudtrail-${var.region}-${var.trail_name_suffix}"
+  name              = "ddb-cloudtrail-${var.region_name}-${var.trail_name_suffix}"
   retention_in_days = 90
   kms_key_id        = aws_kms_alias.cloudtrail_log_group_key.target_key_arn
 }
 
 resource "aws_iam_role" "cloudtrail" {
-  name                 = "ddb-cloudtrail-${var.region}-${var.trail_name_suffix}"
+  name                 = "ddb-cloudtrail-${var.region_name}-${var.trail_name_suffix}"
   assume_role_policy   = data.aws_iam_policy_document.cloudtrail_role_assume_role_policy.json
   permissions_boundary = var.default_boundary
 }
@@ -49,7 +49,7 @@ data "aws_iam_policy_document" "cloudtrail_role_assume_role_policy" {
 }
 
 resource "aws_iam_role_policy" "cloudtrail" {
-  name   = "ddb-cloudtrail-${var.region}-${var.trail_name_suffix}"
+  name   = "ddb-cloudtrail-${var.region_name}-${var.trail_name_suffix}"
   role   = aws_iam_role.cloudtrail.id
   policy = data.aws_iam_policy_document.cloudtrail_role_policy.json
 }

--- a/terraform/account/modules/dynamodb_cloudtrail/cloudtrail.tf
+++ b/terraform/account/modules/dynamodb_cloudtrail/cloudtrail.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudtrail" "cloudtrail" {
-  name                          = "ddb-cloudtrail-${data.aws_region.current.region}-${var.trail_name_suffix}"
+  name                          = "ddb-cloudtrail-${var.region}-${var.trail_name_suffix}"
   cloud_watch_logs_group_arn    = "${aws_cloudwatch_log_group.cloudtrail.arn}:*"
   cloud_watch_logs_role_arn     = aws_iam_role.cloudtrail.arn
   enable_log_file_validation    = true
@@ -20,13 +20,13 @@ resource "aws_cloudtrail" "cloudtrail" {
 }
 
 resource "aws_cloudwatch_log_group" "cloudtrail" {
-  name              = "ddb-cloudtrail-${data.aws_region.current.region}-${var.trail_name_suffix}"
+  name              = "ddb-cloudtrail-${var.region}-${var.trail_name_suffix}"
   retention_in_days = 90
   kms_key_id        = aws_kms_alias.cloudtrail_log_group_key.target_key_arn
 }
 
 resource "aws_iam_role" "cloudtrail" {
-  name                 = "ddb-cloudtrail-${data.aws_region.current.region}-${var.trail_name_suffix}"
+  name                 = "ddb-cloudtrail-${var.region}-${var.trail_name_suffix}"
   assume_role_policy   = data.aws_iam_policy_document.cloudtrail_role_assume_role_policy.json
   permissions_boundary = var.default_boundary
 }
@@ -49,7 +49,7 @@ data "aws_iam_policy_document" "cloudtrail_role_assume_role_policy" {
 }
 
 resource "aws_iam_role_policy" "cloudtrail" {
-  name   = "ddb-cloudtrail-${data.aws_region.current.region}-${var.trail_name_suffix}"
+  name   = "ddb-cloudtrail-${var.region}-${var.trail_name_suffix}"
   role   = aws_iam_role.cloudtrail.id
   policy = data.aws_iam_policy_document.cloudtrail_role_policy.json
 }

--- a/terraform/account/modules/dynamodb_cloudtrail/kms.tf
+++ b/terraform/account/modules/dynamodb_cloudtrail/kms.tf
@@ -126,7 +126,7 @@ data "aws_iam_policy_document" "cloudtrail_log_group_key" {
     principals {
       type = "Service"
       identifiers = [
-        "logs.${var.region}.amazonaws.com",
+        "logs.${var.region_name}.amazonaws.com",
         "events.amazonaws.com"
       ]
     }

--- a/terraform/account/modules/dynamodb_cloudtrail/kms.tf
+++ b/terraform/account/modules/dynamodb_cloudtrail/kms.tf
@@ -126,7 +126,7 @@ data "aws_iam_policy_document" "cloudtrail_log_group_key" {
     principals {
       type = "Service"
       identifiers = [
-        "logs.${data.aws_region.current.region}.amazonaws.com",
+        "logs.${var.region}.amazonaws.com",
         "events.amazonaws.com"
       ]
     }

--- a/terraform/account/modules/dynamodb_cloudtrail/s3.tf
+++ b/terraform/account/modules/dynamodb_cloudtrail/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "cloudtrail" {
-  bucket = "ddb.cloudtrail.${var.region}.${var.bucket_name_suffix}"
+  bucket = "ddb.cloudtrail.${var.region_name}.${var.bucket_name_suffix}"
 }
 
 resource "aws_s3_bucket_acl" "cloudtrail" {
@@ -10,7 +10,7 @@ resource "aws_s3_bucket_acl" "cloudtrail" {
 resource "aws_s3_bucket_logging" "cloudtrail" {
   bucket        = aws_s3_bucket.cloudtrail.id
   target_bucket = var.s3_access_logging_bucket_name
-  target_prefix = "log/${"ddb-cloudtrail-${var.region}-${var.trail_name_suffix}"}/"
+  target_prefix = "log/${"ddb-cloudtrail-${var.region_name}-${var.trail_name_suffix}"}/"
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "cloudtrail" {

--- a/terraform/account/modules/dynamodb_cloudtrail/s3.tf
+++ b/terraform/account/modules/dynamodb_cloudtrail/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "cloudtrail" {
-  bucket = "ddb.cloudtrail.${data.aws_region.current.region}.${var.bucket_name_suffix}"
+  bucket = "ddb.cloudtrail.${var.region}.${var.bucket_name_suffix}"
 }
 
 resource "aws_s3_bucket_acl" "cloudtrail" {
@@ -10,7 +10,7 @@ resource "aws_s3_bucket_acl" "cloudtrail" {
 resource "aws_s3_bucket_logging" "cloudtrail" {
   bucket        = aws_s3_bucket.cloudtrail.id
   target_bucket = var.s3_access_logging_bucket_name
-  target_prefix = "log/${"ddb-cloudtrail-${data.aws_region.current.region}-${var.trail_name_suffix}"}/"
+  target_prefix = "log/${"ddb-cloudtrail-${var.region}-${var.trail_name_suffix}"}/"
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "cloudtrail" {

--- a/terraform/account/modules/dynamodb_cloudtrail/variables.tf
+++ b/terraform/account/modules/dynamodb_cloudtrail/variables.tf
@@ -26,7 +26,7 @@ variable "default_boundary" {
   type        = string
 }
 
-variable "region" {
+variable "region_name" {
   description = "The AWS region"
   type        = string
 }

--- a/terraform/account/modules/dynamodb_cloudtrail/variables.tf
+++ b/terraform/account/modules/dynamodb_cloudtrail/variables.tf
@@ -26,4 +26,7 @@ variable "default_boundary" {
   type        = string
 }
 
-data "aws_region" "current" {}
+variable "region" {
+  description = "The AWS region"
+  type        = string
+}

--- a/terraform/account/region.tf
+++ b/terraform/account/region.tf
@@ -9,6 +9,8 @@ module "eu_west_1" {
   # lambda_container_version = var.lambda_container_version
   network_cidr_block   = "10.162.0.0/16"
   permitted_s3_buckets = local.account.permitted_s3_buckets
+  region               = "eu-west-1"
+  default_tags         = local.default_tags
 
   depends_on = [
     module.cloudwatch_mrk,
@@ -36,6 +38,8 @@ module "eu_west_2" {
   # lambda_container_version = var.lambda_container_version
   network_cidr_block   = "10.162.0.0/16"
   permitted_s3_buckets = local.account.permitted_s3_buckets
+  region               = "eu-west-2"
+  default_tags         = local.default_tags
 
   depends_on = [
     module.cloudwatch_mrk,

--- a/terraform/account/region.tf
+++ b/terraform/account/region.tf
@@ -9,7 +9,7 @@ module "eu_west_1" {
   # lambda_container_version = var.lambda_container_version
   network_cidr_block   = "10.162.0.0/16"
   permitted_s3_buckets = local.account.permitted_s3_buckets
-  region               = "eu-west-1"
+  region_name          = "eu-west-1"
   default_tags         = local.default_tags
 
   depends_on = [
@@ -38,7 +38,7 @@ module "eu_west_2" {
   # lambda_container_version = var.lambda_container_version
   network_cidr_block   = "10.162.0.0/16"
   permitted_s3_buckets = local.account.permitted_s3_buckets
-  region               = "eu-west-2"
+  region_name          = "eu-west-2"
   default_tags         = local.default_tags
 
   depends_on = [

--- a/terraform/account/region.tf
+++ b/terraform/account/region.tf
@@ -10,6 +10,7 @@ module "eu_west_1" {
   network_cidr_block   = "10.162.0.0/16"
   permitted_s3_buckets = local.account.permitted_s3_buckets
   region_name          = "eu-west-1"
+  availability_zones   = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   default_tags         = local.default_tags
 
   depends_on = [
@@ -39,6 +40,7 @@ module "eu_west_2" {
   network_cidr_block   = "10.162.0.0/16"
   permitted_s3_buckets = local.account.permitted_s3_buckets
   region_name          = "eu-west-2"
+  availability_zones   = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
   default_tags         = local.default_tags
 
   depends_on = [

--- a/terraform/account/region/cloudwatch.tf
+++ b/terraform/account/region/cloudwatch.tf
@@ -64,7 +64,7 @@ data "aws_iam_policy_document" "cloudwatch_kms" {
     principals {
       type = "Service"
       identifiers = [
-        "logs.${data.aws_region.current.region}.amazonaws.com",
+        "logs.${var.region}.amazonaws.com",
         "events.amazonaws.com"
       ]
     }

--- a/terraform/account/region/cloudwatch.tf
+++ b/terraform/account/region/cloudwatch.tf
@@ -64,7 +64,7 @@ data "aws_iam_policy_document" "cloudwatch_kms" {
     principals {
       type = "Service"
       identifiers = [
-        "logs.${var.region}.amazonaws.com",
+        "logs.${var.region_name}.amazonaws.com",
         "events.amazonaws.com"
       ]
     }

--- a/terraform/account/region/data_sources.tf
+++ b/terraform/account/region/data_sources.tf
@@ -1,11 +1,3 @@
-data "aws_default_tags" "current" {
-  provider = aws.region
-}
-
 data "aws_caller_identity" "current" {
-  provider = aws.region
-}
-
-data "aws_region" "current" {
   provider = aws.region
 }

--- a/terraform/account/region/dns_firewall.tf
+++ b/terraform/account/region/dns_firewall.tf
@@ -5,6 +5,8 @@ module "dns_firewall" {
   domains_allowed                            = var.account.dns_firewall.domains_allowed
   domains_blocked                            = var.account.dns_firewall.domains_blocked
   brute_force_cache_primary_endpoint_address = aws_elasticache_replication_group.brute_force_cache_replication_group.primary_endpoint_address
+  region                                     = var.region
+  default_tags                               = var.default_tags
 
   providers = {
     aws.region = aws.region

--- a/terraform/account/region/dns_firewall.tf
+++ b/terraform/account/region/dns_firewall.tf
@@ -5,7 +5,7 @@ module "dns_firewall" {
   domains_allowed                            = var.account.dns_firewall.domains_allowed
   domains_blocked                            = var.account.dns_firewall.domains_blocked
   brute_force_cache_primary_endpoint_address = aws_elasticache_replication_group.brute_force_cache_replication_group.primary_endpoint_address
-  region                                     = var.region
+  region_name                                = var.region_name
   default_tags                               = var.default_tags
 
   providers = {

--- a/terraform/account/region/firewalled_network.tf
+++ b/terraform/account/region/firewalled_network.tf
@@ -36,9 +36,9 @@ resource "aws_networkfirewall_firewall_policy" "main" {
 
 resource "aws_networkfirewall_rule_group" "rule_file" {
   capacity = 100
-  name     = "main-${replace(filebase64sha256("${path.module}/network_firewall_rules_${data.aws_default_tags.current.tags.environment-name}.rules"), "/[^[:alnum:]]/", "")}"
+  name     = "main-${replace(filebase64sha256("${path.module}/network_firewall_rules_${var.default_tags["environment-name"]}.rules"), "/[^[:alnum:]]/", "")}"
   type     = "STATEFUL"
-  rules    = file("${path.module}/network_firewall_rules_${data.aws_default_tags.current.tags.environment-name}.rules")
+  rules    = file("${path.module}/network_firewall_rules_${var.default_tags["environment-name"]}.rules")
   lifecycle {
     create_before_destroy = true
   }
@@ -79,6 +79,7 @@ module "vpc_endpoints" {
   public_subnets_cidr_blocks      = module.network.public_subnets[*].cidr_block
   application_route_tables        = data.aws_route_tables.firewalled_network_application
   permitted_s3_buckets            = var.permitted_s3_buckets
+  region                          = var.region
   providers = {
     aws.region = aws.region
   }

--- a/terraform/account/region/firewalled_network.tf
+++ b/terraform/account/region/firewalled_network.tf
@@ -79,7 +79,7 @@ module "vpc_endpoints" {
   public_subnets_cidr_blocks      = module.network.public_subnets[*].cidr_block
   application_route_tables        = data.aws_route_tables.firewalled_network_application
   permitted_s3_buckets            = var.permitted_s3_buckets
-  region                          = var.region
+  region_name                     = var.region_name
   providers = {
     aws.region = aws.region
   }

--- a/terraform/account/region/firewalled_network.tf
+++ b/terraform/account/region/firewalled_network.tf
@@ -36,9 +36,9 @@ resource "aws_networkfirewall_firewall_policy" "main" {
 
 resource "aws_networkfirewall_rule_group" "rule_file" {
   capacity = 100
-  name     = "main-${replace(filebase64sha256("${path.module}/network_firewall_rules_${var.default_tags["environment-name"]}.rules"), "/[^[:alnum:]]/", "")}"
+  name     = "main-${replace(filebase64sha256("${path.module}/network_firewall_rules_${var.default_tags.environment-name}.rules"), "/[^[:alnum:]]/", "")}"
   type     = "STATEFUL"
-  rules    = file("${path.module}/network_firewall_rules_${var.default_tags["environment-name"]}.rules")
+  rules    = file("${path.module}/network_firewall_rules_${var.default_tags.environment-name}.rules")
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/account/region/firewalled_network.tf
+++ b/terraform/account/region/firewalled_network.tf
@@ -1,5 +1,5 @@
 module "network" {
-  source                              = "github.com/ministryofjustice/opg-terraform-aws-firewalled-network?ref=v1.3.1"
+  source                              = "github.com/ministryofjustice/opg-terraform-aws-firewalled-network?ref=add-region-input"
   cidr                                = var.network_cidr_block
   enable_dns_hostnames                = true
   enable_dns_support                  = true
@@ -11,6 +11,7 @@ module "network" {
     account_id   = var.account.shared_firewall_configuration.account_id
     account_name = var.account.shared_firewall_configuration.account_name
   }
+  aws_region = var.region_name
   providers = {
     aws = aws.region
   }

--- a/terraform/account/region/firewalled_network.tf
+++ b/terraform/account/region/firewalled_network.tf
@@ -1,5 +1,5 @@
 module "network" {
-  source                              = "github.com/ministryofjustice/opg-terraform-aws-firewalled-network?ref=5e887a1ee7e6cdfc52ed3e923cd8951319dd556a"
+  source                              = "github.com/ministryofjustice/opg-terraform-aws-firewalled-network?ref=v1.3.2"
   cidr                                = var.network_cidr_block
   enable_dns_hostnames                = true
   enable_dns_support                  = true

--- a/terraform/account/region/firewalled_network.tf
+++ b/terraform/account/region/firewalled_network.tf
@@ -1,5 +1,5 @@
 module "network" {
-  source                              = "github.com/ministryofjustice/opg-terraform-aws-firewalled-network?ref=add-region-input"
+  source                              = "github.com/ministryofjustice/opg-terraform-aws-firewalled-network?ref=5e887a1ee7e6cdfc52ed3e923cd8951319dd556a"
   cidr                                = var.network_cidr_block
   enable_dns_hostnames                = true
   enable_dns_support                  = true
@@ -11,7 +11,8 @@ module "network" {
     account_id   = var.account.shared_firewall_configuration.account_id
     account_name = var.account.shared_firewall_configuration.account_name
   }
-  aws_region = var.region_name
+  aws_availability_zones = var.availability_zones
+  aws_region             = var.region_name
   providers = {
     aws = aws.region
   }

--- a/terraform/account/region/lambda_functions.tf
+++ b/terraform/account/region/lambda_functions.tf
@@ -11,7 +11,7 @@
 # module "clsf_to_sqs" {
 #   source            = "./modules/lambda_function"
 #   count             = var.account.opg_metrics.enabled ? 1 : 0
-#   lambda_name       = "clsf-to-sqs-${data.aws_region.current.region}"
+#   lambda_name       = "clsf-to-sqs-${var.region}"
 #   working_directory = "/var/task"
 #   environment_variables = {
 #     "QUEUE_URL" : aws_sqs_queue.ship_to_opg_metrics[0].id,
@@ -65,7 +65,7 @@
 # module "ship_to_opg_metrics" {
 #   source            = "./modules/lambda_function"
 #   count             = var.account.opg_metrics.enabled ? 1 : 0
-#   lambda_name       = "ship-to-opg-metrics-${data.aws_region.current.region}"
+#   lambda_name       = "ship-to-opg-metrics-${var.region}"
 #   working_directory = "/var/task"
 #   environment_variables = {
 #     "OPG_METRICS_URL" : var.account.opg_metrics.endpoint_url

--- a/terraform/account/region/lambda_functions.tf
+++ b/terraform/account/region/lambda_functions.tf
@@ -11,7 +11,7 @@
 # module "clsf_to_sqs" {
 #   source            = "./modules/lambda_function"
 #   count             = var.account.opg_metrics.enabled ? 1 : 0
-#   lambda_name       = "clsf-to-sqs-${var.region}"
+#   lambda_name       = "clsf-to-sqs-${var.region_name}"
 #   working_directory = "/var/task"
 #   environment_variables = {
 #     "QUEUE_URL" : aws_sqs_queue.ship_to_opg_metrics[0].id,
@@ -65,7 +65,7 @@
 # module "ship_to_opg_metrics" {
 #   source            = "./modules/lambda_function"
 #   count             = var.account.opg_metrics.enabled ? 1 : 0
-#   lambda_name       = "ship-to-opg-metrics-${var.region}"
+#   lambda_name       = "ship-to-opg-metrics-${var.region_name}"
 #   working_directory = "/var/task"
 #   environment_variables = {
 #     "OPG_METRICS_URL" : var.account.opg_metrics.endpoint_url

--- a/terraform/account/region/modules/dns_firewall/data_sources.tf
+++ b/terraform/account/region/modules/dns_firewall/data_sources.tf
@@ -1,11 +1,3 @@
-data "aws_default_tags" "current" {
-  provider = aws.region
-}
-
-data "aws_region" "current" {
-  provider = aws.region
-}
-
 data "aws_vpc" "default" {
   default  = true
   provider = aws.region
@@ -13,7 +5,7 @@ data "aws_vpc" "default" {
 
 data "aws_service" "services" {
   for_each   = toset(local.service_id)
-  region     = data.aws_region.current.region
+  region     = var.region
   service_id = each.value
 
   provider = aws.region
@@ -22,11 +14,11 @@ data "aws_service" "services" {
 data "aws_vpc" "main" {
   filter {
     name   = "tag:application"
-    values = [data.aws_default_tags.current.tags.application]
+    values = [var.default_tags["application"]]
   }
   filter {
     name   = "tag:Name"
-    values = ["${data.aws_default_tags.current.tags.application}-${data.aws_default_tags.current.tags.environment-name}-vpc"]
+    values = ["${var.default_tags["application"]}-${var.default_tags["environment-name"]}-vpc"]
   }
   provider = aws.region
 }

--- a/terraform/account/region/modules/dns_firewall/data_sources.tf
+++ b/terraform/account/region/modules/dns_firewall/data_sources.tf
@@ -14,11 +14,11 @@ data "aws_service" "services" {
 data "aws_vpc" "main" {
   filter {
     name   = "tag:application"
-    values = [var.default_tags["application"]]
+    values = [var.default_tags.application]
   }
   filter {
     name   = "tag:Name"
-    values = ["${var.default_tags["application"]}-${var.default_tags["environment-name"]}-vpc"]
+    values = ["${var.default_tags.application}-${var.default_tags.environment-name}-vpc"]
   }
   provider = aws.region
 }

--- a/terraform/account/region/modules/dns_firewall/data_sources.tf
+++ b/terraform/account/region/modules/dns_firewall/data_sources.tf
@@ -5,7 +5,7 @@ data "aws_vpc" "default" {
 
 data "aws_service" "services" {
   for_each   = toset(local.service_id)
-  region     = var.region
+  region     = var.region_name
   service_id = each.value
 
   provider = aws.region

--- a/terraform/account/region/modules/dns_firewall/main.tf
+++ b/terraform/account/region/modules/dns_firewall/main.tf
@@ -43,9 +43,9 @@ locals {
   aws_service_dns_name = [for service in data.aws_service.services : "${service.dns_name}."]
   interpolated_dns = [
     "${replace(var.brute_force_cache_primary_endpoint_address, "master", "*")}.",
-    "prod-${data.aws_region.current.region}-starport-layer-bucket.s3.${data.aws_region.current.region}.amazonaws.com.",
-    "public-keys.auth.elb.${data.aws_region.current.region}.amazonaws.com.",
-    "311462405659.dkr.ecr.${data.aws_region.current.region}.amazonaws.com.",
+    "prod-${var.region}-starport-layer-bucket.s3.${var.region}.amazonaws.com.",
+    "public-keys.auth.elb.${var.region}.amazonaws.com.",
+    "311462405659.dkr.ecr.${var.region}.amazonaws.com.",
     "*.ual.internal.ecs.",
   ]
 }

--- a/terraform/account/region/modules/dns_firewall/main.tf
+++ b/terraform/account/region/modules/dns_firewall/main.tf
@@ -43,9 +43,9 @@ locals {
   aws_service_dns_name = [for service in data.aws_service.services : "${service.dns_name}."]
   interpolated_dns = [
     "${replace(var.brute_force_cache_primary_endpoint_address, "master", "*")}.",
-    "prod-${var.region}-starport-layer-bucket.s3.${var.region}.amazonaws.com.",
-    "public-keys.auth.elb.${var.region}.amazonaws.com.",
-    "311462405659.dkr.ecr.${var.region}.amazonaws.com.",
+    "prod-${var.region_name}-starport-layer-bucket.s3.${var.region_name}.amazonaws.com.",
+    "public-keys.auth.elb.${var.region_name}.amazonaws.com.",
+    "311462405659.dkr.ecr.${var.region_name}.amazonaws.com.",
     "*.ual.internal.ecs.",
   ]
 }

--- a/terraform/account/region/modules/dns_firewall/variables.tf
+++ b/terraform/account/region/modules/dns_firewall/variables.tf
@@ -3,6 +3,11 @@ variable "kms_key_arn" {
   type        = string
 }
 
+variable "default_tags" {
+  description = "Default tags to apply to all resources"
+  type        = map(string)
+}
+
 variable "domains_allowed" {
   description = "The domains allowed to be resolved by the DNS server."
   type        = list(string)
@@ -21,5 +26,10 @@ variable "enable_block" {
 
 variable "brute_force_cache_primary_endpoint_address" {
   description = "The primary endpoint address of the Brute Force Cache."
+  type        = string
+}
+
+variable "region" {
+  description = "The aws region"
   type        = string
 }

--- a/terraform/account/region/modules/dns_firewall/variables.tf
+++ b/terraform/account/region/modules/dns_firewall/variables.tf
@@ -3,9 +3,21 @@ variable "kms_key_arn" {
   type        = string
 }
 
+# variable "default_tags" {
+#   description = "Default tags to apply to all resources"
+#   type        = map(string)
+# }
+
 variable "default_tags" {
-  description = "Default tags to apply to all resources"
-  type        = map(string)
+  type = object({
+    business-unit          = string
+    application            = string
+    environment-name       = string
+    owner                  = string
+    is-production          = string
+    service-area           = string
+    infrastructure-support = string
+  })
 }
 
 variable "domains_allowed" {

--- a/terraform/account/region/modules/dns_firewall/variables.tf
+++ b/terraform/account/region/modules/dns_firewall/variables.tf
@@ -41,7 +41,7 @@ variable "brute_force_cache_primary_endpoint_address" {
   type        = string
 }
 
-variable "region" {
+variable "region_name" {
   description = "The aws region"
   type        = string
 }

--- a/terraform/account/region/modules/s3_bucket/data_sources.tf
+++ b/terraform/account/region/modules/s3_bucket/data_sources.tf
@@ -2,8 +2,6 @@ locals {
   access_account_name = var.account_name == "preproduction" ? "preprod" : var.account_name
 }
 
-data "aws_region" "current" {}
-
 data "aws_s3_bucket" "access_logging" {
-  bucket = "s3-access-logs-opg-opg-use-an-lpa-${local.access_account_name}-${data.aws_region.current.region}"
+  bucket = "s3-access-logs-opg-opg-use-an-lpa-${local.access_account_name}-${var.region}"
 }

--- a/terraform/account/region/modules/s3_bucket/data_sources.tf
+++ b/terraform/account/region/modules/s3_bucket/data_sources.tf
@@ -3,5 +3,5 @@ locals {
 }
 
 data "aws_s3_bucket" "access_logging" {
-  bucket = "s3-access-logs-opg-opg-use-an-lpa-${local.access_account_name}-${var.region}"
+  bucket = "s3-access-logs-opg-opg-use-an-lpa-${local.access_account_name}-${var.region_name}"
 }

--- a/terraform/account/region/modules/s3_bucket/variables.tf
+++ b/terraform/account/region/modules/s3_bucket/variables.tf
@@ -73,3 +73,8 @@ variable "object_ownership" {
     error_message = "object_ownership must be either BucketOwnerPreferred or ObjectWriter"
   }
 }
+
+variable "region" {
+  description = "The aws region"
+  type        = string
+}

--- a/terraform/account/region/modules/s3_bucket/variables.tf
+++ b/terraform/account/region/modules/s3_bucket/variables.tf
@@ -74,7 +74,7 @@ variable "object_ownership" {
   }
 }
 
-variable "region" {
+variable "region_name" {
   description = "The aws region"
   type        = string
 }

--- a/terraform/account/region/modules/vpc_endpoints/data_sources.tf
+++ b/terraform/account/region/modules/vpc_endpoints/data_sources.tf
@@ -1,7 +1,3 @@
-data "aws_region" "current" {
-  provider = aws.region
-}
-
 data "aws_caller_identity" "current" {
   provider = aws.region
 }

--- a/terraform/account/region/modules/vpc_endpoints/main.tf
+++ b/terraform/account/region/modules/vpc_endpoints/main.tf
@@ -14,7 +14,7 @@ resource "aws_security_group_rule" "vpc_endpoints_private_subnet_ingress" {
   security_group_id = aws_security_group.vpc_endpoints_private.id
   type              = "ingress"
   cidr_blocks       = var.application_subnets_cidr_blocks
-  description       = "Allow Services in Private Subnets of ${data.aws_region.current.region} to connect to VPC Interface Endpoints"
+  description       = "Allow Services in Private Subnets of ${var.region} to connect to VPC Interface Endpoints"
 }
 
 resource "aws_security_group_rule" "vpc_endpoints_public_subnet_ingress" {
@@ -25,7 +25,7 @@ resource "aws_security_group_rule" "vpc_endpoints_public_subnet_ingress" {
   security_group_id = aws_security_group.vpc_endpoints_private.id
   type              = "ingress"
   cidr_blocks       = var.public_subnets_cidr_blocks
-  description       = "Allow Services in Public Subnets of ${data.aws_region.current.region} to connect to VPC Interface Endpoints"
+  description       = "Allow Services in Public Subnets of ${var.region} to connect to VPC Interface Endpoints"
 }
 
 locals {
@@ -37,7 +37,7 @@ resource "aws_vpc_endpoint" "private" {
   for_each = local.interface_endpoint
 
   vpc_id              = var.vpc_id
-  service_name        = "com.amazonaws.${data.aws_region.current.region}.${each.value}"
+  service_name        = "com.amazonaws.${var.region}.${each.value}"
   vpc_endpoint_type   = "Interface"
   private_dns_enabled = true
   security_group_ids  = aws_security_group.vpc_endpoints_private[*].id
@@ -71,7 +71,7 @@ resource "aws_vpc_endpoint_policy" "private" {
 resource "aws_vpc_endpoint" "s3" {
   provider          = aws.region
   vpc_id            = var.vpc_id
-  service_name      = "com.amazonaws.${data.aws_region.current.region}.s3"
+  service_name      = "com.amazonaws.${var.region}.s3"
   route_table_ids   = tolist(var.application_route_tables.ids)
   vpc_endpoint_type = "Gateway"
   policy            = data.aws_iam_policy_document.s3.json
@@ -81,7 +81,7 @@ resource "aws_vpc_endpoint" "s3" {
 resource "aws_vpc_endpoint" "dynamodb" {
   provider          = aws.region
   vpc_id            = var.vpc_id
-  service_name      = "com.amazonaws.${data.aws_region.current.region}.dynamodb"
+  service_name      = "com.amazonaws.${var.region}.dynamodb"
   route_table_ids   = tolist(var.application_route_tables.ids)
   vpc_endpoint_type = "Gateway"
   policy            = data.aws_iam_policy_document.allow_account_access.json
@@ -122,7 +122,7 @@ data "aws_iam_policy_document" "s3_bucket_access" {
     effect  = "Allow"
     actions = ["s3:GetObject"]
     resources = concat([
-      "arn:aws:s3:::prod-${data.aws_region.current.region}-starport-layer-bucket/*",
+      "arn:aws:s3:::prod-${var.region}-starport-layer-bucket/*",
 
     ], var.permitted_s3_buckets)
     principals {

--- a/terraform/account/region/modules/vpc_endpoints/main.tf
+++ b/terraform/account/region/modules/vpc_endpoints/main.tf
@@ -14,7 +14,7 @@ resource "aws_security_group_rule" "vpc_endpoints_private_subnet_ingress" {
   security_group_id = aws_security_group.vpc_endpoints_private.id
   type              = "ingress"
   cidr_blocks       = var.application_subnets_cidr_blocks
-  description       = "Allow Services in Private Subnets of ${var.region} to connect to VPC Interface Endpoints"
+  description       = "Allow Services in Private Subnets of ${var.region_name} to connect to VPC Interface Endpoints"
 }
 
 resource "aws_security_group_rule" "vpc_endpoints_public_subnet_ingress" {
@@ -25,7 +25,7 @@ resource "aws_security_group_rule" "vpc_endpoints_public_subnet_ingress" {
   security_group_id = aws_security_group.vpc_endpoints_private.id
   type              = "ingress"
   cidr_blocks       = var.public_subnets_cidr_blocks
-  description       = "Allow Services in Public Subnets of ${var.region} to connect to VPC Interface Endpoints"
+  description       = "Allow Services in Public Subnets of ${var.region_name} to connect to VPC Interface Endpoints"
 }
 
 locals {
@@ -37,7 +37,7 @@ resource "aws_vpc_endpoint" "private" {
   for_each = local.interface_endpoint
 
   vpc_id              = var.vpc_id
-  service_name        = "com.amazonaws.${var.region}.${each.value}"
+  service_name        = "com.amazonaws.${var.region_name}.${each.value}"
   vpc_endpoint_type   = "Interface"
   private_dns_enabled = true
   security_group_ids  = aws_security_group.vpc_endpoints_private[*].id
@@ -71,7 +71,7 @@ resource "aws_vpc_endpoint_policy" "private" {
 resource "aws_vpc_endpoint" "s3" {
   provider          = aws.region
   vpc_id            = var.vpc_id
-  service_name      = "com.amazonaws.${var.region}.s3"
+  service_name      = "com.amazonaws.${var.region_name}.s3"
   route_table_ids   = tolist(var.application_route_tables.ids)
   vpc_endpoint_type = "Gateway"
   policy            = data.aws_iam_policy_document.s3.json
@@ -81,7 +81,7 @@ resource "aws_vpc_endpoint" "s3" {
 resource "aws_vpc_endpoint" "dynamodb" {
   provider          = aws.region
   vpc_id            = var.vpc_id
-  service_name      = "com.amazonaws.${var.region}.dynamodb"
+  service_name      = "com.amazonaws.${var.region_name}.dynamodb"
   route_table_ids   = tolist(var.application_route_tables.ids)
   vpc_endpoint_type = "Gateway"
   policy            = data.aws_iam_policy_document.allow_account_access.json
@@ -122,7 +122,7 @@ data "aws_iam_policy_document" "s3_bucket_access" {
     effect  = "Allow"
     actions = ["s3:GetObject"]
     resources = concat([
-      "arn:aws:s3:::prod-${var.region}-starport-layer-bucket/*",
+      "arn:aws:s3:::prod-${var.region_name}-starport-layer-bucket/*",
 
     ], var.permitted_s3_buckets)
     principals {

--- a/terraform/account/region/modules/vpc_endpoints/variables.tf
+++ b/terraform/account/region/modules/vpc_endpoints/variables.tf
@@ -32,3 +32,8 @@ variable "permitted_s3_buckets" {
   default     = []
   description = "S3 buckets permitted through the S3 VPC endpoint"
 }
+
+variable "region" {
+  description = "The aws region"
+  type        = string
+}

--- a/terraform/account/region/modules/vpc_endpoints/variables.tf
+++ b/terraform/account/region/modules/vpc_endpoints/variables.tf
@@ -33,7 +33,7 @@ variable "permitted_s3_buckets" {
   description = "S3 buckets permitted through the S3 VPC endpoint"
 }
 
-variable "region" {
+variable "region_name" {
   description = "The aws region"
   type        = string
 }

--- a/terraform/account/region/resource_group.tf
+++ b/terraform/account/region/resource_group.tf
@@ -1,5 +1,5 @@
 resource "aws_resourcegroups_group" "account" {
-  name        = "${data.aws_default_tags.current.tags.environment-name}-account-${data.aws_region.current.region}"
+  name        = "${var.default_tags["environment-name"]}-account-${var.region}"
   description = "Environment level eu-west-1 resources"
 
   resource_query {
@@ -17,7 +17,7 @@ locals {
     TagFilters = [
       {
         Key    = "environment-name",
-        Values = [data.aws_default_tags.current.tags.environment-name]
+        Values = [var.default_tags["environment-name"]]
       }
     ]
   })

--- a/terraform/account/region/resource_group.tf
+++ b/terraform/account/region/resource_group.tf
@@ -1,5 +1,5 @@
 resource "aws_resourcegroups_group" "account" {
-  name        = "${var.default_tags.environment-name}-account-${var.region}"
+  name        = "${var.default_tags.environment-name}-account-${var.region_name}"
   description = "Environment level eu-west-1 resources"
 
   resource_query {

--- a/terraform/account/region/resource_group.tf
+++ b/terraform/account/region/resource_group.tf
@@ -1,5 +1,5 @@
 resource "aws_resourcegroups_group" "account" {
-  name        = "${var.default_tags["environment-name"]}-account-${var.region}"
+  name        = "${var.default_tags.environment-name}-account-${var.region}"
   description = "Environment level eu-west-1 resources"
 
   resource_query {
@@ -17,7 +17,7 @@ locals {
     TagFilters = [
       {
         Key    = "environment-name",
-        Values = [var.default_tags["environment-name"]]
+        Values = [var.default_tags.environment-name]
       }
     ]
   })

--- a/terraform/account/region/s3_lb_access_logs.tf
+++ b/terraform/account/region/s3_lb_access_logs.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "access_log" {
-  bucket = "opg-ual-${var.environment_name}-lb-access-logs-${data.aws_region.current.region}"
+  bucket = "opg-ual-${var.environment_name}-lb-access-logs-${var.region}"
 
   provider = aws.region
 }
@@ -36,7 +36,7 @@ resource "aws_s3_bucket_versioning" "access_log" {
 }
 
 data "aws_s3_bucket" "s3_access_logging" {
-  bucket = "${var.account.s3_access_log_bucket_name}-${data.aws_region.current.region}"
+  bucket = "${var.account.s3_access_log_bucket_name}-${var.region}"
 
   provider = aws.region
 }
@@ -58,7 +58,7 @@ resource "aws_s3_bucket_policy" "access_log" {
 }
 
 data "aws_elb_service_account" "main" {
-  region = data.aws_region.current.region
+  region = var.region
 
   provider = aws.region
 }
@@ -163,14 +163,14 @@ resource "aws_s3_bucket_public_access_block" "access_log" {
 # Old version of the access log bucket. The new version is suffixed with the region name. We're keeping this around for a while to ensure we don't lose any logs.
 # TODO: Remove all of these resources after 400 days (the retention period for the logs)
 resource "aws_s3_bucket" "old_access_log" {
-  count  = data.aws_region.current.region == "eu-west-1" ? 1 : 0
+  count  = var.region == "eu-west-1" ? 1 : 0
   bucket = "opg-ual-${var.environment_name}-lb-access-logs"
 
   provider = aws.region
 }
 
 resource "aws_s3_bucket_public_access_block" "old_access_log" {
-  count = data.aws_region.current.region == "eu-west-1" ? 1 : 0
+  count = var.region == "eu-west-1" ? 1 : 0
 
   bucket                  = aws_s3_bucket.old_access_log[0].id
   block_public_acls       = true
@@ -182,7 +182,7 @@ resource "aws_s3_bucket_public_access_block" "old_access_log" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "old_access_log" {
-  count = data.aws_region.current.region == "eu-west-1" ? 1 : 0
+  count = var.region == "eu-west-1" ? 1 : 0
 
   bucket = aws_s3_bucket.old_access_log[0].id
 
@@ -194,7 +194,7 @@ resource "aws_s3_bucket_ownership_controls" "old_access_log" {
 }
 
 resource "aws_s3_bucket_acl" "old_access_log" {
-  count = data.aws_region.current.region == "eu-west-1" ? 1 : 0
+  count = var.region == "eu-west-1" ? 1 : 0
 
   bucket = aws_s3_bucket.old_access_log[0].id
   acl    = "private"

--- a/terraform/account/region/s3_lb_access_logs.tf
+++ b/terraform/account/region/s3_lb_access_logs.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "access_log" {
-  bucket = "opg-ual-${var.environment_name}-lb-access-logs-${var.region}"
+  bucket = "opg-ual-${var.environment_name}-lb-access-logs-${var.region_name}"
 
   provider = aws.region
 }
@@ -36,7 +36,7 @@ resource "aws_s3_bucket_versioning" "access_log" {
 }
 
 data "aws_s3_bucket" "s3_access_logging" {
-  bucket = "${var.account.s3_access_log_bucket_name}-${var.region}"
+  bucket = "${var.account.s3_access_log_bucket_name}-${var.region_name}"
 
   provider = aws.region
 }
@@ -58,7 +58,7 @@ resource "aws_s3_bucket_policy" "access_log" {
 }
 
 data "aws_elb_service_account" "main" {
-  region = var.region
+  region = var.region_name
 
   provider = aws.region
 }
@@ -163,14 +163,14 @@ resource "aws_s3_bucket_public_access_block" "access_log" {
 # Old version of the access log bucket. The new version is suffixed with the region name. We're keeping this around for a while to ensure we don't lose any logs.
 # TODO: Remove all of these resources after 400 days (the retention period for the logs)
 resource "aws_s3_bucket" "old_access_log" {
-  count  = var.region == "eu-west-1" ? 1 : 0
+  count  = var.region_name == "eu-west-1" ? 1 : 0
   bucket = "opg-ual-${var.environment_name}-lb-access-logs"
 
   provider = aws.region
 }
 
 resource "aws_s3_bucket_public_access_block" "old_access_log" {
-  count = var.region == "eu-west-1" ? 1 : 0
+  count = var.region_name == "eu-west-1" ? 1 : 0
 
   bucket                  = aws_s3_bucket.old_access_log[0].id
   block_public_acls       = true
@@ -182,7 +182,7 @@ resource "aws_s3_bucket_public_access_block" "old_access_log" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "old_access_log" {
-  count = var.region == "eu-west-1" ? 1 : 0
+  count = var.region_name == "eu-west-1" ? 1 : 0
 
   bucket = aws_s3_bucket.old_access_log[0].id
 
@@ -194,7 +194,7 @@ resource "aws_s3_bucket_ownership_controls" "old_access_log" {
 }
 
 resource "aws_s3_bucket_acl" "old_access_log" {
-  count = var.region == "eu-west-1" ? 1 : 0
+  count = var.region_name == "eu-west-1" ? 1 : 0
 
   bucket = aws_s3_bucket.old_access_log[0].id
   acl    = "private"

--- a/terraform/account/region/s3_redacted_logs.tf
+++ b/terraform/account/region/s3_redacted_logs.tf
@@ -1,10 +1,11 @@
 module "redacted-logs" {
   source          = "./modules/s3_bucket"
   account_name    = var.environment_name
-  bucket_name     = "opg-use-an-lpa-redacted-logs-${var.environment_name}-${data.aws_region.current.region}"
+  bucket_name     = "opg-use-an-lpa-redacted-logs-${var.environment_name}-${var.region}"
   expiration_days = 400 # Log Retention is 13 Months/400 Days as Policy
   force_destroy   = false
   kms_key         = aws_kms_key.redacted_s3
+  region          = var.region
 
   providers = {
     aws.region = aws.region

--- a/terraform/account/region/s3_redacted_logs.tf
+++ b/terraform/account/region/s3_redacted_logs.tf
@@ -1,11 +1,11 @@
 module "redacted-logs" {
   source          = "./modules/s3_bucket"
   account_name    = var.environment_name
-  bucket_name     = "opg-use-an-lpa-redacted-logs-${var.environment_name}-${var.region}"
+  bucket_name     = "opg-use-an-lpa-redacted-logs-${var.environment_name}-${var.region_name}"
   expiration_days = 400 # Log Retention is 13 Months/400 Days as Policy
   force_destroy   = false
   kms_key         = aws_kms_key.redacted_s3
-  region          = var.region
+  region_name     = var.region_name
 
   providers = {
     aws.region = aws.region

--- a/terraform/account/region/securityhub.tf
+++ b/terraform/account/region/securityhub.tf
@@ -5,7 +5,7 @@ resource "aws_ebs_snapshot_block_public_access" "this" {
 }
 
 resource "aws_ssm_service_setting" "public_sharing_permission" {
-  setting_id    = "arn:aws:ssm:${var.region}:${var.account.account_id}:servicesetting/ssm/documents/console/public-sharing-permission"
+  setting_id    = "arn:aws:ssm:${var.region_name}:${var.account.account_id}:servicesetting/ssm/documents/console/public-sharing-permission"
   setting_value = "Disable"
 
   provider = aws.region

--- a/terraform/account/region/securityhub.tf
+++ b/terraform/account/region/securityhub.tf
@@ -5,7 +5,7 @@ resource "aws_ebs_snapshot_block_public_access" "this" {
 }
 
 resource "aws_ssm_service_setting" "public_sharing_permission" {
-  setting_id    = "arn:aws:ssm:${data.aws_region.current.region}:${var.account.account_id}:servicesetting/ssm/documents/console/public-sharing-permission"
+  setting_id    = "arn:aws:ssm:${var.region}:${var.account.account_id}:servicesetting/ssm/documents/console/public-sharing-permission"
   setting_value = "Disable"
 
   provider = aws.region

--- a/terraform/account/region/variables.tf
+++ b/terraform/account/region/variables.tf
@@ -36,6 +36,11 @@ variable "account_name" {
   type        = string
 }
 
+variable "default_tags" {
+  description = "default tags to apply to all resources"
+  type        = map(string)
+}
+
 variable "environment_name" {
   description = "The environment name"
   type        = string
@@ -55,4 +60,9 @@ variable "permitted_s3_buckets" {
   type        = list(string)
   default     = []
   description = "S3 buckets permitted through the S3 VPC endpoint"
+}
+
+variable "region" {
+  description = "The aws region"
+  type        = string
 }

--- a/terraform/account/region/variables.tf
+++ b/terraform/account/region/variables.tf
@@ -74,7 +74,7 @@ variable "permitted_s3_buckets" {
   description = "S3 buckets permitted through the S3 VPC endpoint"
 }
 
-variable "region" {
+variable "region_name" {
   description = "The aws region"
   type        = string
 }

--- a/terraform/account/region/variables.tf
+++ b/terraform/account/region/variables.tf
@@ -36,9 +36,21 @@ variable "account_name" {
   type        = string
 }
 
+# variable "default_tags" {
+#   description = "default tags to apply to all resources"
+#   type        = map(string)
+# }
+
 variable "default_tags" {
-  description = "default tags to apply to all resources"
-  type        = map(string)
+  type = object({
+    business-unit          = string
+    application            = string
+    environment-name       = string
+    owner                  = string
+    is-production          = string
+    service-area           = string
+    infrastructure-support = string
+  })
 }
 
 variable "environment_name" {

--- a/terraform/account/region/variables.tf
+++ b/terraform/account/region/variables.tf
@@ -78,3 +78,8 @@ variable "region_name" {
   description = "The aws region"
   type        = string
 }
+
+variable "availability_zones" {
+  description = "List of availability zones to use for the regional network"
+  type        = list(string)
+}

--- a/terraform/account/region/variables.tf
+++ b/terraform/account/region/variables.tf
@@ -36,21 +36,9 @@ variable "account_name" {
   type        = string
 }
 
-# variable "default_tags" {
-#   description = "default tags to apply to all resources"
-#   type        = map(string)
-# }
-
 variable "default_tags" {
-  type = object({
-    business-unit          = string
-    application            = string
-    environment-name       = string
-    owner                  = string
-    is-production          = string
-    service-area           = string
-    infrastructure-support = string
-  })
+  description = "default tags to apply to all resources"
+  type        = map(string)
 }
 
 variable "environment_name" {

--- a/terraform/account/region/waf.tf
+++ b/terraform/account/region/waf.tf
@@ -325,7 +325,7 @@ data "aws_iam_policy_document" "waf_cloudwatch_log_encryption_kms" {
     principals {
       type = "Service"
       identifiers = [
-        "logs.${data.aws_region.current.region}.amazonaws.com",
+        "logs.${var.region}.amazonaws.com",
         "events.amazonaws.com"
       ]
     }

--- a/terraform/account/region/waf.tf
+++ b/terraform/account/region/waf.tf
@@ -325,7 +325,7 @@ data "aws_iam_policy_document" "waf_cloudwatch_log_encryption_kms" {
     principals {
       type = "Service"
       identifiers = [
-        "logs.${var.region}.amazonaws.com",
+        "logs.${var.region_name}.amazonaws.com",
         "events.amazonaws.com"
       ]
     }

--- a/terraform/environment/backups.tf
+++ b/terraform/environment/backups.tf
@@ -11,7 +11,7 @@ module "dynamodb_backup" {
   key_alias                     = data.aws_kms_alias.backup_key_alias.name
   monthly_backup_cold_storage   = local.environment.dynamodb_backups.monthly_cold_storage_in_days
   monthly_backup_deletion       = local.environment.dynamodb_backups.monthly_backup_deletion_in_days
-  region                        = local.region
+  region_name                   = local.region
   region_replication_enabled    = local.environment.dynamodb_backups.region_replication_enabled
   vault_lock_min_retention_days = local.environment.dynamodb_backups.vault_lock_min_retention_days
   vault_lock_max_retention_days = local.environment.dynamodb_backups.vault_lock_max_retention_days

--- a/terraform/environment/backups.tf
+++ b/terraform/environment/backups.tf
@@ -11,6 +11,7 @@ module "dynamodb_backup" {
   key_alias                     = data.aws_kms_alias.backup_key_alias.name
   monthly_backup_cold_storage   = local.environment.dynamodb_backups.monthly_cold_storage_in_days
   monthly_backup_deletion       = local.environment.dynamodb_backups.monthly_backup_deletion_in_days
+  region                        = local.region
   region_replication_enabled    = local.environment.dynamodb_backups.region_replication_enabled
   vault_lock_min_retention_days = local.environment.dynamodb_backups.vault_lock_min_retention_days
   vault_lock_max_retention_days = local.environment.dynamodb_backups.vault_lock_max_retention_days

--- a/terraform/environment/lambda.tf
+++ b/terraform/environment/lambda.tf
@@ -4,7 +4,7 @@ module "lambda_update_statistics" {
   lambda_name = "update-statistics"
   environment_variables = {
     ENVIRONMENT = local.environment_name
-    REGION      = data.aws_region.current.region
+    REGION      = local.region
   }
   image_uri        = "${data.aws_ecr_repository.use_an_lpa_upload_statistics.repository_url}:${var.container_version}"
   ecr_arn          = data.aws_ecr_repository.use_an_lpa_upload_statistics.arn
@@ -108,7 +108,7 @@ module "event_receiver" {
   lambda_name = "event-receiver"
   environment_variables = {
     ENVIRONMENT              = local.environment_name
-    REGION                   = data.aws_region.current.region
+    REGION                   = local.region
     USER_LPA_ACTOR_MAP_TABLE = "${local.environment_name}-UserLpaActorMap"
     ACTOR_USERS_TABLE        = "${local.environment_name}-ActorUsers"
   }

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -11,6 +11,7 @@ locals {
     environment-name = local.environment_name
     owner            = "Sarah Mills: sarah.mills@digital.justice.gov.uk"
     is-production    = local.environment.is_production
+    service-area     = "POAS"
   }
 
   optional_tags = {

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -3,6 +3,7 @@ locals {
   environment       = contains(keys(var.environments), local.environment_name) ? var.environments[local.environment_name] : var.environments["default"]
   dns_namespace_env = local.environment.account_name == "production" ? "" : "${local.environment_name}."
   capacity_provider = local.environment.fargate_spot ? "FARGATE_SPOT" : "FARGATE"
+  region            = data.aws_region.current.region
 
   mandatory_moj_tags = {
     business-unit    = "OPG"

--- a/terraform/environment/modules/dynamodb_backup/data_sources.tf
+++ b/terraform/environment/modules/dynamodb_backup/data_sources.tf
@@ -5,7 +5,7 @@ data "aws_caller_identity" "backup" {
 }
 
 data "aws_kms_key" "source_key" {
-  key_id = "arn:aws:kms:${var.region}:${data.aws_caller_identity.current.account_id}:${var.key_alias}"
+  key_id = "arn:aws:kms:${var.region_name}:${data.aws_caller_identity.current.account_id}:${var.key_alias}"
 }
 
 data "aws_kms_key" "source_key_replica" {
@@ -14,6 +14,6 @@ data "aws_kms_key" "source_key_replica" {
 }
 
 data "aws_kms_key" "cross_account_key" {
-  key_id   = "arn:aws:kms:${var.region}:${data.aws_caller_identity.backup.account_id}:alias/opg-use-an-lpa-${var.account_name}-aws-backup-key"
+  key_id   = "arn:aws:kms:${var.region_name}:${data.aws_caller_identity.backup.account_id}:alias/opg-use-an-lpa-${var.account_name}-aws-backup-key"
   provider = aws.backup
 }

--- a/terraform/environment/modules/dynamodb_backup/data_sources.tf
+++ b/terraform/environment/modules/dynamodb_backup/data_sources.tf
@@ -4,10 +4,8 @@ data "aws_caller_identity" "backup" {
   provider = aws.backup
 }
 
-data "aws_region" "current" {}
-
 data "aws_kms_key" "source_key" {
-  key_id = "arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:${var.key_alias}"
+  key_id = "arn:aws:kms:${var.region}:${data.aws_caller_identity.current.account_id}:${var.key_alias}"
 }
 
 data "aws_kms_key" "source_key_replica" {
@@ -16,6 +14,6 @@ data "aws_kms_key" "source_key_replica" {
 }
 
 data "aws_kms_key" "cross_account_key" {
-  key_id   = "arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.backup.account_id}:alias/opg-use-an-lpa-${var.account_name}-aws-backup-key"
+  key_id   = "arn:aws:kms:${var.region}:${data.aws_caller_identity.backup.account_id}:alias/opg-use-an-lpa-${var.account_name}-aws-backup-key"
   provider = aws.backup
 }

--- a/terraform/environment/modules/dynamodb_backup/variables.tf
+++ b/terraform/environment/modules/dynamodb_backup/variables.tf
@@ -97,7 +97,7 @@ variable "vault_lock_max_retention_days" {
   }
 }
 
-variable "region" {
+variable "region_name" {
   description = "The AWS region"
   type        = string
 }

--- a/terraform/environment/modules/dynamodb_backup/variables.tf
+++ b/terraform/environment/modules/dynamodb_backup/variables.tf
@@ -96,3 +96,8 @@ variable "vault_lock_max_retention_days" {
     error_message = "When enable_vault_lock is true, vault_lock_max_retention_days must be at least as large as daily_backup_deletion and monthly_backup_deletion, otherwise backup jobs would request a retention above the vault ceiling and fail."
   }
 }
+
+variable "region" {
+  description = "The AWS region"
+  type        = string
+}

--- a/terraform/environment/modules/dynamodb_backup/vault.tf
+++ b/terraform/environment/modules/dynamodb_backup/vault.tf
@@ -1,5 +1,5 @@
 resource "aws_backup_vault" "primary" {
-  name        = "${var.environment_name}_${var.region}_dynamodb_vault"
+  name        = "${var.environment_name}_${var.region_name}_dynamodb_vault"
   kms_key_arn = data.aws_kms_key.source_key.arn
 }
 
@@ -11,7 +11,7 @@ resource "aws_backup_vault" "replica" {
 }
 
 resource "aws_backup_vault" "cross_account" {
-  name        = "opg_use_an_lpa_${var.environment_name}_${var.region}_backup"
+  name        = "opg_use_an_lpa_${var.environment_name}_${var.region_name}_backup"
   kms_key_arn = data.aws_kms_key.cross_account_key.arn
   provider    = aws.backup
 }

--- a/terraform/environment/modules/dynamodb_backup/vault.tf
+++ b/terraform/environment/modules/dynamodb_backup/vault.tf
@@ -1,5 +1,5 @@
 resource "aws_backup_vault" "primary" {
-  name        = "${var.environment_name}_${data.aws_region.current.region}_dynamodb_vault"
+  name        = "${var.environment_name}_${var.region}_dynamodb_vault"
   kms_key_arn = data.aws_kms_key.source_key.arn
 }
 
@@ -11,7 +11,7 @@ resource "aws_backup_vault" "replica" {
 }
 
 resource "aws_backup_vault" "cross_account" {
-  name        = "opg_use_an_lpa_${var.environment_name}_${data.aws_region.current.region}_backup"
+  name        = "opg_use_an_lpa_${var.environment_name}_${var.region}_backup"
   kms_key_arn = data.aws_kms_key.cross_account_key.arn
   provider    = aws.backup
 }

--- a/terraform/environment/region.tf
+++ b/terraform/environment/region.tf
@@ -45,7 +45,7 @@ module "eu_west_1" {
   pagerduty_service_id                             = local.environment.pagerduty_service_id
   public_access_enabled                            = var.public_access_enabled
   regions                                          = local.environment.regions
-  region                                           = "eu-west-1"
+  region_name                                      = "eu-west-1"
   default_tags                                     = local.default_tags
   session_expires_use                              = local.environment.session_expires_use
   session_expires_view                             = local.environment.session_expires_view
@@ -137,7 +137,7 @@ module "eu_west_2" {
   pagerduty_service_id                             = local.environment.pagerduty_service_id
   public_access_enabled                            = var.public_access_enabled
   regions                                          = local.environment.regions
-  region                                           = "eu-west-2"
+  region_name                                      = "eu-west-2"
   default_tags                                     = local.default_tags
   session_expires_use                              = local.environment.session_expires_use
   session_expires_view                             = local.environment.session_expires_view

--- a/terraform/environment/region.tf
+++ b/terraform/environment/region.tf
@@ -45,6 +45,8 @@ module "eu_west_1" {
   pagerduty_service_id                             = local.environment.pagerduty_service_id
   public_access_enabled                            = var.public_access_enabled
   regions                                          = local.environment.regions
+  region                                           = "eu-west-1"
+  default_tags                                     = local.default_tags
   session_expires_use                              = local.environment.session_expires_use
   session_expires_view                             = local.environment.session_expires_view
   session_expiry_warning                           = local.environment.session_expiry_warning
@@ -135,6 +137,8 @@ module "eu_west_2" {
   pagerduty_service_id                             = local.environment.pagerduty_service_id
   public_access_enabled                            = var.public_access_enabled
   regions                                          = local.environment.regions
+  region                                           = "eu-west-2"
+  default_tags                                     = local.default_tags
   session_expires_use                              = local.environment.session_expires_use
   session_expires_view                             = local.environment.session_expires_view
   session_expiry_warning                           = local.environment.session_expiry_warning

--- a/terraform/environment/region/admin_ecs.tf
+++ b/terraform/environment/region/admin_ecs.tf
@@ -192,7 +192,7 @@ data "aws_iam_policy_document" "admin_permissions_role" {
     ]
 
     resources = [
-      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/GET/use-an-lpa/*",
+      "arn:aws:execute-api:${var.region_name}:${var.sirius_account_id}:*/*/GET/use-an-lpa/*",
     ]
   }
 
@@ -203,9 +203,9 @@ data "aws_iam_policy_document" "admin_permissions_role" {
       "execute-api:Invoke",
     ]
     resources = [
-      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/GET/healthcheck",
-      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/POST/exists",
-      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/POST/code",
+      "arn:aws:execute-api:${var.region_name}:${var.sirius_account_id}:*/*/GET/healthcheck",
+      "arn:aws:execute-api:${var.region_name}:${var.sirius_account_id}:*/*/POST/exists",
+      "arn:aws:execute-api:${var.region_name}:${var.sirius_account_id}:*/*/POST/code",
     ]
   }
 
@@ -261,7 +261,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = var.region,
+          awslogs-region        = var.region_name,
           awslogs-stream-prefix = "${var.environment_name}.admin-app.use-an-lpa"
         }
       },
@@ -284,7 +284,7 @@ locals {
         },
         {
           name  = "ADMIN_JWT_SIGNING_KEY_URL",
-          value = "https://public-keys.auth.elb.${var.region}.amazonaws.com"
+          value = "https://public-keys.auth.elb.${var.region_name}.amazonaws.com"
         },
         {
           name  = "ADMIN_CLIENT_ID",

--- a/terraform/environment/region/admin_ecs.tf
+++ b/terraform/environment/region/admin_ecs.tf
@@ -192,7 +192,7 @@ data "aws_iam_policy_document" "admin_permissions_role" {
     ]
 
     resources = [
-      "arn:aws:execute-api:${data.aws_region.current.region}:${var.sirius_account_id}:*/*/GET/use-an-lpa/*",
+      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/GET/use-an-lpa/*",
     ]
   }
 
@@ -203,9 +203,9 @@ data "aws_iam_policy_document" "admin_permissions_role" {
       "execute-api:Invoke",
     ]
     resources = [
-      "arn:aws:execute-api:${data.aws_region.current.region}:${var.sirius_account_id}:*/*/GET/healthcheck",
-      "arn:aws:execute-api:${data.aws_region.current.region}:${var.sirius_account_id}:*/*/POST/exists",
-      "arn:aws:execute-api:${data.aws_region.current.region}:${var.sirius_account_id}:*/*/POST/code",
+      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/GET/healthcheck",
+      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/POST/exists",
+      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/POST/code",
     ]
   }
 
@@ -261,7 +261,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = data.aws_region.current.region,
+          awslogs-region        = var.region,
           awslogs-stream-prefix = "${var.environment_name}.admin-app.use-an-lpa"
         }
       },
@@ -284,7 +284,7 @@ locals {
         },
         {
           name  = "ADMIN_JWT_SIGNING_KEY_URL",
-          value = "https://public-keys.auth.elb.${data.aws_region.current.region}.amazonaws.com"
+          value = "https://public-keys.auth.elb.${var.region}.amazonaws.com"
         },
         {
           name  = "ADMIN_CLIENT_ID",

--- a/terraform/environment/region/api_ecs.tf
+++ b/terraform/environment/region/api_ecs.tf
@@ -240,8 +240,8 @@ data "aws_iam_policy_document" "api_permissions_role" {
     ]
 
     resources = [
-      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/GET/use-an-lpa/*",
-      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/POST/use-an-lpa/lpas/requestCode"
+      "arn:aws:execute-api:${var.region_name}:${var.sirius_account_id}:*/*/GET/use-an-lpa/*",
+      "arn:aws:execute-api:${var.region_name}:${var.sirius_account_id}:*/*/POST/use-an-lpa/lpas/requestCode"
     ]
   }
 
@@ -252,12 +252,12 @@ data "aws_iam_policy_document" "api_permissions_role" {
       "execute-api:Invoke",
     ]
     resources = [
-      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/GET/healthcheck",
-      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/POST/revoke",
-      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/POST/validate",
-      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/POST/exists",
-      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/POST/paper-verification-code/expire",
-      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/POST/paper-verification-code/validate",
+      "arn:aws:execute-api:${var.region_name}:${var.sirius_account_id}:*/*/GET/healthcheck",
+      "arn:aws:execute-api:${var.region_name}:${var.sirius_account_id}:*/*/POST/revoke",
+      "arn:aws:execute-api:${var.region_name}:${var.sirius_account_id}:*/*/POST/validate",
+      "arn:aws:execute-api:${var.region_name}:${var.sirius_account_id}:*/*/POST/exists",
+      "arn:aws:execute-api:${var.region_name}:${var.sirius_account_id}:*/*/POST/paper-verification-code/expire",
+      "arn:aws:execute-api:${var.region_name}:${var.sirius_account_id}:*/*/POST/paper-verification-code/validate",
     ]
   }
 
@@ -330,9 +330,9 @@ data "aws_iam_policy_document" "api_permissions_role" {
       "execute-api:Invoke",
     ]
     resources = [
-      "arn:aws:execute-api:${var.region}:${var.lpa_store_account_id}:*/*/POST/lpas",
-      "arn:aws:execute-api:${var.region}:${var.lpa_store_account_id}:*/*/GET/lpas/*",
-      "arn:aws:execute-api:${var.region}:${var.lpa_store_account_id}:*/*/GET/health-check",
+      "arn:aws:execute-api:${var.region_name}:${var.lpa_store_account_id}:*/*/POST/lpas",
+      "arn:aws:execute-api:${var.region_name}:${var.lpa_store_account_id}:*/*/GET/lpas/*",
+      "arn:aws:execute-api:${var.region_name}:${var.lpa_store_account_id}:*/*/GET/health-check",
     ]
   }
 
@@ -343,8 +343,8 @@ data "aws_iam_policy_document" "api_permissions_role" {
       "execute-api:Invoke",
     ]
     resources = [
-      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/GET/image-request/*",
-      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/GET/healthcheck",
+      "arn:aws:execute-api:${var.region_name}:${var.sirius_account_id}:*/*/GET/image-request/*",
+      "arn:aws:execute-api:${var.region_name}:${var.sirius_account_id}:*/*/GET/healthcheck",
     ]
   }
 
@@ -414,7 +414,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = var.region,
+          awslogs-region        = var.region_name,
           awslogs-stream-prefix = "${var.environment_name}.api-web.use-an-lpa"
         }
       },
@@ -457,7 +457,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = var.region,
+          awslogs-region        = var.region_name,
           awslogs-stream-prefix = "${var.environment_name}.actor-otel.use-an-lpa"
         }
       },
@@ -492,7 +492,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = var.region,
+          awslogs-region        = var.region_name,
           awslogs-stream-prefix = "${var.environment_name}.api-app.use-an-lpa"
         }
       },

--- a/terraform/environment/region/api_ecs.tf
+++ b/terraform/environment/region/api_ecs.tf
@@ -240,8 +240,8 @@ data "aws_iam_policy_document" "api_permissions_role" {
     ]
 
     resources = [
-      "arn:aws:execute-api:${data.aws_region.current.region}:${var.sirius_account_id}:*/*/GET/use-an-lpa/*",
-      "arn:aws:execute-api:${data.aws_region.current.region}:${var.sirius_account_id}:*/*/POST/use-an-lpa/lpas/requestCode"
+      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/GET/use-an-lpa/*",
+      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/POST/use-an-lpa/lpas/requestCode"
     ]
   }
 
@@ -252,12 +252,12 @@ data "aws_iam_policy_document" "api_permissions_role" {
       "execute-api:Invoke",
     ]
     resources = [
-      "arn:aws:execute-api:${data.aws_region.current.region}:${var.sirius_account_id}:*/*/GET/healthcheck",
-      "arn:aws:execute-api:${data.aws_region.current.region}:${var.sirius_account_id}:*/*/POST/revoke",
-      "arn:aws:execute-api:${data.aws_region.current.region}:${var.sirius_account_id}:*/*/POST/validate",
-      "arn:aws:execute-api:${data.aws_region.current.region}:${var.sirius_account_id}:*/*/POST/exists",
-      "arn:aws:execute-api:${data.aws_region.current.region}:${var.sirius_account_id}:*/*/POST/paper-verification-code/expire",
-      "arn:aws:execute-api:${data.aws_region.current.region}:${var.sirius_account_id}:*/*/POST/paper-verification-code/validate",
+      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/GET/healthcheck",
+      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/POST/revoke",
+      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/POST/validate",
+      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/POST/exists",
+      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/POST/paper-verification-code/expire",
+      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/POST/paper-verification-code/validate",
     ]
   }
 
@@ -330,9 +330,9 @@ data "aws_iam_policy_document" "api_permissions_role" {
       "execute-api:Invoke",
     ]
     resources = [
-      "arn:aws:execute-api:${data.aws_region.current.region}:${var.lpa_store_account_id}:*/*/POST/lpas",
-      "arn:aws:execute-api:${data.aws_region.current.region}:${var.lpa_store_account_id}:*/*/GET/lpas/*",
-      "arn:aws:execute-api:${data.aws_region.current.region}:${var.lpa_store_account_id}:*/*/GET/health-check",
+      "arn:aws:execute-api:${var.region}:${var.lpa_store_account_id}:*/*/POST/lpas",
+      "arn:aws:execute-api:${var.region}:${var.lpa_store_account_id}:*/*/GET/lpas/*",
+      "arn:aws:execute-api:${var.region}:${var.lpa_store_account_id}:*/*/GET/health-check",
     ]
   }
 
@@ -343,8 +343,8 @@ data "aws_iam_policy_document" "api_permissions_role" {
       "execute-api:Invoke",
     ]
     resources = [
-      "arn:aws:execute-api:${data.aws_region.current.region}:${var.sirius_account_id}:*/*/GET/image-request/*",
-      "arn:aws:execute-api:${data.aws_region.current.region}:${var.sirius_account_id}:*/*/GET/healthcheck",
+      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/GET/image-request/*",
+      "arn:aws:execute-api:${var.region}:${var.sirius_account_id}:*/*/GET/healthcheck",
     ]
   }
 
@@ -414,7 +414,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = data.aws_region.current.region,
+          awslogs-region        = var.region,
           awslogs-stream-prefix = "${var.environment_name}.api-web.use-an-lpa"
         }
       },
@@ -457,7 +457,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = data.aws_region.current.region,
+          awslogs-region        = var.region,
           awslogs-stream-prefix = "${var.environment_name}.actor-otel.use-an-lpa"
         }
       },
@@ -492,7 +492,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = data.aws_region.current.region,
+          awslogs-region        = var.region,
           awslogs-stream-prefix = "${var.environment_name}.api-app.use-an-lpa"
         }
       },

--- a/terraform/environment/region/cloudwatch_dashboard.tf
+++ b/terraform/environment/region/cloudwatch_dashboard.tf
@@ -1,8 +1,8 @@
 resource "aws_cloudwatch_dashboard" "main" {
   count          = var.create_dashboard ? 1 : 0
-  dashboard_name = "${var.environment_name}-${var.region}-dashboard"
+  dashboard_name = "${var.environment_name}-${var.region_name}-dashboard"
   dashboard_body = templatefile("${path.module}/templates/cw_dashboard_watching.tftpl", {
-    region         = var.region,
+    region         = var.region_name,
     environment    = var.environment_name,
     viewer_alb_arn = local.viewer_alb_arn,
     use_alb_arn    = local.use_alb_arn
@@ -12,17 +12,17 @@ resource "aws_cloudwatch_dashboard" "main" {
 }
 
 locals {
-  viewer_alb_arn = trimprefix(aws_lb.viewer.arn, "arn:aws:elasticloadbalancing:${var.region}:${data.aws_caller_identity.current.account_id}:loadbalancer/")
-  use_alb_arn    = trimprefix(aws_lb.use.arn, "arn:aws:elasticloadbalancing:${var.region}:${data.aws_caller_identity.current.account_id}:loadbalancer/")
+  viewer_alb_arn = trimprefix(aws_lb.viewer.arn, "arn:aws:elasticloadbalancing:${var.region_name}:${data.aws_caller_identity.current.account_id}:loadbalancer/")
+  use_alb_arn    = trimprefix(aws_lb.use.arn, "arn:aws:elasticloadbalancing:${var.region_name}:${data.aws_caller_identity.current.account_id}:loadbalancer/")
 }
 
 resource "aws_cloudwatch_dashboard" "onelogin" {
   count          = var.create_onelogin_dashboard ? 1 : 0
-  dashboard_name = "${var.environment_name}-${var.region}-onelogin-dashboard"
+  dashboard_name = "${var.environment_name}-${var.region_name}-onelogin-dashboard"
   dashboard_body = templatefile("${path.module}/templates/cw_dashboard_onelogin.tftpl", {
     ecs_cluster         = aws_ecs_cluster.use_an_lpa.name,
     environment         = var.environment_name,
-    region              = var.region,
+    region              = var.region_name,
     use_health_check    = module.actor_use_my_lpa.health_check_id,
     use_alb_arn         = local.use_alb_arn,
     viewer_health_check = module.viewer_use_my_lpa.health_check_id,

--- a/terraform/environment/region/cloudwatch_dashboard.tf
+++ b/terraform/environment/region/cloudwatch_dashboard.tf
@@ -1,8 +1,8 @@
 resource "aws_cloudwatch_dashboard" "main" {
   count          = var.create_dashboard ? 1 : 0
-  dashboard_name = "${var.environment_name}-${data.aws_region.current.region}-dashboard"
+  dashboard_name = "${var.environment_name}-${var.region}-dashboard"
   dashboard_body = templatefile("${path.module}/templates/cw_dashboard_watching.tftpl", {
-    region         = data.aws_region.current.region,
+    region         = var.region,
     environment    = var.environment_name,
     viewer_alb_arn = local.viewer_alb_arn,
     use_alb_arn    = local.use_alb_arn
@@ -12,17 +12,17 @@ resource "aws_cloudwatch_dashboard" "main" {
 }
 
 locals {
-  viewer_alb_arn = trimprefix(aws_lb.viewer.arn, "arn:aws:elasticloadbalancing:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:loadbalancer/")
-  use_alb_arn    = trimprefix(aws_lb.use.arn, "arn:aws:elasticloadbalancing:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:loadbalancer/")
+  viewer_alb_arn = trimprefix(aws_lb.viewer.arn, "arn:aws:elasticloadbalancing:${var.region}:${data.aws_caller_identity.current.account_id}:loadbalancer/")
+  use_alb_arn    = trimprefix(aws_lb.use.arn, "arn:aws:elasticloadbalancing:${var.region}:${data.aws_caller_identity.current.account_id}:loadbalancer/")
 }
 
 resource "aws_cloudwatch_dashboard" "onelogin" {
   count          = var.create_onelogin_dashboard ? 1 : 0
-  dashboard_name = "${var.environment_name}-${data.aws_region.current.region}-onelogin-dashboard"
+  dashboard_name = "${var.environment_name}-${var.region}-onelogin-dashboard"
   dashboard_body = templatefile("${path.module}/templates/cw_dashboard_onelogin.tftpl", {
     ecs_cluster         = aws_ecs_cluster.use_an_lpa.name,
     environment         = var.environment_name,
-    region              = data.aws_region.current.region,
+    region              = var.region,
     use_health_check    = module.actor_use_my_lpa.health_check_id,
     use_alb_arn         = local.use_alb_arn,
     viewer_health_check = module.viewer_use_my_lpa.health_check_id,

--- a/terraform/environment/region/data_sources.tf
+++ b/terraform/environment/region/data_sources.tf
@@ -38,7 +38,7 @@ data "aws_kms_alias" "cloudwatch_encryption" {
 data "aws_ecr_repository" "use_an_lpa_front_web" {
   provider = aws.management
   name     = "use_an_lpa/front_web"
-  region   = var.region
+  region   = var.region_name
 }
 
 data "aws_ecr_image" "use_an_lpa_front_web" {
@@ -50,7 +50,7 @@ data "aws_ecr_image" "use_an_lpa_front_web" {
 data "aws_ecr_repository" "use_an_lpa_front_app" {
   provider = aws.management
   name     = "use_an_lpa/front_app"
-  region   = var.region
+  region   = var.region_name
 }
 
 data "aws_ecr_image" "use_an_lpa_front_app" {
@@ -62,7 +62,7 @@ data "aws_ecr_image" "use_an_lpa_front_app" {
 data "aws_ecr_repository" "use_an_lpa_api_web" {
   provider = aws.management
   name     = "use_an_lpa/api_web"
-  region   = var.region
+  region   = var.region_name
 }
 
 data "aws_ecr_image" "use_an_lpa_api_web" {
@@ -74,7 +74,7 @@ data "aws_ecr_image" "use_an_lpa_api_web" {
 data "aws_ecr_repository" "use_an_lpa_api_app" {
   provider = aws.management
   name     = "use_an_lpa/api_app"
-  region   = var.region
+  region   = var.region_name
 }
 
 data "aws_ecr_image" "use_an_lpa_api_app" {
@@ -86,7 +86,7 @@ data "aws_ecr_image" "use_an_lpa_api_app" {
 data "aws_ecr_repository" "use_an_lpa_pdf" {
   provider = aws.management
   name     = "pdf-service"
-  region   = var.region
+  region   = var.region_name
 }
 
 data "aws_ecr_image" "pdf_service" {
@@ -99,7 +99,7 @@ data "aws_ecr_image" "pdf_service" {
 data "aws_ecr_repository" "use_an_lpa_admin_app" {
   provider = aws.management
   name     = "use_an_lpa/admin_app"
-  region   = var.region
+  region   = var.region_name
 }
 
 data "aws_ecr_image" "use_an_lpa_admin_app" {
@@ -179,7 +179,7 @@ data "aws_iam_role" "ecs_autoscaling_service_role" {
 }
 
 data "aws_s3_bucket" "access_log" {
-  bucket = "opg-ual-${var.account_name}-lb-access-logs-${var.region}"
+  bucket = "opg-ual-${var.account_name}-lb-access-logs-${var.region_name}"
 
   provider = aws.region
 }

--- a/terraform/environment/region/data_sources.tf
+++ b/terraform/environment/region/data_sources.tf
@@ -1,11 +1,3 @@
-data "aws_region" "current" {
-  provider = aws.region
-}
-
-data "aws_default_tags" "current" {
-  provider = aws.region
-}
-
 data "aws_caller_identity" "current" {
   provider = aws.region
 }
@@ -46,7 +38,7 @@ data "aws_kms_alias" "cloudwatch_encryption" {
 data "aws_ecr_repository" "use_an_lpa_front_web" {
   provider = aws.management
   name     = "use_an_lpa/front_web"
-  region   = data.aws_region.current.name
+  region   = var.region
 }
 
 data "aws_ecr_image" "use_an_lpa_front_web" {
@@ -58,7 +50,7 @@ data "aws_ecr_image" "use_an_lpa_front_web" {
 data "aws_ecr_repository" "use_an_lpa_front_app" {
   provider = aws.management
   name     = "use_an_lpa/front_app"
-  region   = data.aws_region.current.name
+  region   = var.region
 }
 
 data "aws_ecr_image" "use_an_lpa_front_app" {
@@ -70,7 +62,7 @@ data "aws_ecr_image" "use_an_lpa_front_app" {
 data "aws_ecr_repository" "use_an_lpa_api_web" {
   provider = aws.management
   name     = "use_an_lpa/api_web"
-  region   = data.aws_region.current.name
+  region   = var.region
 }
 
 data "aws_ecr_image" "use_an_lpa_api_web" {
@@ -82,7 +74,7 @@ data "aws_ecr_image" "use_an_lpa_api_web" {
 data "aws_ecr_repository" "use_an_lpa_api_app" {
   provider = aws.management
   name     = "use_an_lpa/api_app"
-  region   = data.aws_region.current.name
+  region   = var.region
 }
 
 data "aws_ecr_image" "use_an_lpa_api_app" {
@@ -94,7 +86,7 @@ data "aws_ecr_image" "use_an_lpa_api_app" {
 data "aws_ecr_repository" "use_an_lpa_pdf" {
   provider = aws.management
   name     = "pdf-service"
-  region   = data.aws_region.current.name
+  region   = var.region
 }
 
 data "aws_ecr_image" "pdf_service" {
@@ -107,7 +99,7 @@ data "aws_ecr_image" "pdf_service" {
 data "aws_ecr_repository" "use_an_lpa_admin_app" {
   provider = aws.management
   name     = "use_an_lpa/admin_app"
-  region   = data.aws_region.current.name
+  region   = var.region
 }
 
 data "aws_ecr_image" "use_an_lpa_admin_app" {
@@ -149,12 +141,12 @@ data "aws_secretsmanager_secret" "lpa_data_store_secret" {
 }
 
 data "aws_kms_alias" "jwt_key" {
-  name     = "alias/opg-data-lpa-store/${data.aws_default_tags.current.tags.account-name}/jwt-key"
+  name     = "alias/opg-data-lpa-store/${var.default_tags["account-name"]}/jwt-key"
   provider = aws.management
 }
 
 data "aws_secretsmanager_secret" "lpa_store_jwt_key" {
-  name     = "opg-data-lpa-store/${data.aws_default_tags.current.tags.account-name}/jwt-key"
+  name     = "opg-data-lpa-store/${var.default_tags["account-name"]}/jwt-key"
   provider = aws.management
 }
 
@@ -187,7 +179,7 @@ data "aws_iam_role" "ecs_autoscaling_service_role" {
 }
 
 data "aws_s3_bucket" "access_log" {
-  bucket = "opg-ual-${var.account_name}-lb-access-logs-${data.aws_region.current.region}"
+  bucket = "opg-ual-${var.account_name}-lb-access-logs-${var.region}"
 
   provider = aws.region
 }

--- a/terraform/environment/region/dns.tf
+++ b/terraform/environment/region/dns.tf
@@ -25,7 +25,7 @@ module "public_facing_view_lasting_power_of_attorney" {
 
   dns_namespace_env          = var.dns_namespace_env
   is_active_region           = local.is_active_region
-  current_region             = var.region
+  current_region             = var.region_name
   zone_id                    = data.aws_route53_zone.live_service_view_lasting_power_of_attorney.zone_id
   loadbalancer               = aws_lb.viewer
   dns_name                   = data.aws_route53_zone.live_service_view_lasting_power_of_attorney.name
@@ -43,7 +43,7 @@ module "viewer_use_my_lpa" {
 
   dns_namespace_env          = var.dns_namespace_env
   is_active_region           = local.is_active_region
-  current_region             = var.region
+  current_region             = var.region_name
   zone_id                    = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
   loadbalancer               = aws_lb.viewer
   dns_name                   = "view.lastingpowerofattorney"
@@ -64,7 +64,7 @@ module "public_facing_use_lasting_power_of_attorney" {
 
   dns_namespace_env          = var.dns_namespace_env
   is_active_region           = local.is_active_region
-  current_region             = var.region
+  current_region             = var.region_name
   zone_id                    = data.aws_route53_zone.live_service_use_lasting_power_of_attorney.zone_id
   dns_name                   = data.aws_route53_zone.live_service_use_lasting_power_of_attorney.name
   loadbalancer               = aws_lb.use
@@ -82,7 +82,7 @@ module "actor_use_my_lpa" {
 
   dns_namespace_env          = var.dns_namespace_env
   is_active_region           = local.is_active_region
-  current_region             = var.region
+  current_region             = var.region_name
   zone_id                    = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
   loadbalancer               = aws_lb.use
   dns_name                   = "use.lastingpowerofattorney"
@@ -103,7 +103,7 @@ module "admin_use_my_lpa" {
 
   dns_namespace_env          = var.dns_namespace_env
   is_active_region           = local.is_active_region
-  current_region             = var.region
+  current_region             = var.region_name
   zone_id                    = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
   loadbalancer               = aws_lb.admin
   service_name               = "admin"
@@ -123,7 +123,7 @@ module "mock_onelogin_use_my_lpa" {
 
   dns_namespace_env          = var.dns_namespace_env
   is_active_region           = local.is_active_region
-  current_region             = var.region
+  current_region             = var.region_name
   zone_id                    = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
   loadbalancer               = aws_lb.mock_onelogin[0]
   service_name               = "mock-onelogin"

--- a/terraform/environment/region/dns.tf
+++ b/terraform/environment/region/dns.tf
@@ -25,7 +25,7 @@ module "public_facing_view_lasting_power_of_attorney" {
 
   dns_namespace_env          = var.dns_namespace_env
   is_active_region           = local.is_active_region
-  current_region             = data.aws_region.current.region
+  current_region             = var.region
   zone_id                    = data.aws_route53_zone.live_service_view_lasting_power_of_attorney.zone_id
   loadbalancer               = aws_lb.viewer
   dns_name                   = data.aws_route53_zone.live_service_view_lasting_power_of_attorney.name
@@ -43,7 +43,7 @@ module "viewer_use_my_lpa" {
 
   dns_namespace_env          = var.dns_namespace_env
   is_active_region           = local.is_active_region
-  current_region             = data.aws_region.current.region
+  current_region             = var.region
   zone_id                    = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
   loadbalancer               = aws_lb.viewer
   dns_name                   = "view.lastingpowerofattorney"
@@ -64,7 +64,7 @@ module "public_facing_use_lasting_power_of_attorney" {
 
   dns_namespace_env          = var.dns_namespace_env
   is_active_region           = local.is_active_region
-  current_region             = data.aws_region.current.region
+  current_region             = var.region
   zone_id                    = data.aws_route53_zone.live_service_use_lasting_power_of_attorney.zone_id
   dns_name                   = data.aws_route53_zone.live_service_use_lasting_power_of_attorney.name
   loadbalancer               = aws_lb.use
@@ -82,7 +82,7 @@ module "actor_use_my_lpa" {
 
   dns_namespace_env          = var.dns_namespace_env
   is_active_region           = local.is_active_region
-  current_region             = data.aws_region.current.region
+  current_region             = var.region
   zone_id                    = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
   loadbalancer               = aws_lb.use
   dns_name                   = "use.lastingpowerofattorney"
@@ -103,7 +103,7 @@ module "admin_use_my_lpa" {
 
   dns_namespace_env          = var.dns_namespace_env
   is_active_region           = local.is_active_region
-  current_region             = data.aws_region.current.region
+  current_region             = var.region
   zone_id                    = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
   loadbalancer               = aws_lb.admin
   service_name               = "admin"
@@ -123,7 +123,7 @@ module "mock_onelogin_use_my_lpa" {
 
   dns_namespace_env          = var.dns_namespace_env
   is_active_region           = local.is_active_region
-  current_region             = data.aws_region.current.region
+  current_region             = var.region
   zone_id                    = data.aws_route53_zone.opg_service_justice_gov_uk.zone_id
   loadbalancer               = aws_lb.mock_onelogin[0]
   service_name               = "mock-onelogin"

--- a/terraform/environment/region/ecs_cluster.tf
+++ b/terraform/environment/region/ecs_cluster.tf
@@ -9,7 +9,7 @@ resource "aws_ecs_cluster" "use_an_lpa" {
 }
 
 resource "aws_iam_role_policy" "execution_role" {
-  name   = "${var.environment_name}_execution_role_${var.region}"
+  name   = "${var.environment_name}_execution_role_${var.region_name}"
   policy = data.aws_iam_policy_document.execution_role.json
   role   = var.ecs_execution_role.id
 

--- a/terraform/environment/region/ecs_cluster.tf
+++ b/terraform/environment/region/ecs_cluster.tf
@@ -9,7 +9,7 @@ resource "aws_ecs_cluster" "use_an_lpa" {
 }
 
 resource "aws_iam_role_policy" "execution_role" {
-  name   = "${var.environment_name}_execution_role_${data.aws_region.current.region}"
+  name   = "${var.environment_name}_execution_role_${var.region}"
   policy = data.aws_iam_policy_document.execution_role.json
   role   = var.ecs_execution_role.id
 

--- a/terraform/environment/region/event_bus.tf
+++ b/terraform/environment/region/event_bus.tf
@@ -2,7 +2,7 @@ module "event_bus" {
   source                     = "./modules/event_bus"
   environment_name           = var.environment_name
   event_bus_enabled          = var.event_bus_enabled
-  current_region             = var.region
+  current_region             = var.region_name
   receive_account_ids        = var.receive_account_ids
   queue_visibility_timeout   = local.queue_visibility_timeout
   event_reciever_kms_key_arn = var.event_reciever_kms_key_arn

--- a/terraform/environment/region/event_bus.tf
+++ b/terraform/environment/region/event_bus.tf
@@ -2,7 +2,7 @@ module "event_bus" {
   source                     = "./modules/event_bus"
   environment_name           = var.environment_name
   event_bus_enabled          = var.event_bus_enabled
-  current_region             = data.aws_region.current.region
+  current_region             = var.region
   receive_account_ids        = var.receive_account_ids
   queue_visibility_timeout   = local.queue_visibility_timeout
   event_reciever_kms_key_arn = var.event_reciever_kms_key_arn

--- a/terraform/environment/region/locals.tf
+++ b/terraform/environment/region/locals.tf
@@ -1,10 +1,10 @@
 locals {
-  policy_region_prefix = lower(replace(var.region, "-", ""))
+  policy_region_prefix = lower(replace(var.region_name, "-", ""))
 
   # The primary region is the region where the DynamoDB tables are created and replicated to the secondary region. This should not be changed once the environment is created.
   # The active region is the region where the ECS services are running. The is also the region where users will access the application.
   primary_region   = keys({ for region, region_data in var.regions : region => region_data if region_data.is_primary })[0]
-  is_active_region = var.regions[var.region].is_active
+  is_active_region = var.regions[var.region_name].is_active
 
   # Desired count of the ECS services. Only an active region will have a desired count greater than 0.
   use_desired_count           = local.is_active_region ? var.autoscaling.use.minimum : 0
@@ -19,12 +19,12 @@ locals {
   # Replace the region in the ARN of the DynamoDB tables with the region of the current stack as the tables are created in the primary region
   # and replicated to the secondary region. This allows use to grant access to the tables in the secondary region for applications running in the secondary region.
   dynamodb_tables_arns = {
-    use_codes_table_arn       = replace(var.dynamodb_tables.use_codes_table.arn, local.primary_region, var.region)
-    stats_table_arn           = replace(var.dynamodb_tables.stats_table.arn, local.primary_region, var.region)
-    use_users_table_arn       = replace(var.dynamodb_tables.use_users_table.arn, local.primary_region, var.region)
-    viewer_codes_table_arn    = replace(var.dynamodb_tables.viewer_codes_table.arn, local.primary_region, var.region)
-    viewer_activity_table_arn = replace(var.dynamodb_tables.viewer_activity_table.arn, local.primary_region, var.region)
-    user_lpa_actor_map_arn    = replace(var.dynamodb_tables.user_lpa_actor_map.arn, local.primary_region, var.region)
+    use_codes_table_arn       = replace(var.dynamodb_tables.use_codes_table.arn, local.primary_region, var.region_name)
+    stats_table_arn           = replace(var.dynamodb_tables.stats_table.arn, local.primary_region, var.region_name)
+    use_users_table_arn       = replace(var.dynamodb_tables.use_users_table.arn, local.primary_region, var.region_name)
+    viewer_codes_table_arn    = replace(var.dynamodb_tables.viewer_codes_table.arn, local.primary_region, var.region_name)
+    viewer_activity_table_arn = replace(var.dynamodb_tables.viewer_activity_table.arn, local.primary_region, var.region_name)
+    user_lpa_actor_map_arn    = replace(var.dynamodb_tables.user_lpa_actor_map.arn, local.primary_region, var.region_name)
   }
 
   route53_fqdns = {

--- a/terraform/environment/region/locals.tf
+++ b/terraform/environment/region/locals.tf
@@ -1,10 +1,10 @@
 locals {
-  policy_region_prefix = lower(replace(data.aws_region.current.region, "-", ""))
+  policy_region_prefix = lower(replace(var.region, "-", ""))
 
   # The primary region is the region where the DynamoDB tables are created and replicated to the secondary region. This should not be changed once the environment is created.
   # The active region is the region where the ECS services are running. The is also the region where users will access the application.
   primary_region   = keys({ for region, region_data in var.regions : region => region_data if region_data.is_primary })[0]
-  is_active_region = var.regions[data.aws_region.current.region].is_active
+  is_active_region = var.regions[var.region].is_active
 
   # Desired count of the ECS services. Only an active region will have a desired count greater than 0.
   use_desired_count           = local.is_active_region ? var.autoscaling.use.minimum : 0
@@ -19,12 +19,12 @@ locals {
   # Replace the region in the ARN of the DynamoDB tables with the region of the current stack as the tables are created in the primary region
   # and replicated to the secondary region. This allows use to grant access to the tables in the secondary region for applications running in the secondary region.
   dynamodb_tables_arns = {
-    use_codes_table_arn       = replace(var.dynamodb_tables.use_codes_table.arn, local.primary_region, data.aws_region.current.region)
-    stats_table_arn           = replace(var.dynamodb_tables.stats_table.arn, local.primary_region, data.aws_region.current.region)
-    use_users_table_arn       = replace(var.dynamodb_tables.use_users_table.arn, local.primary_region, data.aws_region.current.region)
-    viewer_codes_table_arn    = replace(var.dynamodb_tables.viewer_codes_table.arn, local.primary_region, data.aws_region.current.region)
-    viewer_activity_table_arn = replace(var.dynamodb_tables.viewer_activity_table.arn, local.primary_region, data.aws_region.current.region)
-    user_lpa_actor_map_arn    = replace(var.dynamodb_tables.user_lpa_actor_map.arn, local.primary_region, data.aws_region.current.region)
+    use_codes_table_arn       = replace(var.dynamodb_tables.use_codes_table.arn, local.primary_region, var.region)
+    stats_table_arn           = replace(var.dynamodb_tables.stats_table.arn, local.primary_region, var.region)
+    use_users_table_arn       = replace(var.dynamodb_tables.use_users_table.arn, local.primary_region, var.region)
+    viewer_codes_table_arn    = replace(var.dynamodb_tables.viewer_codes_table.arn, local.primary_region, var.region)
+    viewer_activity_table_arn = replace(var.dynamodb_tables.viewer_activity_table.arn, local.primary_region, var.region)
+    user_lpa_actor_map_arn    = replace(var.dynamodb_tables.user_lpa_actor_map.arn, local.primary_region, var.region)
   }
 
   route53_fqdns = {

--- a/terraform/environment/region/mock_onelogin_ecs.tf
+++ b/terraform/environment/region/mock_onelogin_ecs.tf
@@ -219,7 +219,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = var.region,
+          awslogs-region        = var.region_name,
           awslogs-stream-prefix = "${var.environment_name}.mock-onelogin-app.use-an-lpa"
         }
       },

--- a/terraform/environment/region/mock_onelogin_ecs.tf
+++ b/terraform/environment/region/mock_onelogin_ecs.tf
@@ -219,7 +219,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = data.aws_region.current.region,
+          awslogs-region        = var.region,
           awslogs-stream-prefix = "${var.environment_name}.mock-onelogin-app.use-an-lpa"
         }
       },

--- a/terraform/environment/region/network.tf
+++ b/terraform/environment/region/network.tf
@@ -6,11 +6,11 @@ data "aws_availability_zones" "available" {
 data "aws_vpc" "main" {
   filter {
     name   = "tag:application"
-    values = [data.aws_default_tags.current.tags.application]
+    values = [var.default_tags["application"]]
   }
   filter {
     name   = "tag:Name"
-    values = ["${data.aws_default_tags.current.tags.application}-${data.aws_default_tags.current.tags.account-name}-vpc"]
+    values = ["${var.default_tags["application"]}-${var.default_tags["account-name"]}-vpc"]
   }
   provider = aws.region
 }

--- a/terraform/environment/region/pdf_ecs.tf
+++ b/terraform/environment/region/pdf_ecs.tf
@@ -168,7 +168,7 @@ locals {
       logDriver = "awslogs",
       options = {
         awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-        awslogs-region        = var.region,
+        awslogs-region        = var.region_name,
         awslogs-stream-prefix = "${var.environment_name}.pdf-app.use-an-lpa"
       }
     },

--- a/terraform/environment/region/pdf_ecs.tf
+++ b/terraform/environment/region/pdf_ecs.tf
@@ -168,7 +168,7 @@ locals {
       logDriver = "awslogs",
       options = {
         awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-        awslogs-region        = data.aws_region.current.region,
+        awslogs-region        = var.region,
         awslogs-stream-prefix = "${var.environment_name}.pdf-app.use-an-lpa"
       }
     },

--- a/terraform/environment/region/resource_group.tf
+++ b/terraform/environment/region/resource_group.tf
@@ -1,5 +1,5 @@
 resource "aws_resourcegroups_group" "environment" {
-  name        = "${var.default_tags["environment-name"]}-environment-${var.region}"
+  name        = "${var.default_tags["environment-name"]}-environment-${var.region_name}"
   description = "Environment level eu-west-1 resources"
 
   resource_query {

--- a/terraform/environment/region/resource_group.tf
+++ b/terraform/environment/region/resource_group.tf
@@ -1,5 +1,5 @@
 resource "aws_resourcegroups_group" "environment" {
-  name        = "${data.aws_default_tags.current.tags.environment-name}-environment-${data.aws_region.current.region}"
+  name        = "${var.default_tags["environment-name"]}-environment-${var.region}"
   description = "Environment level eu-west-1 resources"
 
   resource_query {
@@ -17,7 +17,7 @@ locals {
     TagFilters = [
       {
         Key    = "environment-name",
-        Values = [data.aws_default_tags.current.tags.environment-name]
+        Values = [var.default_tags["environment-name"]]
       }
     ]
   })

--- a/terraform/environment/region/ship_to_metrics.tf
+++ b/terraform/environment/region/ship_to_metrics.tf
@@ -2,7 +2,7 @@
 #
 # data "aws_lambda_function" "clsf_to_sqs" {
 #   count         = var.ship_metrics_queue_enabled ? 1 : 0
-#   function_name = "clsf-to-sqs-${var.region}"
+#   function_name = "clsf-to-sqs-${var.region_name}"
 #
 #   provider = aws.region
 # }
@@ -23,7 +23,7 @@
 #   statement_id  = "${var.environment_name}-AllowExecutionFromCloudWatch"
 #   action        = "lambda:InvokeFunction"
 #   function_name = data.aws_lambda_function.clsf_to_sqs[0].function_name
-#   principal     = "logs.${var.region}.amazonaws.com"
+#   principal     = "logs.${var.region_name}.amazonaws.com"
 #   source_arn    = "${aws_cloudwatch_log_group.application_logs.arn}:*"
 #
 #   provider = aws.region

--- a/terraform/environment/region/ship_to_metrics.tf
+++ b/terraform/environment/region/ship_to_metrics.tf
@@ -2,7 +2,7 @@
 #
 # data "aws_lambda_function" "clsf_to_sqs" {
 #   count         = var.ship_metrics_queue_enabled ? 1 : 0
-#   function_name = "clsf-to-sqs-${data.aws_region.current.region}"
+#   function_name = "clsf-to-sqs-${var.region}"
 #
 #   provider = aws.region
 # }
@@ -23,7 +23,7 @@
 #   statement_id  = "${var.environment_name}-AllowExecutionFromCloudWatch"
 #   action        = "lambda:InvokeFunction"
 #   function_name = data.aws_lambda_function.clsf_to_sqs[0].function_name
-#   principal     = "logs.${data.aws_region.current.region}.amazonaws.com"
+#   principal     = "logs.${var.region}.amazonaws.com"
 #   source_arn    = "${aws_cloudwatch_log_group.application_logs.arn}:*"
 #
 #   provider = aws.region

--- a/terraform/environment/region/use_ecs.tf
+++ b/terraform/environment/region/use_ecs.tf
@@ -221,7 +221,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = var.region,
+          awslogs-region        = var.region_name,
           awslogs-stream-prefix = "${var.environment_name}.actor-web.use-an-lpa"
         }
       },
@@ -268,7 +268,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = var.region,
+          awslogs-region        = var.region_name,
           awslogs-stream-prefix = "${var.environment_name}.actor-otel.use-an-lpa"
         }
       },
@@ -303,7 +303,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = var.region,
+          awslogs-region        = var.region_name,
           awslogs-stream-prefix = "${var.environment_name}.actor-app.use-an-lpa"
         }
       },

--- a/terraform/environment/region/use_ecs.tf
+++ b/terraform/environment/region/use_ecs.tf
@@ -221,7 +221,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = data.aws_region.current.region,
+          awslogs-region        = var.region,
           awslogs-stream-prefix = "${var.environment_name}.actor-web.use-an-lpa"
         }
       },
@@ -268,7 +268,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = data.aws_region.current.region,
+          awslogs-region        = var.region,
           awslogs-stream-prefix = "${var.environment_name}.actor-otel.use-an-lpa"
         }
       },
@@ -303,7 +303,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = data.aws_region.current.region,
+          awslogs-region        = var.region,
           awslogs-stream-prefix = "${var.environment_name}.actor-app.use-an-lpa"
         }
       },

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -288,7 +288,7 @@ variable "lpa_store_account_id" {
   type        = string
 }
 
-variable "region" {
+variable "region_name" {
   description = "The AWS region"
   type        = string
 }

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -287,3 +287,13 @@ variable "lpa_store_account_id" {
   description = "The AWS ID of the LPA store account"
   type        = string
 }
+
+variable "region" {
+  description = "The AWS region"
+  type        = string
+}
+
+variable "default_tags" {
+  description = "Default tags to apply to all resources"
+  type        = map(string)
+}

--- a/terraform/environment/region/viewer_ecs.tf
+++ b/terraform/environment/region/viewer_ecs.tf
@@ -198,7 +198,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = var.region,
+          awslogs-region        = var.region_name,
           awslogs-stream-prefix = "${var.environment_name}.viewer-web.use-an-lpa"
         }
       },
@@ -241,7 +241,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = var.region,
+          awslogs-region        = var.region_name,
           awslogs-stream-prefix = "${var.environment_name}.viewer-otel.use-an-lpa"
         }
       },
@@ -276,7 +276,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = var.region,
+          awslogs-region        = var.region_name,
           awslogs-stream-prefix = "${var.environment_name}.viewer-app.use-an-lpa"
         }
       },

--- a/terraform/environment/region/viewer_ecs.tf
+++ b/terraform/environment/region/viewer_ecs.tf
@@ -198,7 +198,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = data.aws_region.current.region,
+          awslogs-region        = var.region,
           awslogs-stream-prefix = "${var.environment_name}.viewer-web.use-an-lpa"
         }
       },
@@ -241,7 +241,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = data.aws_region.current.region,
+          awslogs-region        = var.region,
           awslogs-stream-prefix = "${var.environment_name}.viewer-otel.use-an-lpa"
         }
       },
@@ -276,7 +276,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.application_logs.name,
-          awslogs-region        = data.aws_region.current.region,
+          awslogs-region        = var.region,
           awslogs-stream-prefix = "${var.environment_name}.viewer-app.use-an-lpa"
         }
       },


### PR DESCRIPTION
Add the new POAS service-area tag.
Terraform wanted to destroy and recreate a lot of resources due to unknown values at apply time on certain data sources, so using variables instead for these data sources including in the firewalled network module.