### PR TITLE
UML-4156: separate dynamodb replicas into their own resources

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -449,7 +449,7 @@
         "filename": "terraform/environment/terraform.tfvars.json",
         "hashed_secret": "02ec08caee6f99ca33e0ac7eef82b8f6e51c4bbf",
         "is_verified": false,
-        "line_number": 173
+        "line_number": 175
       }
     ],
     "tests/smoke/context/AccountContext.php": [
@@ -462,5 +462,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-31T10:39:51Z"
+  "generated_at": "2026-08-03T08:49:29Z"
 }

--- a/docs/runbooks/reextract-an-lpa-scan.md
+++ b/docs/runbooks/reextract-an-lpa-scan.md
@@ -1,1 +1,1 @@
-Instructions on how to re-extract Instructions and Preferences images for a LPA can be found in the [Instructions and Preferences repo runbooks](https://github.com/ministryofjustice/opg-data-lpa-instructions-preferences/blob/main/docs/runbooks/reextract-an-lpa-scan.md)
+Instructions on how to re-extract Instructions and Preferences images for an LPA can be found in the [Instructions and Preferences repo runbooks](https://github.com/ministryofjustice/opg-data-lpa-instructions-preferences/blob/main/docs/runbooks/reextract-an-lpa-scan.md)

--- a/terraform/environment/dynamodb.tf
+++ b/terraform/environment/dynamodb.tf
@@ -19,20 +19,9 @@ resource "aws_dynamodb_table" "use_codes_table" {
     enabled = true
   }
 
-  # For each region in the environment that is not the primary_region, create a DynamoDB replica.
-  dynamic "replica" {
-    for_each = [
-      for region in local.environment.regions : region
-      if region.is_primary != true
-    ]
-
-    content {
-      region_name                 = replica.value.name
-      propagate_tags              = true
-      deletion_protection_enabled = local.environment.dynamodb_tables.deletion_protection_enabled
-      kms_key_arn                 = local.environment.dynamodb_tables.cmk_encryption_enabled ? data.aws_kms_alias.dynamodb_cmk_eu_west_2.target_key_arn : null
-      point_in_time_recovery      = true
-    }
+  # Replicas are managed as standalone aws_dynamodb_table_replica resources in dynamodb_replicas.tf.
+  lifecycle {
+    ignore_changes = [replica]
   }
 
   provider = aws.eu_west_1
@@ -61,19 +50,9 @@ resource "aws_dynamodb_table" "stats_table" {
     enabled = true
   }
 
-  dynamic "replica" {
-    for_each = [
-      for region in local.environment.regions : region
-      if region.is_primary != true
-    ]
-
-    content {
-      region_name                 = replica.value.name
-      propagate_tags              = true
-      deletion_protection_enabled = local.environment.dynamodb_tables.deletion_protection_enabled
-      kms_key_arn                 = local.environment.dynamodb_tables.cmk_encryption_enabled ? data.aws_kms_alias.dynamodb_cmk_eu_west_2.target_key_arn : null
-      point_in_time_recovery      = true
-    }
+  # Replicas are managed as standalone aws_dynamodb_table_replica resources in dynamodb_replicas.tf.
+  lifecycle {
+    ignore_changes = [replica]
   }
 
   provider = aws.eu_west_1
@@ -125,19 +104,9 @@ resource "aws_dynamodb_table" "use_users_table" {
     enabled = true
   }
 
-  dynamic "replica" {
-    for_each = [
-      for region in local.environment.regions : region
-      if region.is_primary != true
-    ]
-
-    content {
-      region_name                 = replica.value.name
-      propagate_tags              = true
-      deletion_protection_enabled = local.environment.dynamodb_tables.deletion_protection_enabled
-      kms_key_arn                 = local.environment.dynamodb_tables.cmk_encryption_enabled ? data.aws_kms_alias.dynamodb_cmk_eu_west_2.target_key_arn : null
-      point_in_time_recovery      = true
-    }
+  # Replicas are managed as standalone aws_dynamodb_table_replica resources in dynamodb_replicas.tf.
+  lifecycle {
+    ignore_changes = [replica]
   }
 
   provider = aws.eu_west_1
@@ -181,19 +150,9 @@ resource "aws_dynamodb_table" "viewer_codes_table" {
     enabled = true
   }
 
-  dynamic "replica" {
-    for_each = [
-      for region in local.environment.regions : region
-      if region.is_primary != true
-    ]
-
-    content {
-      region_name                 = replica.value.name
-      propagate_tags              = true
-      deletion_protection_enabled = local.environment.dynamodb_tables.deletion_protection_enabled
-      kms_key_arn                 = local.environment.dynamodb_tables.cmk_encryption_enabled ? data.aws_kms_alias.dynamodb_cmk_eu_west_2.target_key_arn : null
-      point_in_time_recovery      = true
-    }
+  # Replicas are managed as standalone aws_dynamodb_table_replica resources in dynamodb_replicas.tf.
+  lifecycle {
+    ignore_changes = [replica]
   }
 
   provider = aws.eu_west_1
@@ -227,19 +186,9 @@ resource "aws_dynamodb_table" "viewer_activity_table" {
     enabled = true
   }
 
-  dynamic "replica" {
-    for_each = [
-      for region in local.environment.regions : region
-      if region.is_primary != true
-    ]
-
-    content {
-      region_name                 = replica.value.name
-      propagate_tags              = true
-      deletion_protection_enabled = local.environment.dynamodb_tables.deletion_protection_enabled
-      point_in_time_recovery      = true
-      kms_key_arn                 = local.environment.dynamodb_tables.cmk_encryption_enabled ? data.aws_kms_alias.dynamodb_cmk_eu_west_2.target_key_arn : null
-    }
+  # Replicas are managed as standalone aws_dynamodb_table_replica resources in dynamodb_replicas.tf.
+  lifecycle {
+    ignore_changes = [replica]
   }
 
   provider = aws.eu_west_1
@@ -305,19 +254,9 @@ resource "aws_dynamodb_table" "user_lpa_actor_map" {
     enabled = true
   }
 
-  dynamic "replica" {
-    for_each = [
-      for region in local.environment.regions : region
-      if region.is_primary != true
-    ]
-
-    content {
-      region_name                 = replica.value.name
-      propagate_tags              = true
-      deletion_protection_enabled = local.environment.dynamodb_tables.deletion_protection_enabled
-      kms_key_arn                 = local.environment.dynamodb_tables.cmk_encryption_enabled ? data.aws_kms_alias.dynamodb_cmk_eu_west_2.target_key_arn : null
-      point_in_time_recovery      = true
-    }
+  # Replicas are managed as standalone aws_dynamodb_table_replica resources in dynamodb_replicas.tf.
+  lifecycle {
+    ignore_changes = [replica]
   }
 
   provider = aws.eu_west_1

--- a/terraform/environment/dynamodb_replicas.tf
+++ b/terraform/environment/dynamodb_replicas.tf
@@ -1,0 +1,47 @@
+resource "aws_dynamodb_table_replica" "use_codes_table" {
+  global_table_arn            = aws_dynamodb_table.use_codes_table.arn
+  kms_key_arn                 = local.environment.dynamodb_tables.cmk_encryption_enabled ? data.aws_kms_alias.dynamodb_cmk_eu_west_2.target_key_arn : null
+  deletion_protection_enabled = local.environment.dynamodb_tables.replica_deletion_protection_enabled
+  point_in_time_recovery      = true
+  provider                    = aws.eu_west_2
+}
+
+resource "aws_dynamodb_table_replica" "stats_table" {
+  global_table_arn            = aws_dynamodb_table.stats_table.arn
+  kms_key_arn                 = local.environment.dynamodb_tables.cmk_encryption_enabled ? data.aws_kms_alias.dynamodb_cmk_eu_west_2.target_key_arn : null
+  deletion_protection_enabled = local.environment.dynamodb_tables.replica_deletion_protection_enabled
+  point_in_time_recovery      = true
+  provider                    = aws.eu_west_2
+}
+
+resource "aws_dynamodb_table_replica" "use_users_table" {
+  global_table_arn            = aws_dynamodb_table.use_users_table.arn
+  kms_key_arn                 = local.environment.dynamodb_tables.cmk_encryption_enabled ? data.aws_kms_alias.dynamodb_cmk_eu_west_2.target_key_arn : null
+  deletion_protection_enabled = local.environment.dynamodb_tables.replica_deletion_protection_enabled
+  point_in_time_recovery      = true
+  provider                    = aws.eu_west_2
+}
+
+resource "aws_dynamodb_table_replica" "viewer_codes_table" {
+  global_table_arn            = aws_dynamodb_table.viewer_codes_table.arn
+  kms_key_arn                 = local.environment.dynamodb_tables.cmk_encryption_enabled ? data.aws_kms_alias.dynamodb_cmk_eu_west_2.target_key_arn : null
+  deletion_protection_enabled = local.environment.dynamodb_tables.replica_deletion_protection_enabled
+  point_in_time_recovery      = true
+  provider                    = aws.eu_west_2
+}
+
+resource "aws_dynamodb_table_replica" "viewer_activity_table" {
+  global_table_arn            = aws_dynamodb_table.viewer_activity_table.arn
+  kms_key_arn                 = local.environment.dynamodb_tables.cmk_encryption_enabled ? data.aws_kms_alias.dynamodb_cmk_eu_west_2.target_key_arn : null
+  deletion_protection_enabled = local.environment.dynamodb_tables.replica_deletion_protection_enabled
+  point_in_time_recovery      = true
+  provider                    = aws.eu_west_2
+}
+
+resource "aws_dynamodb_table_replica" "user_lpa_actor_map" {
+  global_table_arn            = aws_dynamodb_table.user_lpa_actor_map.arn
+  kms_key_arn                 = local.environment.dynamodb_tables.cmk_encryption_enabled ? data.aws_kms_alias.dynamodb_cmk_eu_west_2.target_key_arn : null
+  deletion_protection_enabled = local.environment.dynamodb_tables.replica_deletion_protection_enabled
+  point_in_time_recovery      = true
+  provider                    = aws.eu_west_2
+}

--- a/terraform/environment/refactor.tf
+++ b/terraform/environment/refactor.tf
@@ -922,32 +922,32 @@ moved {
   to   = module.eu_west_1.aws_service_discovery_private_dns_namespace.internal_ecs
 }
 
-# import {
-#   to = aws_dynamodb_table_replica.use_codes_table
-#   id = "${local.environment_name}-${local.environment.dynamodb_tables.actor_codes.name}:eu-west-1"
-# }
+import {
+  to = aws_dynamodb_table_replica.use_codes_table
+  id = "${local.environment_name}-${local.environment.dynamodb_tables.actor_codes.name}:eu-west-1"
+}
 
-# import {
-#   to = aws_dynamodb_table_replica.stats_table
-#   id = "${local.environment_name}-${local.environment.dynamodb_tables.stats.name}:eu-west-1"
-# }
+import {
+  to = aws_dynamodb_table_replica.stats_table
+  id = "${local.environment_name}-${local.environment.dynamodb_tables.stats.name}:eu-west-1"
+}
 
-# import {
-#   to = aws_dynamodb_table_replica.use_users_table
-#   id = "${local.environment_name}-${local.environment.dynamodb_tables.actor_users.name}:eu-west-1"
-# }
+import {
+  to = aws_dynamodb_table_replica.use_users_table
+  id = "${local.environment_name}-${local.environment.dynamodb_tables.actor_users.name}:eu-west-1"
+}
 
-# import {
-#   to = aws_dynamodb_table_replica.viewer_codes_table
-#   id = "${local.environment_name}-${local.environment.dynamodb_tables.viewer_codes.name}:eu-west-1"
-# }
+import {
+  to = aws_dynamodb_table_replica.viewer_codes_table
+  id = "${local.environment_name}-${local.environment.dynamodb_tables.viewer_codes.name}:eu-west-1"
+}
 
-# import {
-#   to = aws_dynamodb_table_replica.viewer_activity_table
-#   id = "${local.environment_name}-${local.environment.dynamodb_tables.viewer_activity.name}:eu-west-1"
-# }
+import {
+  to = aws_dynamodb_table_replica.viewer_activity_table
+  id = "${local.environment_name}-${local.environment.dynamodb_tables.viewer_activity.name}:eu-west-1"
+}
 
-# import {
-#   to = aws_dynamodb_table_replica.user_lpa_actor_map
-#   id = "${local.environment_name}-${local.environment.dynamodb_tables.user_lpa_actor_map.name}:eu-west-1"
-# }
+import {
+  to = aws_dynamodb_table_replica.user_lpa_actor_map
+  id = "${local.environment_name}-${local.environment.dynamodb_tables.user_lpa_actor_map.name}:eu-west-1"
+}

--- a/terraform/environment/refactor.tf
+++ b/terraform/environment/refactor.tf
@@ -921,3 +921,33 @@ moved {
   from = aws_service_discovery_private_dns_namespace.internal_ecs
   to   = module.eu_west_1.aws_service_discovery_private_dns_namespace.internal_ecs
 }
+
+import {
+  to = aws_dynamodb_table_replica.use_codes_table
+  id = "${local.environment_name}-${local.environment.dynamodb_tables.actor_codes.name}:eu-west-1"
+}
+
+import {
+  to = aws_dynamodb_table_replica.stats_table
+  id = "${local.environment_name}-${local.environment.dynamodb_tables.stats.name}:eu-west-1"
+}
+
+import {
+  to = aws_dynamodb_table_replica.use_users_table
+  id = "${local.environment_name}-${local.environment.dynamodb_tables.actor_users.name}:eu-west-1"
+}
+
+import {
+  to = aws_dynamodb_table_replica.viewer_codes_table
+  id = "${local.environment_name}-${local.environment.dynamodb_tables.viewer_codes.name}:eu-west-1"
+}
+
+import {
+  to = aws_dynamodb_table_replica.viewer_activity_table
+  id = "${local.environment_name}-${local.environment.dynamodb_tables.viewer_activity.name}:eu-west-1"
+}
+
+import {
+  to = aws_dynamodb_table_replica.user_lpa_actor_map
+  id = "${local.environment_name}-${local.environment.dynamodb_tables.user_lpa_actor_map.name}:eu-west-1"
+}

--- a/terraform/environment/refactor.tf
+++ b/terraform/environment/refactor.tf
@@ -922,32 +922,32 @@ moved {
   to   = module.eu_west_1.aws_service_discovery_private_dns_namespace.internal_ecs
 }
 
-import {
-  to = aws_dynamodb_table_replica.use_codes_table
-  id = "${local.environment_name}-${local.environment.dynamodb_tables.actor_codes.name}:eu-west-1"
-}
+# import {
+#   to = aws_dynamodb_table_replica.use_codes_table
+#   id = "${local.environment_name}-${local.environment.dynamodb_tables.actor_codes.name}:eu-west-1"
+# }
 
-import {
-  to = aws_dynamodb_table_replica.stats_table
-  id = "${local.environment_name}-${local.environment.dynamodb_tables.stats.name}:eu-west-1"
-}
+# import {
+#   to = aws_dynamodb_table_replica.stats_table
+#   id = "${local.environment_name}-${local.environment.dynamodb_tables.stats.name}:eu-west-1"
+# }
 
-import {
-  to = aws_dynamodb_table_replica.use_users_table
-  id = "${local.environment_name}-${local.environment.dynamodb_tables.actor_users.name}:eu-west-1"
-}
+# import {
+#   to = aws_dynamodb_table_replica.use_users_table
+#   id = "${local.environment_name}-${local.environment.dynamodb_tables.actor_users.name}:eu-west-1"
+# }
 
-import {
-  to = aws_dynamodb_table_replica.viewer_codes_table
-  id = "${local.environment_name}-${local.environment.dynamodb_tables.viewer_codes.name}:eu-west-1"
-}
+# import {
+#   to = aws_dynamodb_table_replica.viewer_codes_table
+#   id = "${local.environment_name}-${local.environment.dynamodb_tables.viewer_codes.name}:eu-west-1"
+# }
 
-import {
-  to = aws_dynamodb_table_replica.viewer_activity_table
-  id = "${local.environment_name}-${local.environment.dynamodb_tables.viewer_activity.name}:eu-west-1"
-}
+# import {
+#   to = aws_dynamodb_table_replica.viewer_activity_table
+#   id = "${local.environment_name}-${local.environment.dynamodb_tables.viewer_activity.name}:eu-west-1"
+# }
 
-import {
-  to = aws_dynamodb_table_replica.user_lpa_actor_map
-  id = "${local.environment_name}-${local.environment.dynamodb_tables.user_lpa_actor_map.name}:eu-west-1"
-}
+# import {
+#   to = aws_dynamodb_table_replica.user_lpa_actor_map
+#   id = "${local.environment_name}-${local.environment.dynamodb_tables.user_lpa_actor_map.name}:eu-west-1"
+# }

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -81,6 +81,7 @@
       "dynamodb_tables": {
         "cmk_encryption_enabled": true,
         "deletion_protection_enabled": false,
+        "replica_deletion_protection_enabled": false,
         "actor_codes": {
           "name": "ActorCodes"
         },
@@ -195,6 +196,7 @@
       },
       "dynamodb_tables": {
         "deletion_protection_enabled": false,
+        "replica_deletion_protection_enabled": false,
         "cmk_encryption_enabled": true,
         "actor_codes": {
           "name": "ActorCodes"
@@ -311,6 +313,7 @@
       "dynamodb_tables": {
         "cmk_encryption_enabled": true,
         "deletion_protection_enabled": false,
+        "replica_deletion_protection_enabled": false,
         "actor_codes": {
           "name": "ActorCodes"
         },
@@ -426,6 +429,7 @@
       "dynamodb_tables": {
         "cmk_encryption_enabled": true,
         "deletion_protection_enabled": true,
+        "replica_deletion_protection_enabled": true,
         "actor_codes": {
           "name": "ActorCodes"
         },
@@ -540,6 +544,7 @@
       "dynamodb_tables": {
         "cmk_encryption_enabled": true,
         "deletion_protection_enabled": true,
+        "replica_deletion_protection_enabled": true,
         "actor_codes": {
           "name": "ActorCodes"
         },

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -99,8 +99,9 @@ variable "environments" {
         vault_lock_max_retention_days   = number
       })
       dynamodb_tables = object({
-        cmk_encryption_enabled      = bool
-        deletion_protection_enabled = bool
+        cmk_encryption_enabled              = bool
+        deletion_protection_enabled         = bool
+        replica_deletion_protection_enabled = bool
         actor_codes = object({
           name = string
         })


### PR DESCRIPTION
# Purpose

Separates the replicas into their own resources for more granular management, and for smoother disaster recovery 

Fixes UML-4156

## Learning

You can use varaibles within import statements

## Checklist  <small>(**tick/delete or ~~strikethrough~~** as appropriate)</small>

* [ ] I have performed a self-review of my own code
* [ ] I have added tests to prove my work
* [ ] I have added relevant and appropriately leveled logging, **without PII**, to my code
* [ ] New event_codes have been documented on the [wiki page](https://opgtransform.atlassian.net/wiki/spaces/LSML2/pages/3277881441/Understanding+the+event+logs)
* [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc)
* [ ] I have added welsh translation tags and updated translation files
* [ ] I have run an accessibility tool on any pages I have made changes to and fixed any issues found
* [ ] I have notified the Interaction Designer of any content changes so that appropriate screenshots/flow diagram changes can be made
* [ ] The product team have tested these changes
