### PR TITLE
Allow for local dev of terraform

### DIFF
--- a/terraform/account/terraform.tf
+++ b/terraform/account/terraform.tf
@@ -23,8 +23,10 @@ variable "management_role" {
   description = "The role to assume for the management AWS provider"
 }
 
-locals {
-  default_role = local.account.permissions_boundary_enabled ? "opg-use-an-lpa-ci-boundary" : "opg-use-an-lpa-ci"
+variable "default_role" {
+  default     = "opg-use-an-lpa-ci-boundary"
+  type        = string
+  description = "The role to assume for the service account AWS providers"
 }
 
 provider "aws" {
@@ -34,7 +36,7 @@ provider "aws" {
   }
 
   assume_role {
-    role_arn     = "arn:aws:iam::${local.account.account_id}:role/${local.default_role}"
+    role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
   }
 }
@@ -47,7 +49,7 @@ provider "aws" {
   }
 
   assume_role {
-    role_arn     = "arn:aws:iam::${local.account.account_id}:role/${local.default_role}"
+    role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
   }
 }
@@ -60,7 +62,7 @@ provider "aws" {
   }
 
   assume_role {
-    role_arn     = "arn:aws:iam::${local.account.account_id}:role/${local.default_role}"
+    role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
   }
 }

--- a/terraform/environment/terraform.tf
+++ b/terraform/environment/terraform.tf
@@ -29,16 +29,22 @@ variable "management_role" {
   default = "opg-use-an-lpa-ci"
 }
 
-locals {
-  default_role = local.environment.permissions_boundary_enabled ? "opg-use-an-lpa-ci-boundary" : "opg-use-an-lpa-ci"
+variable "default_role" {
+  type    = string
+  default = "opg-use-an-lpa-ci-boundary"
 }
+
+# locals {
+#   default_role = local.environment.permissions_boundary_enabled ? "opg-use-an-lpa-ci-boundary" : "opg-use-an-lpa-ci"
+# }
+
 provider "aws" {
   region = "eu-west-1"
   default_tags {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${local.default_role}"
+    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
   }
 }
@@ -50,7 +56,7 @@ provider "aws" {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${local.default_role}"
+    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
   }
 }
@@ -62,7 +68,7 @@ provider "aws" {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${local.default_role}"
+    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
   }
 }
@@ -75,7 +81,7 @@ provider "aws" {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${local.default_role}"
+    role_arn     = "arn:aws:iam::${local.environment.account_id}:role/${var.default_role}"
     session_name = "terraform-session"
   }
 }

--- a/terraform/environment/terraform.tf
+++ b/terraform/environment/terraform.tf
@@ -34,10 +34,6 @@ variable "default_role" {
   default = "opg-use-an-lpa-ci-boundary"
 }
 
-# locals {
-#   default_role = local.environment.permissions_boundary_enabled ? "opg-use-an-lpa-ci-boundary" : "opg-use-an-lpa-ci"
-# }
-
 provider "aws" {
   region = "eu-west-1"
   default_tags {


### PR DESCRIPTION
# Purpose

Temporary changes for the boundaried ci work prevented local development of the terraform configurations by not allowing the default role to be overwritten.

## Approach

- replace local.default_role with a variable that defaults to `opg-use-an-lpa-ci-boundary`